### PR TITLE
Jemten feature/dispatch table

### DIFF
--- a/SUMMARY.md
+++ b/SUMMARY.md
@@ -5,6 +5,7 @@
     * [Setup](documentation/Setup.md)
     * [References](documentation/References.md)
     * [Analysis](documentation/Analysis.md)
+    * [Parameters](documentation/Parameters.md)
     * [Code](documentation/Code.md)
       * [Best Practise](documentation/Code/Best_practise.md)
     * [API](documentation/Api.md)

--- a/definitions/analyse_parameters.yaml
+++ b/definitions/analyse_parameters.yaml
@@ -183,6 +183,7 @@ supported_capture_kit:
   type: mip
 ### Programs
 split_fastq_file:
+  analysis_mode: sample
   associated_program:
    - mip
   data_type: SCALAR
@@ -202,6 +203,7 @@ split_fastq_file_read_batch:
   type: program_argument
 ## Gzip
 gzip_fastq:
+  analysis_mode: sample
   associated_program:
    - mip
   data_type: SCALAR
@@ -213,6 +215,7 @@ gzip_fastq:
   type: program
 ## FastQC
 fastqc:
+  analysis_mode: sample
   associated_program:
    - mip
   data_type: SCALAR

--- a/definitions/non_mandatory_parameter_keys.yaml
+++ b/definitions/non_mandatory_parameter_keys.yaml
@@ -18,6 +18,11 @@ file_tag:
   key_data_type: SCALAR
 infile_suffix:
   key_data_type: SCALAR
+analysis_mode:
+  key_data_type: SCALAR
+  values:
+    - sample
+    - family
 outfile_suffix:
   key_data_type: SCALAR
 program_name_path:

--- a/definitions/rare_disease_initiation_map.yaml
+++ b/definitions/rare_disease_initiation_map.yaml
@@ -50,6 +50,7 @@ CHAIN_ALL:
          - GATK_HAPLOTYPECALLER:
             - gatk_haplotypecaller
             - gatk_genotypegvcfs
+            - gatk_concatenate_genotypegvcfs
             - gatk_variantrecalibration
       - gatk_combinevariantcallsets
 # Parallel chains (branches), which inherit from MAIN in initiation

--- a/definitions/rare_disease_parameters.yaml
+++ b/definitions/rare_disease_parameters.yaml
@@ -1430,6 +1430,7 @@ gatk_variantevalall:
   outfile_suffix: ".varianteval"
   type: program
 gatk_variantevalexome:
+  analysis_mode: sample
   associated_program:
    - mip
   data_type: SCALAR
@@ -1743,6 +1744,7 @@ nist_id:
   type: program_argument
 ## RankVariant
 rankvariant:
+  analysis_mode: family
   associated_program:
    - mip
   data_type: SCALAR
@@ -1803,6 +1805,7 @@ rank_model_file:
   type: path
 ##Endvariantannotationblock
 endvariantannotationblock:
+  analysis_mode: family
   associated_program:
    - mip
   data_type: SCALAR
@@ -1828,6 +1831,7 @@ endvariantannotationblock_remove_genes_file:
   type: path
 ## QCCollect
 qccollect:
+  analysis_mode: family
   associated_program:
    - mip
   data_type: SCALAR
@@ -1856,6 +1860,7 @@ qccollect_skip_evaluation:
   type: program_argument
 ## MultiQC
 multiqc:
+  analysis_mode: family
   associated_program:
    - mip
   data_type: SCALAR
@@ -1873,6 +1878,7 @@ multiqc_per_sample:
   type: program_argument
 ## AnalysisRunStatus
 analysisrunstatus:
+  analysis_mode: family
   associated_program:
    - mip
   data_type: SCALAR
@@ -1881,6 +1887,7 @@ analysisrunstatus:
   type: program
 ## Sacct
 sacct:
+  analysis_mode: family
   associated_program:
    - mip
   data_type: SCALAR

--- a/definitions/rare_disease_parameters.yaml
+++ b/definitions/rare_disease_parameters.yaml
@@ -1278,11 +1278,12 @@ gatk_variantrecalibration_snv_tsfilter_level:
   default: 99.9
   type: program_argument
 gatk_combinevariantcallsets:
+  analysis_mode: family
   associated_program:
    - mip
   data_type: SCALAR
   default: 0
-  file_tag: comb_
+  file_tag: _comb_
   outfile_suffix: ".vcf"
   type: program
 gatk_combinevariantcallsets_bcf_file:
@@ -1314,6 +1315,7 @@ variantannotationblock:
   reduce_io: 1
   type: program
 prepareforvariantannotationblock:
+  analysis_mode: family
   associated_program:
    - mip
   data_type: SCALAR
@@ -1323,6 +1325,7 @@ prepareforvariantannotationblock:
   type: program
 ##rhocall
 rhocall:
+  analysis_mode: family
   associated_program:
    - mip
   data_type: SCALAR
@@ -1343,6 +1346,7 @@ rhocall_frequency_file:
   type: path
 ##VT
 vt:
+  analysis_mode: family
   associated_program:
    - mip
   data_type: SCALAR
@@ -1416,6 +1420,7 @@ frequency_genmod_filter_1000g:
   reference: reference_dir
   type: path
 gatk_variantevalall:
+  analysis_mode: sample
   associated_program:
    - mip
   data_type: SCALAR
@@ -1649,6 +1654,7 @@ snpeff_path:
   update_path: absolute_path
 ## Case_check
 peddy:
+  analysis_mode: family
   associated_program:
    - mip
   data_type: SCALAR
@@ -1658,6 +1664,7 @@ peddy:
    - peddy
   type: program
 plink:
+  analysis_mode: family
   associated_program:
    - mip
   data_type: SCALAR
@@ -1667,6 +1674,7 @@ plink:
    - plink2
   type: program
 variant_integrity:
+  analysis_mode: family
   associated_program:
    - mip
   data_type: SCALAR
@@ -1676,6 +1684,7 @@ variant_integrity:
    - variant_integrity
   type: program
 rtg_vcfeval:
+  analysis_mode: sample
   associated_program:
    - mip
   data_type: SCALAR
@@ -1693,6 +1702,7 @@ rtg_vcfeval_reference_genome:
   reference: reference_dir
   type: path
 evaluation:
+  analysis_mode: sample
   associated_program:
    - mip
   data_type: SCALAR

--- a/definitions/rare_disease_parameters.yaml
+++ b/definitions/rare_disease_parameters.yaml
@@ -1384,6 +1384,7 @@ vt_uniq:
   default: 0
   type: program_argument
 frequency_filter:
+  analysis_mode: family
   associated_program:
    - mip
   data_type: SCALAR
@@ -1458,6 +1459,7 @@ gatk_varianteval_gold:
   type: path
 ## VEP
 varianteffectpredictor:
+  analysis_mode: family
   associated_program:
    - mip
   data_type: SCALAR
@@ -1525,6 +1527,7 @@ vep_plugins_dir_path:
   update_path: absolute_path
 ## VCFParser
 vcfparser:
+  analysis_mode: family
   associated_program:
    - mip
   data_type: SCALAR
@@ -1581,6 +1584,7 @@ vcfparser_vep_transcripts:
   type: program_argument
 ## SnpEFF
 snpeff:
+  analysis_mode: family
   associated_program:
    - mip
   data_type: SCALAR

--- a/definitions/rare_disease_parameters.yaml
+++ b/definitions/rare_disease_parameters.yaml
@@ -508,6 +508,7 @@ samtools_subsample_mt_depth:
   default: 60
   type: program_argument
 sambamba_depth:
+  analysis_mode: sample
   associated_program:
    - mip
   data_type: SCALAR
@@ -567,6 +568,7 @@ sambamba_depth_quality_control:
   default: 1
   type: program_argument
 bedtools_genomecov:
+  analysis_mode: sample
   associated_program:
    - mip
   data_type: SCALAR
@@ -582,6 +584,7 @@ bedtools_genomecov_max_coverage:
   default: 30
   type: program_argument
 picardtools_collectmultiplemetrics:
+  analysis_mode: sample
   associated_program:
    - mip
   data_type: SCALAR
@@ -589,6 +592,7 @@ picardtools_collectmultiplemetrics:
   file_tag: nofile_tag
   type: program
 picardtools_collecthsmetrics:
+  analysis_mode: sample
   associated_program:
    - mip
   data_type: SCALAR
@@ -596,14 +600,16 @@ picardtools_collecthsmetrics:
   file_tag: _collecthsmetrics
   type: program
 rcovplots:
+  analysis_mode: sample
   associated_program:
    - mip
   data_type: SCALAR
   default: 0
   file_tag: nofile_tag
   type: program
-##Structural Variant Calling
+## Structural Variant Calling
 cnvnator:
+  analysis_mode: sample
   associated_program:
    - mip
   data_type: SCALAR
@@ -624,6 +630,7 @@ cnv_bin_size:
   default: 1000
   type: program_argument
 delly_call:
+  analysis_mode: sample
   associated_program:
    - mip
   data_type: SCALAR
@@ -635,6 +642,7 @@ delly_call:
   outfile_suffix: ".bcf"
   type: program
 delly_reformat:
+  analysis_mode: family
   associated_program:
    - mip
   data_type: SCALAR

--- a/definitions/rare_disease_parameters.yaml
+++ b/definitions/rare_disease_parameters.yaml
@@ -293,6 +293,7 @@ replace_iupac:
 ###Programs
 ## BWA
 bwa_mem:
+  analysis_mode: sample
   associated_program:
    - mip
   data_type: SCALAR
@@ -348,6 +349,7 @@ bamcalibrationblock:
   reduce_io: 1
   type: program
 picardtools_mergesamfiles:
+  analysis_mode: sample
   associated_program:
    - mip
   data_type: SCALAR
@@ -355,6 +357,7 @@ picardtools_mergesamfiles:
   file_tag: ""
   type: program
 markduplicates:
+  analysis_mode: sample
   associated_program:
    - mip
   data_type: SCALAR
@@ -395,6 +398,7 @@ markduplicates_sambamba_markdup_overflow_list_size:
   type: program_argument
 ## GATK BAM Calibration
 gatk_realigner:
+  analysis_mode: sample
   associated_program:
    - mip
   data_type: SCALAR
@@ -413,6 +417,7 @@ gatk_realigner_indel_known_sites:
   reference: reference_dir
   type: path
 gatk_baserecalibration:
+  analysis_mode: sample
   associated_program:
    - mip
   data_type: SCALAR
@@ -470,6 +475,7 @@ gatk_baserecalibration_static_quantized_quals:
   type: program_argument
 ## Coverage Analysis
 chanjo_sexcheck:
+  analysis_mode: sample
   associated_program:
    - mip
   data_type: SCALAR
@@ -486,6 +492,7 @@ chanjo_sexcheck_log_level:
   default: DEBUG
   type: program_argument
 samtools_subsample_mt:
+  analysis_mode: sample
   associated_program:
    - mip
   data_type: SCALAR
@@ -494,6 +501,7 @@ samtools_subsample_mt:
   outfile_suffix: ".bam"
   type: program
 samtools_subsample_mt_depth:
+  analysis_mode: sample
   associated_program:
    - samtools_subsample_mt
   data_type: SCALAR

--- a/definitions/rare_disease_parameters.yaml
+++ b/definitions/rare_disease_parameters.yaml
@@ -38,6 +38,7 @@ gatk_bundle_download_version:
    - cnvnator
    - gatk_haplotypecaller
    - gatk_genotypegvcfs
+   - gatk_concatenate_genotypegvcfs 
    - bcftools_mpileup
    - gatk_variantrecalibration
    - gatk_variantevalall
@@ -68,6 +69,7 @@ gatk_logging_level:
    - gatk_baserecalibration
    - gatk_haplotypecaller
    - gatk_genotypegvcfs
+   - gatk_concatenate_genotypegvcfs
    - bcftools_mpileup
    - gatk_variantrecalibration
    - gatk_combinevariantcallsets
@@ -85,6 +87,7 @@ gatk_path:
    - gatk_baserecalibration
    - gatk_haplotypecaller
    - gatk_genotypegvcfs
+   - gatk_concatenate_genotypegvcfs
    - bcftools_mpileup
    - gatk_variantrecalibration
    - gatk_combinevariantcallsets
@@ -139,6 +142,7 @@ java_use_large_pages:
    - gatk_baserecalibration
    - gatk_haplotypecaller
    - gatk_genotypegvcfs
+   - gatk_concatenate_genotypegvcfs
    - gatk_variantrecalibration
    - gatk_combinevariantcallsets
    - gatk_variantevalall
@@ -171,6 +175,7 @@ module_time:
     gatk_baserecalibration: 20
     gatk_combinevariantcallsets: 2
     gatk_genotypegvcfs: 10
+    gatk_concatenate_genotypegvcfs: 2
     gatk_haplotypecaller: 30
     gatk_realigner: 20
     gatk_variantevalall: 2
@@ -230,6 +235,7 @@ module_core_number:
     gatk_baserecalibration: 16
     gatk_combinevariantcallsets: 1
     gatk_genotypegvcfs: 4
+    gatk_concatenate_genotypegvcfs: 2
     gatk_haplotypecaller: 16
     gatk_realigner: 16
     gatk_variantevalall: 1
@@ -1057,6 +1063,7 @@ sv_reformat_remove_genes_file:
   type: path
 ##Bcftools
 bcftools_mpileup:
+  analysis_mode: family
   associated_program:
    - mip
   data_type: SCALAR
@@ -1076,6 +1083,7 @@ bcftools_mpileup_filter_variant:
   type: program_argument
 ##Freebayes
 freebayes:
+  analysis_mode: family
   associated_program:
    - mip
   data_type: SCALAR
@@ -1090,6 +1098,7 @@ freebayes:
   type: program
 ## GATK Genotype
 gatk_haplotypecaller:
+  analysis_mode: sample
   associated_program:
    - mip
   data_type: SCALAR
@@ -1146,19 +1155,14 @@ gatk_haplotypecaller_snp_known_set:
   type: path
 ## GATK Genotype Calibration
 gatk_genotypegvcfs:
+  analysis_mode: family
   associated_program:
    - mip
   data_type: SCALAR
   default: 0
-  file_tag: _
+  file_tag: _gent_
   outfile_suffix: ".vcf"
   type: program
-gatk_concatenate_genotypegvcfs_bcf_file:
-  associated_program:
-   - gatk_genotypegvcfs
-  data_type: SCALAR
-  default: 0
-  type: program_argument
 gatk_genotypegvcfs_all_sites:
   associated_program:
    - gatk_genotypegvcfs
@@ -1172,7 +1176,23 @@ gatk_genotypegvcfs_ref_gvcf:
   exists_check: file
   reference: reference_dir
   type: path
+gatk_concatenate_genotypegvcfs:
+  analysis_mode: family
+  associated_program:
+   - mip
+  data_type: SCALAR
+  default: 0
+  file_tag: ""
+  outfile_suffix: ".vcf"
+  type: program
+gatk_concatenate_genotypegvcfs_bcf_file:
+  associated_program:
+   - gatk_concatenate_genotypegvcfs
+  data_type: SCALAR
+  default: 0
+  type: program_argument
 gatk_variantrecalibration:
+  analysis_mode: family
   associated_program:
    - mip
   data_type: SCALAR
@@ -1290,7 +1310,7 @@ variantannotationblock:
    - mip
   data_type: SCALAR
   default: 0
-  file_tag: nofile_tag
+  file_tag: ""
   reduce_io: 1
   type: program
 prepareforvariantannotationblock:

--- a/definitions/rare_disease_parameters.yaml
+++ b/definitions/rare_disease_parameters.yaml
@@ -689,6 +689,7 @@ expansionhunter:
   program_type: structural_variant_callers
   type: program
 expansionhunter_repeat_specs_dir:
+  analysis_mode: sample
   associated_program:
    - expansionhunter
   data_type: SCALAR
@@ -696,6 +697,7 @@ expansionhunter_repeat_specs_dir:
   type: path
   update_path: absolute_path
 manta:
+  analysis_mode: family
   associated_program:
    - mip
   data_type: SCALAR
@@ -708,6 +710,7 @@ manta:
   program_type: structural_variant_callers
   type: program
 tiddit:
+  analysis_mode: family
   associated_program:
    - mip
   data_type: SCALAR
@@ -734,6 +737,7 @@ tiddit_minimum_number_supporting_pairs:
   default: 6
   type: program_argument
 sv_combinevariantcallsets:
+  analysis_mode: family
   associated_program:
    - mip
   data_type: SCALAR
@@ -839,6 +843,7 @@ sv_vt_decompose:
   default: 0
   type: program_argument
 vcf2cytosure:
+  analysis_mode: family
   associated_program:
     - mip
   data_type: SCALAR
@@ -882,6 +887,7 @@ vcf2cytosure_var_size:
   default: 0
   type: program_argument
 sv_varianteffectpredictor:
+  analysis_mode: family
   associated_program:
    - mip
   data_type: SCALAR
@@ -924,6 +930,7 @@ sv_vep_plugins:
    - LoFtool
   type: program_argument
 sv_vcfparser:
+  analysis_mode: family
   associated_program:
    - mip
   data_type: SCALAR
@@ -984,6 +991,7 @@ sv_vcfparser_vep_transcripts:
   default: 0
   type: program_argument
 sv_rankvariant:
+  analysis_mode: family
   associated_program:
    - mip
   data_type: SCALAR
@@ -1024,6 +1032,7 @@ sv_rank_model_file:
   type: path
 ##Sv_reformat
 sv_reformat:
+  analysis_mode: family
   associated_program:
    - mip
   data_type: SCALAR

--- a/definitions/rna_parameters.yaml
+++ b/definitions/rna_parameters.yaml
@@ -133,6 +133,7 @@ picardtools_path:
 ###Programs
 ## Salmon
 salmon_quant:
+  analysis_mode: sample
   associated_program:
    - mip
   data_type: SCALAR
@@ -151,6 +152,7 @@ salmon_rna_lib_configuration:
   type: program_argument
 ## Star Aln
 star_aln:
+  analysis_mode: sample
   associated_program:
    - mip
   data_type: SCALAR
@@ -200,6 +202,7 @@ two_pass_mode:
   type: program_argument
 ## Star Fusion
 star_fusion:
+  analysis_mode: sample
   associated_program:
    - mip
   data_type: SCALAR
@@ -212,6 +215,7 @@ star_fusion:
   type: program
 ## Merge bam files
 picardtools_mergesamfiles:
+  analysis_mode: sample
   associated_program:
    - mip
   data_type: SCALAR
@@ -220,6 +224,7 @@ picardtools_mergesamfiles:
   type: program
 ## Mark duplicates
 markduplicates:
+  analysis_mode: sample
   associated_program:
    - mip
   data_type: SCALAR
@@ -260,6 +265,7 @@ markduplicates_sambamba_markdup_overflow_list_size:
   type: program_argument
 ## GATK SplitNCigarReads
 gatk_splitncigarreads:
+  analysis_mode: sample
   associated_program:
     - mip
   data_type: SCALAR
@@ -268,6 +274,7 @@ gatk_splitncigarreads:
   type: program
 ## GATK BAM Calibration
 gatk_baserecalibration:
+  analysis_mode: sample
   associated_program:
    - mip
   data_type: SCALAR
@@ -325,6 +332,7 @@ gatk_baserecalibration_static_quantized_quals:
   type: program_argument
 ## GATK Genotype
 gatk_haplotypecaller:
+  analysis_mode: sample
   associated_program:
    - mip
   data_type: SCALAR
@@ -381,6 +389,7 @@ gatk_haplotypecaller_snp_known_set:
   type: path
 ## GATK ASE
 gatk_asereadcounter:
+  analysis_mode: sample
   associated_program:
    - mip
   data_type: SCALAR
@@ -390,6 +399,7 @@ gatk_asereadcounter:
   type: program
 ## GATK VariantFiltration
 gatk_variantfiltration:
+  analysis_mode: sample
   associated_program:
     - mip
   data_type: SCALAR
@@ -419,6 +429,7 @@ gatk_variantfiltration_cluster_window_size:
   type: program_argument
 ## BootstrapAnn
 bootstrapann:
+  analysis_mode: sample
   associated_program:
     - mip
   data_type: SCALAR

--- a/documentation/API/define_parameters.md
+++ b/documentation/API/define_parameters.md
@@ -12,6 +12,7 @@ The parameters that MIP support are recorded in a yaml file format. The order of
 The define parameters file has the following data structure and keys:
 ```
 program: { # Program hash
+  analysis_mode: string, value="sample | family" # Mode for running the analysis recipe
   associated_program: [
     - string, value="mip | p<program>" # Evaluate parameter if associated program is active. Ties program argument to one or several programs.
   ]

--- a/documentation/Parameters.md
+++ b/documentation/Parameters.md
@@ -1,0 +1,29 @@
+# Parameters
+All parameters in MIP are defined in the `definition` folder located in the MIP directory. The parameters are defined at the corresponding CLI command level YAML file:
+ - "mip" i.e. "perl mip -> mip_parameters.yaml"
+ - "[process]" e.g. "perl mip analyse -> analyse_parameters.yaml"
+ - "[pipeline]" e.g. "perl mip analyse rare_disease -> rare_disease_parameters.yaml"
+
+This makes MIP aware of the parameter and the keys and values used to define the parameter decides the features and methods that will be used on the parameter. You do not have to add the parameter in any specific order.
+
+There are 3 types of parameters:
+- "program"
+- "program_argument"
+- "path_parameter"
+
+The program parameter is also know as the analysis recipe switch. It turns on and off the program module.
+
+You should also have the parameter as an option on the command line interface. This is done by adding the parameter to the corresponding CLI perl module in `lib/MIP/Cli`.
+ - "mip" i.e. "perl mip -> lib/MIP/Cli/Mip.pm"
+ - "[process]" e.g. "perl mip analyse -> lib/MIP/Cli/Mip/Analyse.pm"
+ - "[pipeline]" e.g. "perl mip analyse rare_disease -> lib/MIP/Cli/Mip/Analyse/Rare_disease.pm"
+
+To decide when and where the analysis recipe will be executed you the name of the analysis recipe parameter to the initiation map file for the corresponding pipeline you are working on. The initiation map file is located in the `definition` folder in the MIP directory. The order of the initation map and the chain you place the parameter on will decide when the program will execute and its upstream dependencies.
+
+So far we have defined the features of the analysis recipe, added it to the CLI, and decided where and when to execute the program module. We also have to point to the actual code of the recipe. This is done by adding your analysis recipe name and the code reference pointing to the analysis recipe perl module to the analysis_recipe and program_name hashes in the `lib/MIP/Recipe/Pipeline/[Pipeline]` perl module. 
+
+To add a analysis recipe switch follow these steps:
+ - Add the parameter at the corresponding CLI command level YAML file in the `definition` folder in the MIP directory
+ - Add the parameter to the corresponing CLI perl module in `lib/MIP/Cli` in MIPs lib directory.
+ - Add the analysis recipe switch to the initiation map file in the `definition` folder in the MIP directory.
+ - Add the parameter name to the analysis_recipe and program_name hashes in the `lib/MIP/Recipe/Pipeline/[Pipeline]` perl module. 

--- a/lib/MIP/Cli/Mip/Analyse/Rare_disease.pm
+++ b/lib/MIP/Cli/Mip/Analyse/Rare_disease.pm
@@ -1220,8 +1220,19 @@ q{GATK GenoTypeGVCFs gVCF reference infile list for joint genotyping},
     );
 
     option(
+        q{gatk_concatenate_genotypegvcfs} => (
+            cmd_aliases => [qw{ pgcgt }],
+            cmd_tags    => [q{Analysis recipe switch}],
+            documentation =>
+              q{Concatenate gVCF records using GATK Concatenate variants},
+            is  => q{rw},
+            isa => enum( [ 0, 1, 2 ] ),
+        )
+    );
+
+    option(
         q{gatk_concatenate_genotypegvcfs_bcf_file} => (
-            cmd_aliases => [qw{ ggbcf }],
+            cmd_aliases => [qw{ gcgbcf }],
             cmd_flag    => q{gatk_genotype_bcf_f},
             documentation =>
               q{Produce a bcf from the GATK ConcatenateGenoTypeGVCFs vcf},

--- a/lib/MIP/Get/Analysis.pm
+++ b/lib/MIP/Get/Analysis.pm
@@ -27,7 +27,7 @@ BEGIN {
     use base qw{ Exporter };
 
     # Set the version for version checking
-    our $VERSION = 1.05;
+    our $VERSION = 1.06;
 
     # Functions and variables which can be optionally exported
     our @EXPORT_OK =
@@ -521,7 +521,7 @@ sub print_program {
 
             if (
                 not $parameter =~
-                / pbamcalibrationblock | pvariantannotationblock /xsm )
+                / bamcalibrationblock | pvariantannotationblock /xsm )
             {
 
                 print {*STDOUT} q{--}

--- a/lib/MIP/Get/Analysis.pm
+++ b/lib/MIP/Get/Analysis.pm
@@ -521,7 +521,7 @@ sub print_program {
 
             if (
                 not $parameter =~
-                / bamcalibrationblock | pvariantannotationblock /xsm )
+                / bamcalibrationblock | variantannotationblock /xsm )
             {
 
                 print {*STDOUT} q{--}

--- a/lib/MIP/Main/Analyse.pm
+++ b/lib/MIP/Main/Analyse.pm
@@ -77,7 +77,6 @@ use MIP::Update::Programs
 use MIP::QC::Record qw{ add_to_sample_info };
 
 ## Recipes
-use MIP::Recipes::Analysis::Split_fastq_file qw{ analysis_split_fastq_file };
 use MIP::Recipes::Pipeline::Rare_disease qw{ pipeline_rare_disease };
 use MIP::Recipes::Pipeline::Rna qw{ pipeline_rna };
 use MIP::Recipes::Pipeline::Cancer qw{ pipeline_cancer };
@@ -957,35 +956,6 @@ sub mip_analyse {
 
             $sample_info{$key} = $value;
         }
-    }
-
-## Split of fastq files in batches
-    if ( $active_parameter{split_fastq_file} ) {
-
-        $log->info(q{[Split fastq files in batches]});
-
-      SAMPLE_ID:
-        foreach my $sample_id ( @{ $active_parameter{sample_ids} } ) {
-
-            ## Split input fastq files into batches of reads, versions and compress. Moves original file to subdirectory
-            analysis_split_fastq_file(
-                {
-                    parameter_href        => \%parameter,
-                    active_parameter_href => \%active_parameter,
-                    infile_href           => \%infile,
-                    job_id_href           => \%job_id,
-                    insample_directory    => $indir_path{$sample_id},
-                    outsample_directory   => $indir_path{$sample_id},
-                    sample_id             => $sample_id,
-                    program_name          => q{split_fastq_file},
-                    sequence_read_batch =>
-                      $active_parameter{split_fastq_file_read_batch},
-                }
-            );
-        }
-
-        ## End here if this module is turned on
-        exit;
     }
 
 ### Cancer

--- a/lib/MIP/Main/Analyse.pm
+++ b/lib/MIP/Main/Analyse.pm
@@ -77,7 +77,6 @@ use MIP::Update::Programs
 use MIP::QC::Record qw{ add_to_sample_info };
 
 ## Recipes
-use MIP::Recipes::Analysis::Gzip_fastq qw{ analysis_gzip_fastq };
 use MIP::Recipes::Analysis::Split_fastq_file qw{ analysis_split_fastq_file };
 use MIP::Recipes::Pipeline::Rare_disease qw{ pipeline_rare_disease };
 use MIP::Recipes::Pipeline::Rna qw{ pipeline_rna };
@@ -893,7 +892,7 @@ sub mip_analyse {
     );
 
 ## Reformat file names to MIP format, get file name info and add info to sample_info
-    my $is_file_uncompressed = parse_fastq_infiles(
+    parse_fastq_infiles(
         {
             active_parameter_href           => \%active_parameter,
             file_info_href                  => \%file_info,
@@ -987,46 +986,6 @@ sub mip_analyse {
 
         ## End here if this module is turned on
         exit;
-    }
-
-## GZip of fastq files
-    if (   $active_parameter{gzip_fastq}
-        && $is_file_uncompressed )
-    {
-
-        $log->info(q{[Gzip for fastq files]});
-
-      SAMPLES:
-        foreach my $sample_id ( @{ $active_parameter{sample_ids} } ) {
-
-            ## Determine which sample id had the uncompressed files
-          INFILES:
-            foreach my $infile ( @{ $infile{$sample_id} } ) {
-
-                my $infile_suffix = $parameter{gzip_fastq}{infile_suffix};
-
-                if ( $infile =~ /$infile_suffix$/sxm ) {
-
-                    ## Automatically gzips fastq files
-                    analysis_gzip_fastq(
-                        {
-                            parameter_href          => \%parameter,
-                            active_parameter_href   => \%active_parameter,
-                            sample_info_href        => \%sample_info,
-                            infile_href             => \%infile,
-                            infile_lane_prefix_href => \%infile_lane_prefix,
-                            job_id_href             => \%job_id,
-                            insample_directory      => $indir_path{$sample_id},
-                            sample_id               => $sample_id,
-                            program_name            => q{gzip_fastq},
-                        }
-                    );
-
-                    # Call once per sample_id
-                    last INFILES;
-                }
-            }
-        }
     }
 
 ### Cancer

--- a/lib/MIP/Main/Analyse.pm
+++ b/lib/MIP/Main/Analyse.pm
@@ -89,7 +89,7 @@ BEGIN {
     require Exporter;
 
     # Set the version for version checking
-    our $VERSION = 1.06;
+    our $VERSION = 1.07;
 
     # Functions and variables which can be optionally exported
     our @EXPORT_OK = qw{ mip_analyse };
@@ -1062,17 +1062,17 @@ sub mip_analyse {
         ## Pipeline recipe for rna data
         pipeline_rna(
             {
-                parameter_href          => \%parameter,
                 active_parameter_href   => \%active_parameter,
-                sample_info_href        => \%sample_info,
                 file_info_href          => \%file_info,
                 indir_path_href         => \%indir_path,
                 infile_href             => \%infile,
                 infile_lane_prefix_href => \%infile_lane_prefix,
-                lane_href               => \%lane,
                 job_id_href             => \%job_id,
-                outaligner_dir          => $active_parameter{outaligner_dir},
+                lane_href               => \%lane,
                 log                     => $log,
+                order_programs_ref      => \@order_programs,
+                parameter_href          => \%parameter,
+                sample_info_href        => \%sample_info,
             }
         );
     }
@@ -1088,17 +1088,18 @@ sub mip_analyse {
         ## Pipeline recipe for rna data
         pipeline_rare_disease(
             {
-                parameter_href          => \%parameter,
                 active_parameter_href   => \%active_parameter,
-                sample_info_href        => \%sample_info,
                 file_info_href          => \%file_info,
                 indir_path_href         => \%indir_path,
                 infile_href             => \%infile,
                 infile_lane_prefix_href => \%infile_lane_prefix,
-                lane_href               => \%lane,
                 job_id_href             => \%job_id,
-                outaligner_dir          => $active_parameter{outaligner_dir},
+                lane_href               => \%lane,
                 log                     => $log,
+                order_programs_ref      => \@order_programs,
+                outaligner_dir          => $active_parameter{outaligner_dir},
+                parameter_href          => \%parameter,
+                sample_info_href        => \%sample_info,
             }
         );
     }

--- a/lib/MIP/Parse/File.pm
+++ b/lib/MIP/Parse/File.pm
@@ -34,7 +34,7 @@ Readonly my $EMPTY_STR => q{};
 sub parse_fastq_infiles {
 
 ## Function : Parse fastq infiles for MIP processing.
-## Returns  : $any_uncompressed_file
+## Returns  :
 ## Arguments: $active_parameter_href           => Active parameters for this analysis hash {REF}
 ##          : $file_info_href                  => File info hash {REF}
 ##          : $indir_path_href                 => Indirectories path(s) hash {REF}
@@ -130,9 +130,6 @@ sub parse_fastq_infiles {
     use MIP::Set::File qw{ set_file_compression_features };
     use MIP::QC::Record qw{ add_infile_info };
 
-# Used to decide later if any inputfiles needs to be compressed before starting analysis
-    my $any_uncompressed_file;
-
   SAMPLE_ID:
     for my $sample_id ( keys %{$infile_href} ) {
 
@@ -158,7 +155,7 @@ sub parse_fastq_infiles {
             if ( not $is_file_compressed ) {
 
                 ## Note: All files are rechecked downstream and uncompressed ones are gzipped automatically
-                $any_uncompressed_file++;
+                $file_info_href->{is_file_uncompressed}{$sample_id}++;
             }
 
             ## Parse infile according to filename convention
@@ -311,7 +308,7 @@ q{Will add fake date '20010101' to follow file convention since this is not reco
             }
         }
     }
-    return $any_uncompressed_file;
+    return;
 }
 
 sub parse_fastq_infiles_format {

--- a/lib/MIP/Recipes/Analysis/Analysisrunstatus.pm
+++ b/lib/MIP/Recipes/Analysis/Analysisrunstatus.pm
@@ -22,7 +22,7 @@ BEGIN {
     use base qw{ Exporter };
 
     # Set the version for version checking
-    our $VERSION = 1.00;
+    our $VERSION = 1.01;
 
     # Functions and variables which can be optionally exported
     our @EXPORT_OK = qw{ analysis_analysisrunstatus };
@@ -41,6 +41,7 @@ sub analysis_analysisrunstatus {
 ## Returns  :
 ## Arguments: $active_parameter_href   => Active parameters for this analysis hash {REF}
 ##          : $family_id               => Family id
+##          : $file_info_href          => File info hash {REF}
 ##          : $infile_lane_prefix_href => Infile(s) without the ".ending" {REF}
 ##          : $job_id_href             => Job id hash {REF}
 ##          : $parameter_href          => Parameter hash {REF}
@@ -51,6 +52,7 @@ sub analysis_analysisrunstatus {
 
     ## Flatten argument(s)
     my $active_parameter_href;
+    my $file_info_href;
     my $infile_lane_prefix_href;
     my $job_id_href;
     my $parameter_href;
@@ -71,6 +73,13 @@ sub analysis_analysisrunstatus {
         family_id => {
             default     => $arg_href->{active_parameter_href}{family_id},
             store       => \$family_id,
+            strict_type => 1,
+        },
+        file_info_href => {
+            default     => {},
+            defined     => 1,
+            required    => 1,
+            store       => \$file_info_href,
             strict_type => 1,
         },
         infile_lane_prefix_href => {
@@ -120,17 +129,18 @@ sub analysis_analysisrunstatus {
     ## Retrieve logger object
     my $log = Log::Log4perl->get_logger(q{MIP});
 
-    ## Set MIP program name
+    ## Set program mode
     my $program_mode = $active_parameter_href->{$program_name};
 
     ## Unpack parameters
     my $job_id_chain = $parameter_href->{$program_name}{chain};
-    my ( $core_number, $time, @source_environment_cmds ) = get_module_parameters(
+    my ( $core_number, $time, @source_environment_cmds ) =
+      get_module_parameters(
         {
             active_parameter_href => $active_parameter_href,
-            program_name      => $program_name,
+            program_name          => $program_name,
         }
-    );
+      );
 
     ## Filehandles
     # Create anonymous filehandle

--- a/lib/MIP/Recipes/Analysis/Bamcalibrationblock.pm
+++ b/lib/MIP/Recipes/Analysis/Bamcalibrationblock.pm
@@ -165,6 +165,19 @@ sub analysis_bamcalibrationblock {
     # Create anonymous filehandle
     my $FILEHANDLE = IO::Handle->new();
 
+    ## Broadcasting
+  PROGRAM:
+    foreach my $program ( @{$order_programs_ref} ) {
+
+        ## Only for active programs
+        next PROGRAM if ( not $active_parameter_href->{$program} );
+
+        $log->info( $TAB
+              . $OPEN_BRACKET
+              . $program_name_href->{$program}
+              . $CLOSE_BRACKET );
+    }
+
   SAMPLE_ID:
     foreach my $sample_id ( @{ $active_parameter_href->{sample_ids} } ) {
 
@@ -191,10 +204,6 @@ sub analysis_bamcalibrationblock {
 
             ## Only for active programs
             next PROGRAM if ( not $active_parameter_href->{$program} );
-
-            $log->info( $OPEN_BRACKET
-                  . $program_name_href->{$program}
-                  . $CLOSE_BRACKET );
 
             ($xargs_file_counter) = $bamcal_ar_href->{$program}->(
                 {

--- a/lib/MIP/Recipes/Analysis/Bamcalibrationblock.pm
+++ b/lib/MIP/Recipes/Analysis/Bamcalibrationblock.pm
@@ -154,12 +154,12 @@ sub analysis_bamcalibrationblock {
 
     check( $tmpl, $arg_href, 1 ) or croak q{Could not parse arguments!};
 
+    use MIP::Get::Parameter qw{ get_module_parameters };
     use MIP::Script::Setup_script qw{ setup_script };
 
     ## Constants
     Readonly my $PROCESS_TIME => 80;
-
-    my $core_number = $active_parameter_href->{max_cores_per_node};
+    Readonly my $CORE_NUMBER  => $active_parameter_href->{max_cores_per_node};
 
     ## Filehandles
     # Create anonymous filehandle
@@ -182,12 +182,18 @@ sub analysis_bamcalibrationblock {
     foreach my $sample_id ( @{ $active_parameter_href->{sample_ids} } ) {
 
         my $xargs_file_counter = 0;
+        my ( $c_n, $t, @source_environment_cmds ) = get_module_parameters(
+            {
+                active_parameter_href => $active_parameter_href,
+                program_name          => $program_name,
+            }
+        );
 
         ## Creates program directories (info & programData & programScript), program script filenames and writes sbatch header
         my ( $file_path, $program_info_path ) = setup_script(
             {
                 active_parameter_href => $active_parameter_href,
-                core_number           => $core_number,
+                core_number           => $CORE_NUMBER,
                 directory_id          => $sample_id,
                 FILEHANDLE            => $FILEHANDLE,
                 job_id_href           => $job_id_href,
@@ -195,7 +201,8 @@ sub analysis_bamcalibrationblock {
                 program_directory => $active_parameter_href->{outaligner_dir},
                 program_name      => $program_name,
                 process_time      => $PROCESS_TIME,
-                temp_directory    => $temp_directory,
+                source_environment_commands_ref => \@source_environment_cmds,
+                temp_directory                  => $temp_directory,
             }
         );
 
@@ -218,6 +225,7 @@ sub analysis_bamcalibrationblock {
                     program_name            => $program,
                     sample_id               => $sample_id,
                     sample_info_href        => $sample_info_href,
+                    xargs_file_counter      => $xargs_file_counter,
                 }
             );
         }

--- a/lib/MIP/Recipes/Analysis/Bamcalibrationblock.pm
+++ b/lib/MIP/Recipes/Analysis/Bamcalibrationblock.pm
@@ -48,7 +48,7 @@ sub analysis_bamcalibrationblock {
 ##          : $order_programs_ref      => Order of programs
 ##          : $parameter_href          => Parameter hash {REF}
 ##          : $program_name            => Program name
-##          : $program_name-href       => Program name hash for log messages {REF}
+##          : $program_name_href       => Program name hash for log messages {REF}
 ##          : $sample_info_href        => Info on samples and family hash {REF}
 ##          : $temp_directory          => Temporary directory
 

--- a/lib/MIP/Recipes/Analysis/Bamcalibrationblock.pm
+++ b/lib/MIP/Recipes/Analysis/Bamcalibrationblock.pm
@@ -21,7 +21,7 @@ BEGIN {
     use base qw{ Exporter };
 
     # Set the version for version checking
-    our $VERSION = 1.02;
+    our $VERSION = 1.03;
 
     # Functions and variables which can be optionally exported
     our @EXPORT_OK = qw{ analysis_bamcalibrationblock };
@@ -29,23 +29,26 @@ BEGIN {
 }
 
 ## Constants
-Readonly my $TAB        => qq{\t};
-Readonly my $NEWLINE    => qq{\n};
-Readonly my $UNDERSCORE => q{_};
+Readonly my $CLOSE_BRACKET => q{]};
+Readonly my $NEWLINE       => qq{\n};
+Readonly my $OPEN_BRACKET  => q{[};
+Readonly my $TAB           => qq{\t};
+Readonly my $UNDERSCORE    => q{_};
 
 sub analysis_bamcalibrationblock {
 
-## Function : Run consecutive module
+## Function : Run consecutive analysis recipes on the same node
 ## Returns  :
 ## Arguments: $active_parameter_href   => Active parameters for this analysis hash {REF}
+##          : $bamcal_ar_href          => Analysis recipes for bamcalibration block
 ##          : $file_info_href          => File info hash {REF}
 ##          : $infile_lane_prefix_href => Infile(s) without the ".ending" {REF}
 ##          : $job_id_href             => Job id hash {REF}
-##          : $lane_href               => The lane info hash {REF}
 ##          : $log                     => Log object to write to
-##          : $outaligner_dir          => Outaligner dir used
+##          : $order_programs_ref      => Order of programs
 ##          : $parameter_href          => Parameter hash {REF}
 ##          : $program_name            => Program name
+##          : $program_name-href       => Program name hash for log messages {REF}
 ##          : $sample_info_href        => Info on samples and family hash {REF}
 ##          : $temp_directory          => Temporary directory
 
@@ -53,102 +56,104 @@ sub analysis_bamcalibrationblock {
 
     ## Flatten argument(s)
     my $active_parameter_href;
+    my $bamcal_ar_href;
     my $file_info_href;
     my $infile_lane_prefix_href;
     my $job_id_href;
-    my $lane_href;
     my $log;
+    my $order_programs_ref;
     my $parameter_href;
     my $program_name;
+    my $program_name_href;
     my $sample_info_href;
 
     ## Default(s)
-    my $outaligner_dir;
     my $temp_directory;
 
     my $tmpl = {
         active_parameter_href => {
-            required    => 1,
-            defined     => 1,
             default     => {},
-            strict_type => 1,
+            defined     => 1,
+            required    => 1,
             store       => \$active_parameter_href,
+            strict_type => 1,
+        },
+        bamcal_ar_href => {
+            default     => {},
+            defined     => 1,
+            required    => 1,
+            store       => \$bamcal_ar_href,
+            strict_type => 1,
         },
         file_info_href => {
-            required    => 1,
-            defined     => 1,
             default     => {},
-            strict_type => 1,
+            defined     => 1,
+            required    => 1,
             store       => \$file_info_href,
+            strict_type => 1,
         },
         infile_lane_prefix_href => {
-            required    => 1,
-            defined     => 1,
             default     => {},
-            strict_type => 1,
+            defined     => 1,
+            required    => 1,
             store       => \$infile_lane_prefix_href,
+            strict_type => 1,
         },
         job_id_href => {
-            required    => 1,
-            defined     => 1,
             default     => {},
-            strict_type => 1,
+            defined     => 1,
+            required    => 1,
             store       => \$job_id_href,
-        },
-        lane_href => {
-            required    => 1,
-            defined     => 1,
-            default     => {},
             strict_type => 1,
-            store       => \$lane_href
         },
         log => {
-            required => 1,
             defined  => 1,
-            store    => \$log
+            required => 1,
+            store    => \$log,
         },
-        outaligner_dir => {
-            default     => $arg_href->{active_parameter_href}{outaligner_dir},
+        order_programs_ref => {
+            default     => [],
+            defined     => 1,
+            required    => 1,
+            store       => \$order_programs_ref,
             strict_type => 1,
-            store       => \$outaligner_dir,
         },
         parameter_href => {
-            required    => 1,
-            defined     => 1,
             default     => {},
-            strict_type => 1,
+            defined     => 1,
+            required    => 1,
             store       => \$parameter_href,
+            strict_type => 1,
         },
         program_name => {
-            required    => 1,
             defined     => 1,
-            strict_type => 1,
+            required    => 1,
             store       => \$program_name,
+            strict_type => 1,
+        },
+        program_name_href => {
+            default     => {},
+            defined     => 1,
+            required    => 1,
+            store       => \$program_name_href,
+            strict_type => 1,
         },
         sample_info_href => {
-            required    => 1,
-            defined     => 1,
             default     => {},
-            strict_type => 1,
+            defined     => 1,
+            required    => 1,
             store       => \$sample_info_href,
+            strict_type => 1,
         },
         temp_directory => {
             default     => $arg_href->{active_parameter_href}{temp_directory},
-            strict_type => 1,
             store       => \$temp_directory,
+            strict_type => 1,
         },
     };
 
     check( $tmpl, $arg_href, 1 ) or croak q{Could not parse arguments!};
 
-    use MIP::Recipes::Analysis::Gatk_realigner
-      qw{ analysis_gatk_realigner_rio };
-    use MIP::Recipes::Analysis::Gatk_baserecalibration
-      qw{ analysis_gatk_baserecalibration_rio };
-    use MIP::Recipes::Analysis::Markduplicates
-      qw{ analysis_markduplicates_rio };
-    use MIP::Recipes::Analysis::Picardtools_mergesamfiles
-      qw{ analysis_picardtools_mergesamfiles_rio };
     use MIP::Script::Setup_script qw{ setup_script };
 
     ## Constants
@@ -160,138 +165,55 @@ sub analysis_bamcalibrationblock {
     # Create anonymous filehandle
     my $FILEHANDLE = IO::Handle->new();
 
-    # Set order of supplying user info
-    my @rio_program_order =
-      qw{ picardtools_mergesamfiles markduplicates gatk_realigner gatk_baserecalibration };
-
-    # Store what to supply to user
-    my %rio_program = (
-        picardtools_mergesamfiles => q{[Picardtools mergesamfiles]},
-        markduplicates            => q{[Markduplicates]},
-        gatk_realigner => q{[GATK realignertargetcreator/indelrealigner]},
-        gatk_baserecalibration => q{[GATK baserecalibrator/printreads]},
-    );
-
-  RIO_PROGRAM:
-    foreach my $program_name (@rio_program_order) {
-
-        if ( $active_parameter_href->{$program_name} ) {
-
-            my $program_header = $rio_program{$program_name};
-
-            $log->info( $TAB . $program_header );
-        }
-    }
-
   SAMPLE_ID:
     foreach my $sample_id ( @{ $active_parameter_href->{sample_ids} } ) {
 
         my $xargs_file_counter = 0;
 
-        ## Assign directories
-        my $insample_directory = catdir( $active_parameter_href->{outdata_dir},
-            $sample_id, $outaligner_dir );
-        my $outsample_directory = catdir( $active_parameter_href->{outdata_dir},
-            $sample_id, $outaligner_dir );
-
         ## Creates program directories (info & programData & programScript), program script filenames and writes sbatch header
         my ( $file_path, $program_info_path ) = setup_script(
             {
                 active_parameter_href => $active_parameter_href,
-                job_id_href           => $job_id_href,
-                FILEHANDLE            => $FILEHANDLE,
-                directory_id          => $sample_id,
-            log                       => $log,
-                program_name          => $program_name,
-                program_directory     => $outaligner_dir,
                 core_number           => $core_number,
-                process_time          => $PROCESS_TIME,
-                temp_directory        => $temp_directory,
+                directory_id          => $sample_id,
+                FILEHANDLE            => $FILEHANDLE,
+                job_id_href           => $job_id_href,
+                log                   => $log,
+                program_directory => $active_parameter_href->{outaligner_dir},
+                program_name      => $program_name,
+                process_time      => $PROCESS_TIME,
+                temp_directory    => $temp_directory,
             }
         );
 
-        ## Always run Picardtools mergesamfiles even for single samples to rename them correctly for standardised downstream processing.
-        ## Will also split alignment per contig and copy to temporary directory for -rio 1 block to enable selective removal of block submodules.
-        if ( $active_parameter_href->{picardtools_mergesamfiles} ) {
+      PROGRAM:
+        foreach my $program ( @{$order_programs_ref} ) {
 
-            ($xargs_file_counter) = analysis_picardtools_mergesamfiles_rio(
+            ## Only for active programs
+            next PROGRAM if ( not $active_parameter_href->{$program} );
+
+            $log->info( $OPEN_BRACKET
+                  . $program_name_href->{$program}
+                  . $CLOSE_BRACKET );
+
+            ($xargs_file_counter) = $bamcal_ar_href->{$program}->(
                 {
-                    parameter_href          => $parameter_href,
                     active_parameter_href   => $active_parameter_href,
-                    sample_info_href        => $sample_info_href,
                     file_info_href          => $file_info_href,
-                    infile_lane_prefix_href => $infile_lane_prefix_href,
-                    lane_href               => $lane_href,
-                    job_id_href             => $job_id_href,
-                    insample_directory      => $insample_directory,
-                    sample_id               => $sample_id,
-                    program_name            => q{picardtools_mergesamfiles},
                     file_path               => $file_path,
-                    program_info_path       => $program_info_path,
                     FILEHANDLE              => $FILEHANDLE,
-                }
-            );
-        }
-
-        # Markduplicates
-        if ( $active_parameter_href->{markduplicates} ) {
-
-            ($xargs_file_counter) = analysis_markduplicates_rio(
-                {
-                    parameter_href        => $parameter_href,
-                    active_parameter_href => $active_parameter_href,
-                    sample_info_href      => $sample_info_href,
-                    file_info_href        => $file_info_href,
-                    sample_id             => $sample_id,
-                    program_name          => q{markduplicates},
-                    file_path             => $file_path,
-                    program_info_path     => $program_info_path,
-                    FILEHANDLE            => $FILEHANDLE,
-                    xargs_file_counter    => $xargs_file_counter,
-                }
-            );
-        }
-
-        ## Run GATK realignertargetcreator/indelrealigner
-        if ( $active_parameter_href->{gatk_realigner} ) {
-
-            ($xargs_file_counter) = analysis_gatk_realigner_rio(
-                {
-                    parameter_href        => $parameter_href,
-                    active_parameter_href => $active_parameter_href,
-                    file_info_href        => $file_info_href,
-                    sample_id             => $sample_id,
-                    program_name          => q{gatk_realigner},
-                    file_path             => $file_path,
-                    program_info_path     => $program_info_path,
-                    FILEHANDLE            => $FILEHANDLE,
-                    xargs_file_counter    => $xargs_file_counter,
-                }
-            );
-        }
-
-        ## Run GATK baserecalibrator/printreads
-        if ( $active_parameter_href->{gatk_baserecalibration} ) {
-
-            ($xargs_file_counter) = analysis_gatk_baserecalibration_rio(
-                {
-                    parameter_href          => $parameter_href,
-                    active_parameter_href   => $active_parameter_href,
-                    sample_info_href        => $sample_info_href,
-                    file_info_href          => $file_info_href,
                     infile_lane_prefix_href => $infile_lane_prefix_href,
                     job_id_href             => $job_id_href,
-                    sample_id               => $sample_id,
-                    outsample_directory     => $outsample_directory,
-                    program_name            => q{gatk_baserecalibration},
-                    file_path               => $file_path,
+                    parameter_href          => $parameter_href,
                     program_info_path       => $program_info_path,
-                    FILEHANDLE              => $FILEHANDLE,
-                    xargs_file_counter      => $xargs_file_counter,
+                    program_name            => $program,
+                    sample_id               => $sample_id,
+                    sample_info_href        => $sample_info_href,
                 }
             );
         }
     }
+
     return;
 }
 

--- a/lib/MIP/Recipes/Analysis/Bcftools_mpileup.pm
+++ b/lib/MIP/Recipes/Analysis/Bcftools_mpileup.pm
@@ -21,7 +21,7 @@ BEGIN {
     use base qw{ Exporter };
 
     # Set the version for version checking
-    our $VERSION = 1.01;
+    our $VERSION = 1.02;
 
     # Functions and variables which can be optionally exported
     our @EXPORT_OK = qw{ analysis_bcftools_mpileup };
@@ -48,7 +48,6 @@ sub analysis_bcftools_mpileup {
 ##          : $infile_lane_prefix_href => Infile(s) without the ".ending" {REF}
 ##          : $job_id_href             => Job id hash {REF}
 ##          : $outaligner_dir          => Outaligner_dir used in the analysis
-##          : $outfamily_directory     => Out family directory
 ##          : $parameter_href          => Parameter hash {REF}
 ##          : $program_name            => Program name
 ##          : $sample_info_href        => Info on samples and family hash {REF}
@@ -62,7 +61,6 @@ sub analysis_bcftools_mpileup {
     my $file_info_href;
     my $infile_lane_prefix_href;
     my $job_id_href;
-    my $outfamily_directory;
     my $parameter_href;
     my $program_name;
     my $sample_info_href;
@@ -76,82 +74,75 @@ sub analysis_bcftools_mpileup {
 
     my $tmpl = {
         active_parameter_href => {
-            required    => 1,
-            defined     => 1,
             default     => {},
-            strict_type => 1,
+            defined     => 1,
+            required    => 1,
             store       => \$active_parameter_href,
+            strict_type => 1,
         },
         call_type =>
-          { default => q{BOTH}, strict_type => 1, store => \$call_type, },
+          { default => q{BOTH}, store => \$call_type, strict_type => 1, },
         family_id => {
             default     => $arg_href->{active_parameter_href}{family_id},
-            strict_type => 1,
             store       => \$family_id,
+            strict_type => 1,
         },
         file_info_href => {
-            required    => 1,
-            defined     => 1,
             default     => {},
-            strict_type => 1,
+            defined     => 1,
+            required    => 1,
             store       => \$file_info_href,
+            strict_type => 1,
         },
         infile_lane_prefix_href => {
-            required    => 1,
-            defined     => 1,
             default     => {},
-            strict_type => 1,
+            defined     => 1,
+            required    => 1,
             store       => \$infile_lane_prefix_href,
+            strict_type => 1,
         },
         job_id_href => {
-            required    => 1,
-            defined     => 1,
             default     => {},
-            strict_type => 1,
+            defined     => 1,
+            required    => 1,
             store       => \$job_id_href,
+            strict_type => 1,
         },
         outaligner_dir => {
             default     => $arg_href->{active_parameter_href}{outaligner_dir},
-            strict_type => 1,
             store       => \$outaligner_dir,
-        },
-
-        outfamily_directory => {
-            required    => 1,
-            defined     => 1,
             strict_type => 1,
-            store       => \$outfamily_directory,
         },
         parameter_href => {
-            required    => 1,
-            defined     => 1,
             default     => {},
-            strict_type => 1,
+            defined     => 1,
+            required    => 1,
             store       => \$parameter_href,
+            strict_type => 1,
         },
         program_name => {
-            required    => 1,
             defined     => 1,
-            strict_type => 1,
+            required    => 1,
             store       => \$program_name,
+            strict_type => 1,
         },
         sample_info_href => {
-            required    => 1,
-            defined     => 1,
             default     => {},
-            strict_type => 1,
+            defined     => 1,
+            required    => 1,
             store       => \$sample_info_href,
+            strict_type => 1,
         },
         temp_directory_ref => {
             default     => $arg_href->{active_parameter_href}{temp_directory},
-            strict_type => 1,
             store       => \$temp_directory,
+            strict_type => 1,
         },
         xargs_file_counter => {
-            default     => 0,
             allow       => qr/ ^\d+$ /xsm,
-            strict_type => 1,
+            default     => 0,
             store       => \$xargs_file_counter,
+            strict_type => 1,
         },
     };
 
@@ -175,22 +166,25 @@ sub analysis_bcftools_mpileup {
     ## Retrieve logger object
     my $log = Log::Log4perl->get_logger(q{MIP});
 
-    ## Set MIP program name
+    ## Set program name
     my $program_mode = $active_parameter_href->{$program_name};
 
     ## Unpack parameters
     my $job_id_chain = $parameter_href->{$program_name}{chain};
-    my ( $core_number, $time, @source_environment_cmds ) = get_module_parameters(
+    my ( $core_number, $time, @source_environment_cmds ) =
+      get_module_parameters(
         {
             active_parameter_href => $active_parameter_href,
-            program_name      => $program_name,
+            program_name          => $program_name,
         }
-    );
+      );
     ## Alias
     my $program_outdirectory_name =
       $parameter_href->{$program_name}{outdir_name};
     my $program_directory =
       catfile( $outaligner_dir, $program_outdirectory_name );
+    my $outfamily_directory = catfile( $active_parameter_href->{outdata_dir},
+        $family_id, $outaligner_dir, $program_outdirectory_name );
     my $xargs_file_path_prefix;
     my $reference_path = $active_parameter_href->{human_genome_reference};
 
@@ -245,7 +239,7 @@ sub analysis_bcftools_mpileup {
     ## Set file suffix for next module within jobid chain
     my $outfile_suffix = set_file_suffix(
         {
-            file_suffix => $parameter_href->{$program_name}{outfile_suffix},
+            file_suffix    => $parameter_href->{$program_name}{outfile_suffix},
             job_id_chain   => $job_id_chain,
             parameter_href => $parameter_href,
             suffix_key     => q{variant_file_suffix},

--- a/lib/MIP/Recipes/Analysis/BootstrapAnn.pm
+++ b/lib/MIP/Recipes/Analysis/BootstrapAnn.pm
@@ -25,7 +25,7 @@ BEGIN {
     use base qw{ Exporter };
 
     # Set the version for version checking
-    our $VERSION = 1.00;
+    our $VERSION = 1.01;
 
     # Functions and variables which can be optionally exported
     our @EXPORT_OK = qw{ analysis_bootstrapann };
@@ -43,6 +43,7 @@ sub analysis_bootstrapann {
 ## Arguments: $active_parameter_href   => Active parameters for this analysis hash {REF}
 ##          : $family_id               => Family id
 ##          : $file_info_href          => File info hash {REF}
+##          : $indir_path_ref          => Indirectories path(s) hash {REF}
 ##          : $infile_lane_prefix_href => Infile(s) without the ".ending" {REF}
 ##          : $insample_directory      => In sample directory
 ##          : $job_id_href             => Job id hash {REF}
@@ -59,10 +60,9 @@ sub analysis_bootstrapann {
     ## Flatten argument(s)
     my $active_parameter_href;
     my $file_info_href;
+    my $indir_path_href;
     my $infile_lane_prefix_href;
-    my $insample_directory;
     my $job_id_href;
-    my $outsample_directory;
     my $parameter_href;
     my $program_name;
     my $sample_id;
@@ -70,7 +70,6 @@ sub analysis_bootstrapann {
 
     ## Default(s)
     my $family_id;
-    my $outaligner_dir;
     my $temp_directory;
 
     my $tmpl = {
@@ -93,6 +92,11 @@ sub analysis_bootstrapann {
             store       => \$file_info_href,
             strict_type => 1,
         },
+        indir_path_href => {
+            default     => {},
+            store       => \$indir_path_href,
+            strict_type => 1,
+        },
         infile_lane_prefix_href => {
             default     => {},
             defined     => 1,
@@ -100,28 +104,11 @@ sub analysis_bootstrapann {
             store       => \$infile_lane_prefix_href,
             strict_type => 1,
         },
-        insample_directory => {
-            defined     => 1,
-            required    => 1,
-            store       => \$insample_directory,
-            strict_type => 1,
-        },
         job_id_href => {
             default     => {},
             defined     => 1,
             required    => 1,
             store       => \$job_id_href,
-            strict_type => 1,
-        },
-        outaligner_dir => {
-            default     => $arg_href->{active_parameter_href}{outaligner_dir},
-            store       => \$outaligner_dir,
-            strict_type => 1,
-        },
-        outsample_directory => {
-            defined     => 1,
-            required    => 1,
-            store       => \$outsample_directory,
             strict_type => 1,
         },
         parameter_href => {
@@ -193,6 +180,12 @@ sub analysis_bootstrapann {
     # Create anonymous filehandle
     my $FILEHANDLE = IO::Handle->new();
 
+    ## Assign directories
+    my $insample_directory = catdir( $active_parameter_href->{outdata_dir},
+        $sample_id, $active_parameter_href->{outaligner_dir} );
+    my $outsample_directory = catdir( $active_parameter_href->{outdata_dir},
+        $sample_id, $active_parameter_href->{outaligner_dir} );
+
     ## Creates program directories (info & programData & programScript), program script filenames and writes sbatch header
     my ( $file_path, $program_info_path ) = setup_script(
         {
@@ -203,8 +196,9 @@ sub analysis_bootstrapann {
             job_id_href           => $job_id_href,
             log                   => $log,
             process_time          => $time,
-            program_directory     => catfile( $outaligner_dir, q{gatk} ),
-            program_name          => $program_name,
+            program_directory =>
+              catfile( $active_parameter_href->{outaligner_dir}, q{gatk} ),
+            program_name                    => $program_name,
             source_environment_commands_ref => \@source_environment_cmds,
             temp_directory                  => $temp_directory,
         }

--- a/lib/MIP/Recipes/Analysis/Bwa_mem.pm
+++ b/lib/MIP/Recipes/Analysis/Bwa_mem.pm
@@ -46,7 +46,6 @@ sub analysis_bwa_mem {
 ## Arguments: $active_parameter_href   => Active parameters for this analysis hash {REF}
 ##          : $family_id               => Family id
 ##          : $file_info_href          => File info hash {REF}
-##          : indir_path_href          => Indirectories path(s) hash {REF}
 ##          : $infile_lane_prefix_href => Infile(s) without the ".ending" {REF}
 ##          : $job_id_href             => Job id hash {REF}
 ##          : $parameter_href          => Parameter hash {REF}
@@ -60,7 +59,6 @@ sub analysis_bwa_mem {
     ## Flatten argument(s)
     my $active_parameter_href;
     my $file_info_href;
-    my $indir_path_href;
     my $infile_lane_prefix_href;
     my $job_id_href;
     my $parameter_href;
@@ -90,13 +88,6 @@ sub analysis_bwa_mem {
             defined     => 1,
             required    => 1,
             store       => \$file_info_href,
-            strict_type => 1,
-        },
-        indir_path_href => {
-            default     => {},
-            defined     => 1,
-            required    => 1,
-            store       => \$indir_path_href,
             strict_type => 1,
         },
         infile_lane_prefix_href => {
@@ -187,7 +178,7 @@ sub analysis_bwa_mem {
     my @infiles = @{ $file_info_href->{$sample_id}{mip_infiles} };
 
     ## Assign directories
-    my $insample_directory  = $indir_path_href->{$sample_id};
+    my $insample_directory  = $file_info_href->{$sample_id}{mip_infiles_dir};
     my $outsample_directory = catdir( $active_parameter_href->{outdata_dir},
         $sample_id, $active_parameter_href->{outaligner_dir} );
 

--- a/lib/MIP/Recipes/Analysis/Bwa_mem.pm
+++ b/lib/MIP/Recipes/Analysis/Bwa_mem.pm
@@ -22,7 +22,7 @@ BEGIN {
     use base qw{ Exporter };
 
     # Set the version for version checking
-    our $VERSION = 1.04;
+    our $VERSION = 1.05;
 
     # Functions and variables which can be optionally exported
     our @EXPORT_OK = qw{ analysis_bwa_mem };
@@ -46,12 +46,9 @@ sub analysis_bwa_mem {
 ## Arguments: $active_parameter_href   => Active parameters for this analysis hash {REF}
 ##          : $family_id               => Family id
 ##          : $file_info_href          => File info hash {REF}
-##          : $infiles_ref             => Infiles hash {REF}
+##          : indir_path_href          => Indirectories path(s) hash {REF}
 ##          : $infile_lane_prefix_href => Infile(s) without the ".ending" {REF}
-##          : $insample_directory      => In sample directory
 ##          : $job_id_href             => Job id hash {REF}
-##          : $outaligner_dir          => Outaligner_dir used in the analysis
-##          : $outsample_directory     => Out sample directory
 ##          : $parameter_href          => Parameter hash {REF}
 ##          : $program_name            => Program name
 ##          : $sample_id               => Sample id
@@ -63,11 +60,9 @@ sub analysis_bwa_mem {
     ## Flatten argument(s)
     my $active_parameter_href;
     my $file_info_href;
-    my $infiles_ref;
+    my $indir_path_href;
     my $infile_lane_prefix_href;
-    my $insample_directory;
     my $job_id_href;
-    my $outsample_directory;
     my $parameter_href;
     my $program_name;
     my $sample_id;
@@ -75,7 +70,6 @@ sub analysis_bwa_mem {
 
     ## Default(s)
     my $family_id;
-    my $outaligner_dir;
     my $temp_directory;
 
     my $tmpl = {
@@ -98,11 +92,11 @@ sub analysis_bwa_mem {
             store       => \$file_info_href,
             strict_type => 1,
         },
-        infiles_ref => {
-            default     => [],
+        indir_path_href => {
+            default     => {},
             defined     => 1,
             required    => 1,
-            store       => \$infiles_ref,
+            store       => \$indir_path_href,
             strict_type => 1,
         },
         infile_lane_prefix_href => {
@@ -112,28 +106,11 @@ sub analysis_bwa_mem {
             store       => \$infile_lane_prefix_href,
             strict_type => 1,
         },
-        insample_directory => {
-            defined     => 1,
-            required    => 1,
-            store       => \$insample_directory,
-            strict_type => 1,
-        },
         job_id_href => {
             default     => {},
             defined     => 1,
             required    => 1,
             store       => \$job_id_href,
-            strict_type => 1,
-        },
-        outaligner_dir => {
-            default     => $arg_href->{active_parameter_href}{outaligner_dir},
-            store       => \$outaligner_dir,
-            strict_type => 1,
-        },
-        outsample_directory => {
-            defined     => 1,
-            required    => 1,
-            store       => \$outsample_directory,
             strict_type => 1,
         },
         parameter_href => {
@@ -194,18 +171,26 @@ sub analysis_bwa_mem {
     my $consensus_analysis_type =
       $parameter_href->{dynamic_parameter}{consensus_analysis_type};
     my $referencefile_path = $active_parameter_href->{human_genome_reference};
-    my ( $core_number, $time, @source_environment_cmds ) = get_module_parameters(
+    my ( $core_number, $time, @source_environment_cmds ) =
+      get_module_parameters(
         {
             active_parameter_href => $active_parameter_href,
-            program_name      => $program_name,
+            program_name          => $program_name,
         }
-    );
+      );
 
     ## Filehandles
     # Create anonymous filehandle
     my $FILEHANDLE = IO::Handle->new();
 
+    ## Get infiles
+    my @infiles = @{ $file_info_href->{$sample_id}{mip_infiles} };
+
     ## Assign directories
+    my $insample_directory  = $indir_path_href->{$sample_id};
+    my $outsample_directory = catdir( $active_parameter_href->{outdata_dir},
+        $sample_id, $active_parameter_href->{outaligner_dir} );
+
     # Used downstream
     $parameter_href->{$program_name}{$sample_id}{indirectory} =
       $outsample_directory;
@@ -218,7 +203,7 @@ sub analysis_bwa_mem {
     ## Set file suffix for next module within jobid chain
     my $outfile_suffix = set_file_suffix(
         {
-            file_suffix => $parameter_href->{$program_name}{outfile_suffix},
+            file_suffix    => $parameter_href->{$program_name}{outfile_suffix},
             job_id_chain   => $job_id_chain,
             parameter_href => $parameter_href,
             suffix_key     => q{alignment_file_suffix},
@@ -258,16 +243,16 @@ sub analysis_bwa_mem {
         ## Creates program directories (info & programData & programScript), program script filenames and writes sbatch header
         my ( $file_name, $program_info_path ) = setup_script(
             {
-                active_parameter_href           => $active_parameter_href,
-                core_number                     => $core_number,
-                directory_id                    => $sample_id,
-                FILEHANDLE                      => $FILEHANDLE,
-                job_id_href                     => $job_id_href,
-                log                             => $log,
-                program_directory               => lc $outaligner_dir,
-                program_name                    => $program_name,
-                process_time                    => $time,
-                sleep                           => 1,
+                active_parameter_href => $active_parameter_href,
+                core_number           => $core_number,
+                directory_id          => $sample_id,
+                FILEHANDLE            => $FILEHANDLE,
+                job_id_href           => $job_id_href,
+                log                   => $log,
+                program_directory => $active_parameter_href->{outaligner_dir},
+                program_name      => $program_name,
+                process_time      => $time,
+                sleep             => 1,
                 source_environment_commands_ref => \@source_environment_cmds,
                 temp_directory                  => $temp_directory,
             }
@@ -282,7 +267,7 @@ sub analysis_bwa_mem {
 
         # Read 1
         my $insample_dir_fastqc_path_read_one =
-          catfile( $insample_directory, $infiles_ref->[$paired_end_tracker] );
+          catfile( $insample_directory, $infiles[$paired_end_tracker] );
         migrate_file(
             {
                 FILEHANDLE   => $FILEHANDLE,
@@ -296,7 +281,7 @@ sub analysis_bwa_mem {
 
             my $insample_dir_fastqc_path_read_two =
               catfile( $insample_directory,
-                $infiles_ref->[ $paired_end_tracker + 1 ] );
+                $infiles[ $paired_end_tracker + 1 ] );
 
             # Read 2
             migrate_file(
@@ -328,7 +313,7 @@ sub analysis_bwa_mem {
 
         ## Infile(s)
         my $fastq_file_path =
-          catfile( $temp_directory, $infiles_ref->[$paired_end_tracker] );
+          catfile( $temp_directory, $infiles[$paired_end_tracker] );
         my $second_fastq_file_path;
 
         # If second read direction is present
@@ -337,7 +322,7 @@ sub analysis_bwa_mem {
             # Increment to collect correct read 2 from %infile
             $paired_end_tracker = $paired_end_tracker + 1;
             $second_fastq_file_path =
-              catfile( $temp_directory, $infiles_ref->[$paired_end_tracker] );
+              catfile( $temp_directory, $infiles[$paired_end_tracker] );
         }
 
         ## Read group header line

--- a/lib/MIP/Recipes/Analysis/Chanjo_sex_check.pm
+++ b/lib/MIP/Recipes/Analysis/Chanjo_sex_check.pm
@@ -22,7 +22,7 @@ BEGIN {
     use base qw{ Exporter };
 
     # Set the version for version checking
-    our $VERSION = 1.05;
+    our $VERSION = 1.06;
 
     # Functions and variables which can be optionally exported
     our @EXPORT_OK = qw{ analysis_chanjo_sex_check };
@@ -41,11 +41,9 @@ sub analysis_chanjo_sex_check {
 ## Arguments: $active_parameter_href   => Active parameters for this analysis hash {REF}
 ##          : $family_id               => Family id
 ##          : $file_info_href          => The file_info hash {REF}
+##          : indir_path_href          => Indirectories path(s) hash {REF}
 ##          : $infile_lane_prefix_href => Infile(s) without the ".ending" {REF}
-##          : $insample_directory      => In sample directory
 ##          : $job_id_href             => Job id hash {REF}
-##          : $outaligner_dir          => Outaligner_dir used in the analysis
-##          : $outsample_directory     => Out sample directory
 ##          : $parameter_href          => Parameter hash {REF}
 ##          : $program_name            => Program name
 ##          : $sample_info_href        => Info on samples and family hash {REF}
@@ -53,21 +51,19 @@ sub analysis_chanjo_sex_check {
 
     my ($arg_href) = @_;
 
-    ## Default(s)
-    my $family_id;
-    my $outaligner_dir;
-
     ## Flatten argument(s)
     my $active_parameter_href;
     my $file_info_href;
+    my $indir_path_href;
     my $infile_lane_prefix_href;
-    my $insample_directory;
     my $job_id_href;
-    my $outsample_directory;
     my $parameter_href;
     my $program_name;
     my $sample_info_href;
     my $sample_id;
+
+    ## Default(s)
+    my $family_id;
 
     my $tmpl = {
         active_parameter_href => {
@@ -89,6 +85,13 @@ sub analysis_chanjo_sex_check {
             store       => \$file_info_href,
             strict_type => 1,
         },
+        indir_path_href => {
+            default     => {},
+            defined     => 1,
+            required    => 1,
+            store       => \$indir_path_href,
+            strict_type => 1,
+        },
         infile_lane_prefix_href => {
             default     => {},
             defined     => 1,
@@ -96,28 +99,11 @@ sub analysis_chanjo_sex_check {
             store       => \$infile_lane_prefix_href,
             strict_type => 1,
         },
-        insample_directory => {
-            defined     => 1,
-            required    => 1,
-            store       => \$insample_directory,
-            strict_type => 1,
-        },
         job_id_href => {
             default     => {},
             defined     => 1,
             required    => 1,
             store       => \$job_id_href,
-            strict_type => 1,
-        },
-        outaligner_dir => {
-            default     => $arg_href->{active_parameter_href}{outaligner_dir},
-            store       => \$outaligner_dir,
-            strict_type => 1,
-        },
-        outsample_directory => {
-            defined     => 1,
-            required    => 1,
-            store       => \$outsample_directory,
             strict_type => 1,
         },
         parameter_href => {
@@ -167,16 +153,24 @@ sub analysis_chanjo_sex_check {
 
     ## Alias
     my $job_id_chain = $parameter_href->{$program_name}{chain};
-    my ( $core_number, $time, @source_environment_cmds ) = get_module_parameters(
+    my ( $core_number, $time, @source_environment_cmds ) =
+      get_module_parameters(
         {
             active_parameter_href => $active_parameter_href,
-            program_name      => $program_name,
+            program_name          => $program_name,
         }
-    );
+      );
 
     ## Filehandles
     # Create anonymous filehandle
     my $FILEHANDLE = IO::Handle->new();
+
+    ## Assign directories
+    my $insample_directory  = $indir_path_href->{$sample_id};
+    my $outsample_directory = catdir(
+        $active_parameter_href->{outdata_dir},    $sample_id,
+        $active_parameter_href->{outaligner_dir}, q{coveragereport}
+    );
 
     ## Add merged infile name prefix after merging all BAM files per sample_id
     my $merged_infile_prefix = get_merged_infile_prefix(
@@ -231,8 +225,10 @@ sub analysis_chanjo_sex_check {
             log                   => $log,
             job_id_href           => $job_id_href,
             process_time          => $time,
-            program_directory =>
-              catfile( lc($outaligner_dir), q{coveragereport} ),
+            program_directory     => catfile(
+                lc( $active_parameter_href->{outaligner_dir} ),
+                q{coveragereport}
+            ),
             program_name                    => $program_name,
             source_environment_commands_ref => \@source_environment_cmds,
         }

--- a/lib/MIP/Recipes/Analysis/Chanjo_sex_check.pm
+++ b/lib/MIP/Recipes/Analysis/Chanjo_sex_check.pm
@@ -41,7 +41,6 @@ sub analysis_chanjo_sex_check {
 ## Arguments: $active_parameter_href   => Active parameters for this analysis hash {REF}
 ##          : $family_id               => Family id
 ##          : $file_info_href          => The file_info hash {REF}
-##          : indir_path_href          => Indirectories path(s) hash {REF}
 ##          : $infile_lane_prefix_href => Infile(s) without the ".ending" {REF}
 ##          : $job_id_href             => Job id hash {REF}
 ##          : $parameter_href          => Parameter hash {REF}
@@ -54,7 +53,6 @@ sub analysis_chanjo_sex_check {
     ## Flatten argument(s)
     my $active_parameter_href;
     my $file_info_href;
-    my $indir_path_href;
     my $infile_lane_prefix_href;
     my $job_id_href;
     my $parameter_href;
@@ -83,13 +81,6 @@ sub analysis_chanjo_sex_check {
             defined     => 1,
             required    => 1,
             store       => \$file_info_href,
-            strict_type => 1,
-        },
-        indir_path_href => {
-            default     => {},
-            defined     => 1,
-            required    => 1,
-            store       => \$indir_path_href,
             strict_type => 1,
         },
         infile_lane_prefix_href => {
@@ -166,7 +157,8 @@ sub analysis_chanjo_sex_check {
     my $FILEHANDLE = IO::Handle->new();
 
     ## Assign directories
-    my $insample_directory  = $indir_path_href->{$sample_id};
+    my $insample_directory = catdir( $active_parameter_href->{outdata_dir},
+        $sample_id, $active_parameter_href->{outaligner_dir} );
     my $outsample_directory = catdir(
         $active_parameter_href->{outdata_dir},    $sample_id,
         $active_parameter_href->{outaligner_dir}, q{coveragereport}

--- a/lib/MIP/Recipes/Analysis/Delly_reformat.pm
+++ b/lib/MIP/Recipes/Analysis/Delly_reformat.pm
@@ -47,7 +47,6 @@ sub analysis_delly_reformat {
 ##          : $infile_lane_prefix_href => Infile(s) without the ".ending" {REF}
 ##          : $job_id_href             => Job id hash {REF}
 ##          : $outaligner_dir          => Outaligner_dir used in the analysis
-##          : $outfamily_directory     => Out family directory
 ##          : $parameter_href          => Parameter hash {REF}
 ##          : $program_name            => Program name
 ##          : $reference_dir           => MIP reference directory
@@ -62,7 +61,6 @@ sub analysis_delly_reformat {
     my $file_info_href;
     my $infile_lane_prefix_href;
     my $job_id_href;
-    my $outfamily_directory;
     my $parameter_href;
     my $program_name;
     my $sample_info_href;
@@ -114,12 +112,6 @@ sub analysis_delly_reformat {
         outaligner_dir => {
             default     => $arg_href->{active_parameter_href}{outaligner_dir},
             store       => \$outaligner_dir,
-            strict_type => 1,
-        },
-        outfamily_directory => {
-            defined     => 1,
-            required    => 1,
-            store       => \$outfamily_directory,
             strict_type => 1,
         },
         parameter_href => {
@@ -221,6 +213,14 @@ sub analysis_delly_reformat {
             source_environment_commands_ref => \@source_environment_cmds,
             temp_directory                  => $temp_directory,
         }
+    );
+
+    ## Assign directories
+    my $outfamily_directory = catfile(
+        $active_parameter_href->{outdata_dir},
+        $active_parameter_href->{family_id},
+        $active_parameter_href->{outaligner_dir},
+        $program_outdirectory_name,
     );
 
     # Used downstream

--- a/lib/MIP/Recipes/Analysis/Delly_reformat.pm
+++ b/lib/MIP/Recipes/Analysis/Delly_reformat.pm
@@ -21,7 +21,7 @@ BEGIN {
     use base qw{ Exporter };
 
     # Set the version for version checking
-    our $VERSION = 1.01;
+    our $VERSION = 1.02;
 
     # Functions and variables which can be optionally exported
     our @EXPORT_OK = qw{ analysis_delly_reformat };
@@ -77,86 +77,86 @@ sub analysis_delly_reformat {
 
     my $tmpl = {
         active_parameter_href => {
-            required    => 1,
-            defined     => 1,
             default     => {},
-            strict_type => 1,
+            defined     => 1,
+            required    => 1,
             store       => \$active_parameter_href,
+            strict_type => 1,
         },
         call_type =>
-          { default => q{SV}, strict_type => 1, store => \$call_type, },
+          { default => q{SV}, store => \$call_type, strict_type => 1, },
         family_id => {
             default     => $arg_href->{active_parameter_href}{family_id},
-            strict_type => 1,
             store       => \$family_id,
+            strict_type => 1,
         },
         file_info_href => {
-            required    => 1,
-            defined     => 1,
             default     => {},
-            strict_type => 1,
+            defined     => 1,
+            required    => 1,
             store       => \$file_info_href,
+            strict_type => 1,
         },
         infile_lane_prefix_href => {
-            required    => 1,
-            defined     => 1,
             default     => {},
-            strict_type => 1,
+            defined     => 1,
+            required    => 1,
             store       => \$infile_lane_prefix_href,
+            strict_type => 1,
         },
         job_id_href => {
-            required    => 1,
-            defined     => 1,
             default     => {},
-            strict_type => 1,
+            defined     => 1,
+            required    => 1,
             store       => \$job_id_href,
+            strict_type => 1,
         },
         outaligner_dir => {
             default     => $arg_href->{active_parameter_href}{outaligner_dir},
-            strict_type => 1,
             store       => \$outaligner_dir,
+            strict_type => 1,
         },
         outfamily_directory => {
-            required    => 1,
             defined     => 1,
-            strict_type => 1,
+            required    => 1,
             store       => \$outfamily_directory,
+            strict_type => 1,
         },
         parameter_href => {
-            required    => 1,
-            defined     => 1,
             default     => {},
-            strict_type => 1,
+            defined     => 1,
+            required    => 1,
             store       => \$parameter_href,
+            strict_type => 1,
         },
         program_name => {
-            required    => 1,
             defined     => 1,
-            strict_type => 1,
+            required    => 1,
             store       => \$program_name,
+            strict_type => 1,
         },
         reference_dir_ref => {
             default     => $arg_href->{active_parameter_href}{reference_dir},
-            strict_type => 1,
             store       => \$reference_dir,
+            strict_type => 1,
         },
         sample_info_href => {
-            required    => 1,
-            defined     => 1,
             default     => {},
-            strict_type => 1,
+            defined     => 1,
+            required    => 1,
             store       => \$sample_info_href,
+            strict_type => 1,
         },
         temp_directory => {
             default     => $arg_href->{active_parameter_href}{temp_directory},
-            strict_type => 1,
             store       => \$temp_directory,
+            strict_type => 1,
         },
         xargs_file_counter => {
-            default     => 0,
             allow       => qr/ ^\d+$ /xsm,
-            strict_type => 1,
+            default     => 0,
             store       => \$xargs_file_counter,
+            strict_type => 1,
         },
     };
 
@@ -182,7 +182,7 @@ sub analysis_delly_reformat {
     ## Retrieve logger object
     my $log = Log::Log4perl->get_logger(q{MIP});
 
-    ## Set MIP program name
+    ## Set program name
     my $program_mode = $active_parameter_href->{$program_name};
 
     ## Unpack parameters
@@ -190,12 +190,13 @@ sub analysis_delly_reformat {
     my $program_outdirectory_name =
       $parameter_href->{$program_name}{outdir_name};
     my $referencefile_path = $active_parameter_href->{human_genome_reference};
-    my ( $core_number, $time, @source_environment_cmds ) = get_module_parameters(
+    my ( $core_number, $time, @source_environment_cmds ) =
+      get_module_parameters(
         {
             active_parameter_href => $active_parameter_href,
-            program_name      => $program_name,
+            program_name          => $program_name,
         }
-    );
+      );
 
     ## Filehandles
     # Create anonymous filehandles

--- a/lib/MIP/Recipes/Analysis/Endvariantannotationblock.pm
+++ b/lib/MIP/Recipes/Analysis/Endvariantannotationblock.pm
@@ -79,82 +79,83 @@ sub analysis_endvariantannotationblock {
 
     my $tmpl = {
         active_parameter_href => {
-            required    => 1,
-            defined     => 1,
             default     => {},
-            strict_type => 1,
+            defined     => 1,
+            required    => 1,
             store       => \$active_parameter_href,
+            strict_type => 1,
         },
         call_type =>
-          { default => q{BOTH}, strict_type => 1, store => \$call_type, },
+          { default => q{BOTH}, store => \$call_type, strict_type => 1, },
         family_id => {
             default     => $arg_href->{active_parameter_href}{family_id},
-            strict_type => 1,
             store       => \$family_id,
-        },
-        file_path      => { strict_type => 1, store => \$file_path },
-        file_info_href => {
-            required    => 1,
-            defined     => 1,
-            default     => {},
             strict_type => 1,
+        },
+        file_path      => { store => \$file_path, strict_type => 1, },
+        file_info_href => {
+            default     => {},
+            defined     => 1,
+            required    => 1,
             store       => \$file_info_href,
+            strict_type => 1,
         },
         infile_lane_prefix_href => {
-            required    => 1,
-            defined     => 1,
             default     => {},
-            strict_type => 1,
+            defined     => 1,
+            required    => 1,
             store       => \$infile_lane_prefix_href,
+            strict_type => 1,
         },
         job_id_href => {
-            required    => 1,
-            defined     => 1,
             default     => {},
-            strict_type => 1,
+            defined     => 1,
+            required    => 1,
             store       => \$job_id_href,
+            strict_type => 1,
         },
         outaligner_dir => {
             default     => $arg_href->{active_parameter_href}{outaligner_dir},
-            strict_type => 1,
             store       => \$outaligner_dir,
+            strict_type => 1,
         },
         parameter_href => {
-            required    => 1,
-            defined     => 1,
             default     => {},
-            strict_type => 1,
-            store       => \$parameter_href,
-        },
-        program_info_path => { strict_type => 1, store => \$program_info_path },
-        program_name      => {
-            required    => 1,
             defined     => 1,
+            required    => 1,
+            store       => \$parameter_href,
             strict_type => 1,
+        },
+        program_info_path =>
+          { store => \$program_info_path, strict_type => 1, },
+        program_name => {
+            defined     => 1,
+            required    => 1,
             store       => \$program_name,
+            strict_type => 1,
         },
         reference_dir => {
             default     => $arg_href->{active_parameter_href}{reference_dir},
-            strict_type => 1,
             store       => \$reference_dir,
+            strict_type => 1,
         },
         sample_info_href => {
-            required    => 1,
-            defined     => 1,
             default     => {},
-            strict_type => 1,
+            defined     => 1,
+            required    => 1,
             store       => \$sample_info_href,
+            strict_type => 1,
         },
         temp_directory => {
             default     => $arg_href->{active_parameter_href}{temp_directory},
-            strict_type => 1,
             store       => \$temp_directory,
+            strict_type => 1,
         },
         xargs_file_counter => {
-            default     => 0,
             allow       => qr/ ^\d+$ /xsm,
-            strict_type => 1,
+            default     => 0,
             store       => \$xargs_file_counter,
+            strict_type => 1,
         },
     };
 
@@ -181,7 +182,7 @@ sub analysis_endvariantannotationblock {
     ## Retrieve logger object
     my $log = Log::Log4perl->get_logger(q{MIP});
 
-    ## Set MIP program name
+    ## Set program mode
     my $program_mode = $active_parameter_href->{$program_name};
 
     ## Unpack parameters
@@ -189,12 +190,13 @@ sub analysis_endvariantannotationblock {
       $parameter_href->{dynamic_parameter}{consensus_analysis_type};
     my $job_id_chain  = $parameter_href->{$program_name}{chain};
     my $reduce_io_ref = \$active_parameter_href->{reduce_io};
-    my ( $core_number, $time, @source_environment_cmds ) = get_module_parameters(
+    my ( $core_number, $time, @source_environment_cmds ) =
+      get_module_parameters(
         {
             active_parameter_href => $active_parameter_href,
-            program_name      => $program_name,
+            program_name          => $program_name,
         }
-    );
+      );
 
     my $vcfparser_analysis_type = $EMPTY_STR;
 
@@ -259,7 +261,7 @@ sub analysis_endvariantannotationblock {
 
     my $outfile_suffix = set_file_suffix(
         {
-            file_suffix => $parameter_href->{$program_name}{outfile_suffix},
+            file_suffix    => $parameter_href->{$program_name}{outfile_suffix},
             job_id_chain   => $job_id_chain,
             parameter_href => $parameter_href,
             suffix_key     => q{variant_file_suffix},
@@ -544,6 +546,7 @@ sub analysis_endvariantannotationblock_rio {
 ##          : $program_name            => Program name
 ##          : $reference_dir           => MIP reference directory
 ##          : $sample_info_href        => Info on samples and family hash {REF}
+##          : $stderr_path             => Stderr path of the block script
 ##          : $temp_directory          => Temporary directory
 ##          : $xargs_file_counter      => The xargs file counter
 
@@ -560,6 +563,7 @@ sub analysis_endvariantannotationblock_rio {
     my $program_info_path;
     my $program_name;
     my $sample_info_href;
+    my $stderr_path;
 
     ## Default(s)
     my $call_type;
@@ -571,83 +575,90 @@ sub analysis_endvariantannotationblock_rio {
 
     my $tmpl = {
         active_parameter_href => {
-            required    => 1,
-            defined     => 1,
             default     => {},
-            strict_type => 1,
+            defined     => 1,
+            required    => 1,
             store       => \$active_parameter_href,
+            strict_type => 1,
         },
         call_type =>
-          { default => q{BOTH}, strict_type => 1, store => \$call_type, },
+          { default => q{BOTH}, store => \$call_type, strict_type => 1, },
         family_id => {
             default     => $arg_href->{active_parameter_href}{family_id},
-            strict_type => 1,
             store       => \$family_id,
-        },
-        FILEHANDLE => { store       => \$FILEHANDLE, },
-        file_path  => { strict_type => 1, store => \$file_path },
-        file_info_href => {
-            required    => 1,
-            defined     => 1,
-            default     => {},
             strict_type => 1,
+        },
+        FILEHANDLE => { store => \$FILEHANDLE, },
+        file_path  => { store => \$file_path, strict_type => 1, },
+        file_info_href => {
+            default     => {},
+            defined     => 1,
+            required    => 1,
             store       => \$file_info_href,
+            strict_type => 1,
         },
         infile_lane_prefix_href => {
-            required    => 1,
-            defined     => 1,
             default     => {},
-            strict_type => 1,
+            defined     => 1,
+            required    => 1,
             store       => \$infile_lane_prefix_href,
+            strict_type => 1,
         },
         job_id_href => {
-            required    => 1,
-            defined     => 1,
             default     => {},
-            strict_type => 1,
+            defined     => 1,
+            required    => 1,
             store       => \$job_id_href,
+            strict_type => 1,
         },
         outaligner_dir => {
             default     => $arg_href->{active_parameter_href}{outaligner_dir},
-            strict_type => 1,
             store       => \$outaligner_dir,
+            strict_type => 1,
         },
         parameter_href => {
-            required    => 1,
-            defined     => 1,
             default     => {},
-            strict_type => 1,
-            store       => \$parameter_href,
-        },
-        program_info_path => { strict_type => 1, store => \$program_info_path },
-        program_name      => {
-            required    => 1,
             defined     => 1,
+            required    => 1,
+            store       => \$parameter_href,
             strict_type => 1,
+        },
+        program_info_path =>
+          { store => \$program_info_path, strict_type => 1, },
+        program_name => {
+            defined     => 1,
+            required    => 1,
             store       => \$program_name,
+            strict_type => 1,
         },
         reference_dir => {
             default     => $arg_href->{active_parameter_href}{reference_dir},
-            strict_type => 1,
             store       => \$reference_dir,
+            strict_type => 1,
         },
         sample_info_href => {
-            required    => 1,
-            defined     => 1,
             default     => {},
-            strict_type => 1,
+            defined     => 1,
+            required    => 1,
             store       => \$sample_info_href,
+            strict_type => 1,
+        },
+        stderr_path => {
+            defined     => 1,
+            required    => 1,
+            store       => \$stderr_path,
+            strict_type => 1,
         },
         temp_directory => {
             default     => $arg_href->{active_parameter_href}{temp_directory},
-            strict_type => 1,
             store       => \$temp_directory,
+            strict_type => 1,
         },
         xargs_file_counter => {
-            default     => 0,
             allow       => qr/ ^\d+$ /xsm,
-            strict_type => 1,
+            default     => 0,
             store       => \$xargs_file_counter,
+            strict_type => 1,
         },
     };
 
@@ -674,7 +685,7 @@ sub analysis_endvariantannotationblock_rio {
     ## Retrieve logger object
     my $log = Log::Log4perl->get_logger(q{MIP});
 
-    ## Set MIP program name
+    ## Set program mode
     my $program_mode = $active_parameter_href->{$program_name};
 
     ## Unpack parameters
@@ -682,12 +693,13 @@ sub analysis_endvariantannotationblock_rio {
       $parameter_href->{dynamic_parameter}{consensus_analysis_type};
     my $job_id_chain  = $parameter_href->{$program_name}{chain};
     my $reduce_io_ref = \$active_parameter_href->{reduce_io};
-    my ( $core_number, $time, @source_environment_cmds ) = get_module_parameters(
+    my ( $core_number, $time, @source_environment_cmds ) =
+      get_module_parameters(
         {
             active_parameter_href => $active_parameter_href,
-            program_name      => $program_name,
+            program_name          => $program_name,
         }
-    );
+      );
 
     my $vcfparser_analysis_type = $EMPTY_STR;
 
@@ -734,7 +746,7 @@ sub analysis_endvariantannotationblock_rio {
 
     my $outfile_suffix = set_file_suffix(
         {
-            file_suffix => $parameter_href->{$program_name}{outfile_suffix},
+            file_suffix    => $parameter_href->{$program_name}{outfile_suffix},
             job_id_chain   => $job_id_chain,
             parameter_href => $parameter_href,
             suffix_key     => q{variant_file_suffix},

--- a/lib/MIP/Recipes/Analysis/Fastqc.pm
+++ b/lib/MIP/Recipes/Analysis/Fastqc.pm
@@ -40,9 +40,7 @@ sub analysis_fastqc {
 ## Arguments: $active_parameter_href   => Active parameters for this analysis hash {REF}
 ##          : $file_info_href          => File info hash {REF}
 ##          : $infile_lane_prefix_href => Infile(s) without the ".ending" {REF}
-##          : $insample_directory      => In sample directory
 ##          : $job_id_href             => Job id hash {REF}
-##          : $outsample_directory     => Out sample directory
 ##          : $parameter_href          => Parameter hash {REF}
 ##          : $program_name            => Program name
 ##          : $sample_id               => Sample id
@@ -55,11 +53,7 @@ sub analysis_fastqc {
     my $active_parameter_href;
     my $file_info_href;
     my $infile_lane_prefix_href;
-
-    #my $insample_directory;
     my $job_id_href;
-
-    #my $outsample_directory;
     my $parameter_href;
     my $program_name;
     my $sample_id;
@@ -147,7 +141,8 @@ sub analysis_fastqc {
     my $log = Log::Log4perl->get_logger(q{MIP});
 
     ## Unpack parameters
-    my @infiles      = @{ $file_info_href->{$sample_id}{mip_infiles} };
+    my @infiles = @{ $file_info_href->{$sample_id}{mip_infiles} };
+
     my $program_mode = $active_parameter_href->{$program_name};
     my ( $core_number, $time, @source_environment_cmds ) =
       get_module_parameters(
@@ -273,9 +268,7 @@ sub analysis_fastqc {
 
     ## Copies files from temporary folder to source.
     $process_batches_count = 1;
-    while ( my ( $index, $infile ) =
-        each @{ $sample_info_href->{infile}{$sample_id} } )
-    {
+    while ( my ( $index, $infile ) = each @infiles ) {
 
         $process_batches_count = print_wait(
             {

--- a/lib/MIP/Recipes/Analysis/Fastqc.pm
+++ b/lib/MIP/Recipes/Analysis/Fastqc.pm
@@ -39,7 +39,6 @@ sub analysis_fastqc {
 ## Returns  :
 ## Arguments: $active_parameter_href   => Active parameters for this analysis hash {REF}
 ##          : $file_info_href          => File info hash {REF}
-##          : indir_path_href          => Indirectories path(s) hash {REF}
 ##          : $infile_lane_prefix_href => Infile(s) without the ".ending" {REF}
 ##          : $insample_directory      => In sample directory
 ##          : $job_id_href             => Job id hash {REF}
@@ -55,7 +54,6 @@ sub analysis_fastqc {
     ## Flatten argument(s)
     my $active_parameter_href;
     my $file_info_href;
-    my $indir_path_href;
     my $infile_lane_prefix_href;
 
     #my $insample_directory;
@@ -84,13 +82,6 @@ sub analysis_fastqc {
             store       => \$file_info_href,
             strict_type => 1,
         },
-        indir_path_href => {
-            default     => {},
-            defined     => 1,
-            required    => 1,
-            store       => \$indir_path_href,
-            strict_type => 1,
-        },
         infile_lane_prefix_href => {
             default     => {},
             defined     => 1,
@@ -98,13 +89,6 @@ sub analysis_fastqc {
             store       => \$infile_lane_prefix_href,
             strict_type => 1,
         },
-
-        #insample_directory => {
-        #    defined     => 1,
-        #    required    => 1,
-        #    store       => \$insample_directory,
-        #    strict_type => 1,
-        #},
         job_id_href => {
             default     => {},
             defined     => 1,
@@ -112,13 +96,6 @@ sub analysis_fastqc {
             store       => \$job_id_href,
             strict_type => 1,
         },
-
-        #outsample_directory => {
-        #    defined     => 1,
-        #    required    => 1,
-        #    store       => \$outsample_directory,
-        #    strict_type => 1,
-        #},
         parameter_href => {
             default     => {},
             defined     => 1,
@@ -185,7 +162,7 @@ sub analysis_fastqc {
     my $FILEHANDLE = IO::Handle->new();
 
     ## Directories
-    my $insample_directory = $indir_path_href->{$sample_id};
+    my $insample_directory = $file_info_href->{$sample_id}{mip_infiles_dir};
     my $outsample_directory =
       catdir( $active_parameter_href->{outdata_dir}, $sample_id,
         $program_name );

--- a/lib/MIP/Recipes/Analysis/Freebayes.pm
+++ b/lib/MIP/Recipes/Analysis/Freebayes.pm
@@ -21,7 +21,7 @@ BEGIN {
     use base qw{ Exporter };
 
     # Set the version for version checking
-    our $VERSION = 1.01;
+    our $VERSION = 1.02;
 
     # Functions and variables which can be optionally exported
     our @EXPORT_OK = qw{ analysis_freebayes_calling };
@@ -46,7 +46,6 @@ sub analysis_freebayes_calling {
 ##          : $file_info_href          => File_info hash {REF}
 ##          : $infile_lane_prefix_href => Infile(s) without the ".ending" {REF}
 ##          : $job_id_href             => Job id hash {REF}
-##          : $outfamily_directory     => Out family directory
 ##          : $outaligner_dir          => Outaligner_dir used in the analysis
 ##          : $parameter_href          => Parameter hash {REF}
 ##          : $program_name            => Program name
@@ -68,88 +67,81 @@ sub analysis_freebayes_calling {
     my $file_info_href;
     my $infile_lane_prefix_href;
     my $job_id_href;
-    my $outfamily_directory;
     my $parameter_href;
     my $program_name;
     my $sample_info_href;
 
     my $tmpl = {
         active_parameter_href => {
-            required    => 1,
-            defined     => 1,
             default     => {},
-            strict_type => 1,
+            defined     => 1,
+            required    => 1,
             store       => \$active_parameter_href,
+            strict_type => 1,
         },
         call_type =>
-          { default => q{BOTH}, strict_type => 1, store => \$call_type, },
+          { default => q{BOTH}, store => \$call_type, strict_type => 1, },
         family_id => {
             default     => $arg_href->{active_parameter_href}{family_id},
-            strict_type => 1,
             store       => \$family_id,
+            strict_type => 1,
         },
         file_info_href => {
-            required    => 1,
-            defined     => 1,
             default     => {},
-            strict_type => 1,
+            defined     => 1,
+            required    => 1,
             store       => \$file_info_href,
+            strict_type => 1,
         },
         infile_lane_prefix_href => {
-            required    => 1,
-            defined     => 1,
             default     => {},
-            strict_type => 1,
+            defined     => 1,
+            required    => 1,
             store       => \$infile_lane_prefix_href,
+            strict_type => 1,
         },
         job_id_href => {
-            required    => 1,
-            defined     => 1,
             default     => {},
-            strict_type => 1,
+            defined     => 1,
+            required    => 1,
             store       => \$job_id_href,
+            strict_type => 1,
         },
         outaligner_dir => {
             default     => $arg_href->{active_parameter_href}{outaligner_dir},
-            strict_type => 1,
             store       => \$outaligner_dir,
-        },
-        outfamily_directory => {
-            required    => 1,
-            defined     => 1,
             strict_type => 1,
-            store       => \$outfamily_directory,
         },
         parameter_href => {
-            required    => 1,
-            defined     => 1,
             default     => {},
-            strict_type => 1,
+            defined     => 1,
+            required    => 1,
             store       => \$parameter_href,
+            strict_type => 1,
         },
         program_name => {
-            required    => 1,
             defined     => 1,
-            strict_type => 1,
+            required    => 1,
             store       => \$program_name,
+            strict_type => 1,
         },
         sample_info_href => {
-            required    => 1,
-            defined     => 1,
             default     => {},
-            strict_type => 1,
+            defined     => 1,
+            required    => 1,
             store       => \$sample_info_href,
+            strict_type => 1,
         },
         temp_directory => {
             default     => $arg_href->{active_parameter_href}{temp_directory},
-            strict_type => 1,
             store       => \$temp_directory,
+            strict_type => 1,
         },
         xargs_file_counter => {
-            default     => 0,
             allow       => qr/ ^\d+$ /sxm,
-            strict_type => 1,
+            default     => 0,
             store       => \$xargs_file_counter,
+            strict_type => 1,
         },
     };
 
@@ -173,18 +165,19 @@ sub analysis_freebayes_calling {
     ## Retrieve logger object
     my $log = Log::Log4perl->get_logger(q{MIP});
 
-    ## Set MIP program name
+    ## Set program name
     my $program_mode = $active_parameter_href->{$program_name};
 
     ## Unpack parameters
     my $job_id_chain       = $parameter_href->{$program_name}{chain};
     my $referencefile_path = $active_parameter_href->{human_genome_reference};
-    my ( $core_number, $time, @source_environment_cmds ) = get_module_parameters(
+    my ( $core_number, $time, @source_environment_cmds ) =
+      get_module_parameters(
         {
             active_parameter_href => $active_parameter_href,
-            program_name      => $program_name,
+            program_name          => $program_name,
         }
-    );
+      );
 
     ## Alias
     my $program_outdirectory_name =
@@ -215,6 +208,8 @@ sub analysis_freebayes_calling {
     );
 
     ## Assign directories
+    my $outfamily_directory = catfile( $active_parameter_href->{outdata_dir},
+        $family_id, $outaligner_dir, $program_outdirectory_name, );
     $parameter_href->{$program_name}{indirectory} = $outfamily_directory;
 
     ## Assign file_tags
@@ -239,7 +234,7 @@ sub analysis_freebayes_calling {
     ## Set file suffix for next module within jobid chain
     my $outfile_suffix = set_file_suffix(
         {
-            file_suffix => $parameter_href->{$program_name}{outfile_suffix},
+            file_suffix    => $parameter_href->{$program_name}{outfile_suffix},
             job_id_chain   => $job_id_chain,
             parameter_href => $parameter_href,
             suffix_key     => q{variant_file_suffix},

--- a/lib/MIP/Recipes/Analysis/Frequency_filter.pm
+++ b/lib/MIP/Recipes/Analysis/Frequency_filter.pm
@@ -22,7 +22,7 @@ BEGIN {
     use base qw{ Exporter };
 
     # Set the version for version checking
-    our $VERSION = 1.00;
+    our $VERSION = 1.01;
 
     # Functions and variables which can be optionally exported
     our @EXPORT_OK =
@@ -50,10 +50,8 @@ sub analysis_frequency_filter {
 ##          : $file_info_href          => File_info hash {REF}
 ##          : $file_path               => File path
 ##          : $infile_lane_prefix_href => Infile(s) without the ".ending" {REF}
-##          : $infamily_directory      => In family directory
 ##          : $job_id_href             => Job id hash {REF}
 ##          : $outaligner_dir          => Outaligner_dir used in the analysis
-##          : $outfamily_directory     => Out family directory
 ##          : $parameter_href          => Parameter hash {REF}
 ##          : $program_info_path       => The program info path
 ##          : $program_name            => Program name
@@ -68,10 +66,8 @@ sub analysis_frequency_filter {
     my $active_parameter_href;
     my $file_info_href;
     my $file_path;
-    my $infamily_directory;
     my $infile_lane_prefix_href;
     my $job_id_href;
-    my $outfamily_directory;
     my $parameter_href;
     my $program_info_path;
     my $program_name;
@@ -87,90 +83,79 @@ sub analysis_frequency_filter {
 
     my $tmpl = {
         active_parameter_href => {
-            required    => 1,
-            defined     => 1,
             default     => {},
-            strict_type => 1,
+            defined     => 1,
+            required    => 1,
             store       => \$active_parameter_href,
+            strict_type => 1,
         },
         call_type =>
-          { default => q{BOTH}, strict_type => 1, store => \$call_type, },
+          { default => q{BOTH}, store => \$call_type, strict_type => 1, },
         family_id => {
             default     => $arg_href->{active_parameter_href}{family_id},
-            strict_type => 1,
             store       => \$family_id,
+            strict_type => 1,
         },
         file_info_href => {
-            required    => 1,
-            defined     => 1,
             default     => {},
-            strict_type => 1,
+            defined     => 1,
+            required    => 1,
             store       => \$file_info_href,
+            strict_type => 1,
         },
-        file_path               => { strict_type => 1, store => \$file_path },
+        file_path               => { store => \$file_path, strict_type => 1, },
         infile_lane_prefix_href => {
-            required    => 1,
-            defined     => 1,
             default     => {},
-            strict_type => 1,
-            store       => \$infile_lane_prefix_href,
-        },
-        infamily_directory => {
-            required    => 1,
             defined     => 1,
+            required    => 1,
+            store       => \$infile_lane_prefix_href,
             strict_type => 1,
-            store       => \$infamily_directory,
         },
         job_id_href => {
-            required    => 1,
-            defined     => 1,
             default     => {},
-            strict_type => 1,
+            defined     => 1,
+            required    => 1,
             store       => \$job_id_href,
+            strict_type => 1,
         },
         outaligner_dir => {
             default     => $arg_href->{active_parameter_href}{outaligner_dir},
-            strict_type => 1,
             store       => \$outaligner_dir,
-        },
-        outfamily_directory => {
-            required    => 1,
-            defined     => 1,
             strict_type => 1,
-            store       => \$outfamily_directory,
         },
         parameter_href => {
-            required    => 1,
-            defined     => 1,
             default     => {},
-            strict_type => 1,
-            store       => \$parameter_href,
-        },
-        program_info_path => { strict_type => 1, store => \$program_info_path },
-        program_name      => {
-            required    => 1,
             defined     => 1,
+            required    => 1,
+            store       => \$parameter_href,
             strict_type => 1,
+        },
+        program_info_path =>
+          { store => \$program_info_path, strict_type => 1, },
+        program_name => {
+            defined     => 1,
+            required    => 1,
             store       => \$program_name,
+            strict_type => 1,
         },
         sample_info_href => {
-            required    => 1,
-            defined     => 1,
             default     => {},
-            strict_type => 1,
+            defined     => 1,
+            required    => 1,
             store       => \$sample_info_href,
+            strict_type => 1,
         },
-        stderr_path    => { strict_type => 1, store => \$stderr_path },
+        stderr_path    => { store => \$stderr_path, strict_type => 1, },
         temp_directory => {
             default     => $arg_href->{active_parameter_href}{temp_directory},
-            strict_type => 1,
             store       => \$temp_directory,
+            strict_type => 1,
         },
         xargs_file_counter => {
-            default     => 0,
             allow       => qr/ ^\d+$ /xsm,
-            strict_type => 1,
+            default     => 0,
             store       => \$xargs_file_counter,
+            strict_type => 1,
         },
     };
 
@@ -191,17 +176,18 @@ sub analysis_frequency_filter {
     ## Retrieve logger object
     my $log = Log::Log4perl->get_logger(q{MIP});
 
-    ## Set MIP program name
+    ## Set program mode
     my $program_mode = $active_parameter_href->{$program_name};
 
     ## Unpack parameters
     my $job_id_chain = $parameter_href->{$program_name}{chain};
-    my ( $core_number, $time, @source_environment_cmds ) = get_module_parameters(
+    my ( $core_number, $time, @source_environment_cmds ) =
+      get_module_parameters(
         {
             active_parameter_href => $active_parameter_href,
-            program_name      => $program_name,
+            program_name          => $program_name,
         }
-    );
+      );
 
     ## Filehandles
     # Create anonymous filehandle
@@ -237,6 +223,11 @@ sub analysis_frequency_filter {
 
     $stderr_path = $program_info_path . $DOT . q{stderr.txt};
 
+    ## Assign directories
+    my $infamily_directory = catdir( $active_parameter_href->{outdata_dir},
+        $family_id, $outaligner_dir );
+    my $outfamily_directory = $infamily_directory;
+
     # Used downstream
     $parameter_href->{$program_name}{indirectory} = $outfamily_directory;
 
@@ -265,7 +256,7 @@ sub analysis_frequency_filter {
     );
     my $outfile_suffix = set_file_suffix(
         {
-            file_suffix => $parameter_href->{$program_name}{outfile_suffix},
+            file_suffix    => $parameter_href->{$program_name}{outfile_suffix},
             job_id_chain   => $job_id_chain,
             parameter_href => $parameter_href,
             suffix_key     => q{variant_file_suffix},
@@ -397,10 +388,8 @@ sub analysis_frequency_filter_rio {
 ##          : $file_info_href          => File_info hash {REF}
 ##          : $file_path               => File path
 ##          : $infile_lane_prefix_href => Infile(s) without the ".ending" {REF}
-##          : $infamily_directory      => In family directory
 ##          : $job_id_href             => Job id hash {REF}
 ##          : $outaligner_dir          => Outaligner_dir used in the analysis
-##          : $outfamily_directory     => Out family directory
 ##          : $parameter_href          => Parameter hash {REF}
 ##          : $program_info_path       => The program info path
 ##          : $program_name            => Program name
@@ -416,10 +405,8 @@ sub analysis_frequency_filter_rio {
     my $FILEHANDLE;
     my $file_info_href;
     my $file_path;
-    my $infamily_directory;
     my $infile_lane_prefix_href;
     my $job_id_href;
-    my $outfamily_directory;
     my $parameter_href;
     my $program_info_path;
     my $program_name;
@@ -435,91 +422,80 @@ sub analysis_frequency_filter_rio {
 
     my $tmpl = {
         active_parameter_href => {
-            required    => 1,
-            defined     => 1,
             default     => {},
-            strict_type => 1,
+            defined     => 1,
+            required    => 1,
             store       => \$active_parameter_href,
+            strict_type => 1,
         },
         call_type =>
-          { default => q{BOTH}, strict_type => 1, store => \$call_type, },
+          { default => q{BOTH}, store => \$call_type, strict_type => 1, },
         family_id => {
             default     => $arg_href->{active_parameter_href}{family_id},
-            strict_type => 1,
             store       => \$family_id,
+            strict_type => 1,
         },
         FILEHANDLE     => { store => \$FILEHANDLE, },
         file_info_href => {
-            required    => 1,
-            defined     => 1,
             default     => {},
-            strict_type => 1,
+            defined     => 1,
+            required    => 1,
             store       => \$file_info_href,
+            strict_type => 1,
         },
-        file_path               => { strict_type => 1, store => \$file_path },
+        file_path               => { store => \$file_path, strict_type => 1, },
         infile_lane_prefix_href => {
-            required    => 1,
-            defined     => 1,
             default     => {},
-            strict_type => 1,
-            store       => \$infile_lane_prefix_href,
-        },
-        infamily_directory => {
-            required    => 1,
             defined     => 1,
+            required    => 1,
+            store       => \$infile_lane_prefix_href,
             strict_type => 1,
-            store       => \$infamily_directory,
         },
         job_id_href => {
-            required    => 1,
-            defined     => 1,
             default     => {},
-            strict_type => 1,
+            defined     => 1,
+            required    => 1,
             store       => \$job_id_href,
+            strict_type => 1,
         },
         outaligner_dir => {
             default     => $arg_href->{active_parameter_href}{outaligner_dir},
-            strict_type => 1,
             store       => \$outaligner_dir,
-        },
-        outfamily_directory => {
-            required    => 1,
-            defined     => 1,
             strict_type => 1,
-            store       => \$outfamily_directory,
         },
         parameter_href => {
-            required    => 1,
-            defined     => 1,
             default     => {},
-            strict_type => 1,
-            store       => \$parameter_href,
-        },
-        program_info_path => { strict_type => 1, store => \$program_info_path },
-        program_name      => {
-            required    => 1,
             defined     => 1,
+            required    => 1,
+            store       => \$parameter_href,
             strict_type => 1,
+        },
+        program_info_path =>
+          { store => \$program_info_path, strict_type => 1, },
+        program_name => {
+            defined     => 1,
+            required    => 1,
             store       => \$program_name,
+            strict_type => 1,
         },
         sample_info_href => {
-            required    => 1,
-            defined     => 1,
             default     => {},
-            strict_type => 1,
+            defined     => 1,
+            required    => 1,
             store       => \$sample_info_href,
+            strict_type => 1,
         },
-        stderr_path    => { strict_type => 1, store => \$stderr_path },
+        stderr_path    => { store => \$stderr_path, strict_type => 1, },
         temp_directory => {
             default     => $arg_href->{active_parameter_href}{temp_directory},
-            strict_type => 1,
             store       => \$temp_directory,
+            strict_type => 1,
         },
         xargs_file_counter => {
-            default     => 0,
             allow       => qr/ ^\d+$ /xsm,
-            strict_type => 1,
+            default     => 0,
             store       => \$xargs_file_counter,
+            strict_type => 1,
         },
     };
 
@@ -541,17 +517,18 @@ sub analysis_frequency_filter_rio {
     ## Retrieve logger object
     my $log = Log::Log4perl->get_logger(q{MIP});
 
-    ## Set MIP program name
+    ## Set program mode
     my $program_mode = $active_parameter_href->{$program_name};
 
     ## Unpack parameters
     my $job_id_chain = $parameter_href->{$program_name}{chain};
-    my ( $core_number, $time, @source_environment_cmds ) = get_module_parameters(
+    my ( $core_number, $time, @source_environment_cmds ) =
+      get_module_parameters(
         {
             active_parameter_href => $active_parameter_href,
-            program_name      => $program_name,
+            program_name          => $program_name,
         }
-    );
+      );
 
     ## Filehandles
     # Create anonymous filehandle
@@ -565,6 +542,10 @@ sub analysis_frequency_filter_rio {
             max_cores_per_node => $active_parameter_href->{max_cores_per_node},
         }
     );
+
+    my $infamily_directory = catdir( $active_parameter_href->{outdata_dir},
+        $family_id, $outaligner_dir );
+    my $outfamily_directory = $infamily_directory;
 
     # Used downstream
     $parameter_href->{$program_name}{indirectory} = $outfamily_directory;
@@ -605,7 +586,7 @@ sub analysis_frequency_filter_rio {
     );
     my $outfile_suffix = set_file_suffix(
         {
-            file_suffix => $parameter_href->{$program_name}{outfile_suffix},
+            file_suffix    => $parameter_href->{$program_name}{outfile_suffix},
             job_id_chain   => $job_id_chain,
             parameter_href => $parameter_href,
             suffix_key     => q{variant_file_suffix},

--- a/lib/MIP/Recipes/Analysis/Gatk_asereadcounter.pm
+++ b/lib/MIP/Recipes/Analysis/Gatk_asereadcounter.pm
@@ -25,7 +25,7 @@ BEGIN {
     use base qw{ Exporter };
 
     # Set the version for version checking
-    our $VERSION = 1.01;
+    our $VERSION = 1.02;
 
     # Functions and variables which can be optionally exported
     our @EXPORT_OK = qw{ analysis_gatk_asereadcounter };
@@ -43,11 +43,9 @@ sub analysis_gatk_asereadcounter {
 ## Arguments: $active_parameter_href   => Active parameters for this analysis hash {REF}
 ##          : $family_id               => Family id
 ##          : $file_info_href          => File info hash {REF}
+##          : $indir_path_ref          => Indirectories path(s) hash {REF}
 ##          : $infile_lane_prefix_href => Infile(s) without the ".ending" {REF}
-##          : $insample_directory      => In sample directory
 ##          : $job_id_href             => Job id hash {REF}
-##          : $outaligner_dir          => Outaligner_dir used in the analysis
-##          : $outsample_directory     => Out sample directory
 ##          : $parameter_href          => Parameter hash {REF}
 ##          : $program_name            => Program name
 ##          : $sample_id               => Sample id
@@ -59,10 +57,9 @@ sub analysis_gatk_asereadcounter {
     ## Flatten argument(s)
     my $active_parameter_href;
     my $file_info_href;
+    my $indir_path_href;
     my $infile_lane_prefix_href;
-    my $insample_directory;
     my $job_id_href;
-    my $outsample_directory;
     my $parameter_href;
     my $program_name;
     my $sample_id;
@@ -70,7 +67,6 @@ sub analysis_gatk_asereadcounter {
 
     ## Default(s)
     my $family_id;
-    my $outaligner_dir;
     my $temp_directory;
 
     my $tmpl = {
@@ -93,6 +89,11 @@ sub analysis_gatk_asereadcounter {
             store       => \$file_info_href,
             strict_type => 1,
         },
+        indir_path_href => {
+            default     => {},
+            store       => \$indir_path_href,
+            strict_type => 1,
+        },
         infile_lane_prefix_href => {
             default     => {},
             defined     => 1,
@@ -100,28 +101,11 @@ sub analysis_gatk_asereadcounter {
             store       => \$infile_lane_prefix_href,
             strict_type => 1,
         },
-        insample_directory => {
-            defined     => 1,
-            required    => 1,
-            store       => \$insample_directory,
-            strict_type => 1,
-        },
         job_id_href => {
             default     => {},
             defined     => 1,
             required    => 1,
             store       => \$job_id_href,
-            strict_type => 1,
-        },
-        outaligner_dir => {
-            default     => $arg_href->{active_parameter_href}{outaligner_dir},
-            store       => \$outaligner_dir,
-            strict_type => 1,
-        },
-        outsample_directory => {
-            defined     => 1,
-            required    => 1,
-            store       => \$outsample_directory,
             strict_type => 1,
         },
         parameter_href => {
@@ -194,6 +178,12 @@ sub analysis_gatk_asereadcounter {
     # Create anonymous filehandle
     my $FILEHANDLE = IO::Handle->new();
 
+    ## Assign directories
+    my $insample_directory = catdir( $active_parameter_href->{outdata_dir},
+        $sample_id, $active_parameter_href->{outaligner_dir} );
+    my $outsample_directory = catdir( $active_parameter_href->{outdata_dir},
+        $sample_id, $active_parameter_href->{outaligner_dir} );
+
     ## Creates program directories (info & programData & programScript), program script filenames and writes sbatch header
     my ( $file_path, $program_info_path ) = setup_script(
         {
@@ -204,8 +194,9 @@ sub analysis_gatk_asereadcounter {
             job_id_href           => $job_id_href,
             log                   => $log,
             process_time          => $time,
-            program_directory     => catfile( $outaligner_dir, q{gatk} ),
-            program_name          => $program_name,
+            program_directory =>
+              catfile( $active_parameter_href->{outaligner_dir}, q{gatk} ),
+            program_name                    => $program_name,
             source_environment_commands_ref => \@source_environment_cmds,
             temp_directory                  => $temp_directory,
         }

--- a/lib/MIP/Recipes/Analysis/Gatk_combinevariantcallsets.pm
+++ b/lib/MIP/Recipes/Analysis/Gatk_combinevariantcallsets.pm
@@ -21,7 +21,7 @@ BEGIN {
     use base qw{ Exporter };
 
     # Set the version for version checking
-    our $VERSION = 1.03;
+    our $VERSION = 1.04;
 
     # Functions and variables which can be optionally exported
     our @EXPORT_OK = qw{ analysis_gatk_combinevariantcallsets };
@@ -46,7 +46,6 @@ sub analysis_gatk_combinevariantcallsets {
 ##          : $infile_lane_prefix_href => Infile(s) without the ".ending" {REF}
 ##          : $job_id_href             => Job id hash {REF}
 ##          : $outaligner_dir          => Outaligner_dir used in the analysis
-##          : $outfamily_directory     => Out family directory
 ##          : $parameter_href          => Parameter hash {REF}
 ##          : $program_name            => Program name
 ##          : $sample_info_href        => Info on samples and family hash {REF}
@@ -59,7 +58,6 @@ sub analysis_gatk_combinevariantcallsets {
     my $file_info_href;
     my $infile_lane_prefix_href;
     my $job_id_href;
-    my $outfamily_directory;
     my $parameter_href;
     my $program_name;
     my $sample_info_href;
@@ -72,75 +70,69 @@ sub analysis_gatk_combinevariantcallsets {
 
     my $tmpl = {
         active_parameter_href => {
-            required    => 1,
-            defined     => 1,
             default     => {},
-            strict_type => 1,
+            defined     => 1,
+            required    => 1,
             store       => \$active_parameter_href,
+            strict_type => 1,
         },
         call_type =>
-          { default => q{BOTH}, strict_type => 1, store => \$call_type, },
+          { default => q{BOTH}, store => \$call_type, strict_type => 1, },
         family_id => {
             default     => $arg_href->{active_parameter_href}{family_id},
-            strict_type => 1,
             store       => \$family_id,
+            strict_type => 1,
         },
         file_info_href => {
-            required    => 1,
-            defined     => 1,
             default     => {},
-            strict_type => 1,
+            defined     => 1,
+            required    => 1,
             store       => \$file_info_href,
+            strict_type => 1,
         },
         infile_lane_prefix_href => {
-            required    => 1,
-            defined     => 1,
             default     => {},
-            strict_type => 1,
+            defined     => 1,
+            required    => 1,
             store       => \$infile_lane_prefix_href,
+            strict_type => 1,
         },
         job_id_href => {
-            required    => 1,
-            defined     => 1,
             default     => {},
-            strict_type => 1,
+            defined     => 1,
+            required    => 1,
             store       => \$job_id_href,
+            strict_type => 1,
         },
         outaligner_dir => {
             default     => $arg_href->{active_parameter_href}{outaligner_dir},
-            strict_type => 1,
             store       => \$outaligner_dir,
-        },
-        outfamily_directory => {
-            required    => 1,
-            defined     => 1,
             strict_type => 1,
-            store       => \$outfamily_directory,
         },
         parameter_href => {
-            required    => 1,
-            defined     => 1,
             default     => {},
-            strict_type => 1,
+            defined     => 1,
+            required    => 1,
             store       => \$parameter_href,
+            strict_type => 1,
         },
         program_name => {
-            required    => 1,
             defined     => 1,
-            strict_type => 1,
+            required    => 1,
             store       => \$program_name,
+            strict_type => 1,
         },
         sample_info_href => {
-            required    => 1,
-            defined     => 1,
             default     => {},
-            strict_type => 1,
+            defined     => 1,
+            required    => 1,
             store       => \$sample_info_href,
+            strict_type => 1,
         },
         temp_directory => {
             default     => $arg_href->{active_parameter_href}{temp_directory},
-            strict_type => 1,
             store       => \$temp_directory,
+            strict_type => 1,
         },
     };
 
@@ -169,7 +161,7 @@ sub analysis_gatk_combinevariantcallsets {
     ## Retrieve logger object
     my $log = Log::Log4perl->get_logger(q{MIP});
 
-    ## Set MIP program name
+    ## Set program mode
     my $program_mode = $active_parameter_href->{$program_name};
 
     ## Alias
@@ -181,7 +173,7 @@ sub analysis_gatk_combinevariantcallsets {
       get_module_parameters(
         {
             active_parameter_href => $active_parameter_href,
-            program_name      => $program_name,
+            program_name          => $program_name,
         }
       );
 
@@ -208,6 +200,9 @@ sub analysis_gatk_combinevariantcallsets {
     );
 
     ## Assign directories
+    my $outfamily_directory = catfile( $active_parameter_href->{outdata_dir},
+        $family_id, $outaligner_dir );
+
     # Used downstream
     $parameter_href->{$program_name}{indirectory} = $outfamily_directory;
 
@@ -231,7 +226,7 @@ sub analysis_gatk_combinevariantcallsets {
             parameter_href => $parameter_href,
             suffix_key     => q{variant_file_suffix},
             job_id_chain   => $job_id_chain,
-            file_suffix => $parameter_href->{$program_name}{outfile_suffix},
+            file_suffix    => $parameter_href->{$program_name}{outfile_suffix},
         }
     );
 

--- a/lib/MIP/Recipes/Analysis/Gatk_concatenate_genotypegvcfs.pm
+++ b/lib/MIP/Recipes/Analysis/Gatk_concatenate_genotypegvcfs.pm
@@ -21,7 +21,7 @@ BEGIN {
     use base qw{ Exporter };
 
     # Set the version for version checking
-    our $VERSION = 1.03;
+    our $VERSION = 1.04;
 
     # Functions and variables which can be optionally exported
     our @EXPORT_OK = qw{ analysis_gatk_concatenate_genotypegvcfs };
@@ -40,10 +40,8 @@ sub analysis_gatk_concatenate_genotypegvcfs {
 ## Returns  :
 ## Arguments: $active_parameter_href   => Active parameters for this analysis hash {REF}
 ##          : $file_info_href          => File info hash {REF}
-##          : $infamily_directory      => In family directory
 ##          : $infile_lane_prefix_href => Infile(s) without the ".ending" {REF}
 ##          : $job_id_href             => Job id hash {REF}
-##          : $outfamily_directory     => Out family directory
 ##          : $parameter_href          => Parameter hash {REF}
 ##          : $program_name            => Program name
 ##          : $sample_info_href        => Info on samples and family hash {REF}
@@ -53,10 +51,8 @@ sub analysis_gatk_concatenate_genotypegvcfs {
     ## Flatten argument(s)
     my $active_parameter_href;
     my $file_info_href;
-    my $infamily_directory;
     my $infile_lane_prefix_href;
     my $job_id_href;
-    my $outfamily_directory;
     my $parameter_href;
     my $program_name;
     my $sample_info_href;
@@ -69,81 +65,69 @@ sub analysis_gatk_concatenate_genotypegvcfs {
 
     my $tmpl = {
         active_parameter_href => {
-            required    => 1,
-            defined     => 1,
             default     => {},
-            strict_type => 1,
+            defined     => 1,
+            required    => 1,
             store       => \$active_parameter_href,
+            strict_type => 1,
         },
         call_type =>
-          { default => q{BOTH}, strict_type => 1, store => \$call_type, },
+          { default => q{BOTH}, store => \$call_type, strict_type => 1, },
         family_id => {
             default     => $arg_href->{active_parameter_href}{family_id},
-            strict_type => 1,
             store       => \$family_id,
+            strict_type => 1,
         },
         file_info_href => {
-            required    => 1,
-            defined     => 1,
             default     => {},
-            strict_type => 1,
-            store       => \$file_info_href,
-        },
-        infamily_directory => {
-            required    => 1,
             defined     => 1,
+            required    => 1,
+            store       => \$file_info_href,
             strict_type => 1,
-            store       => \$infamily_directory,
         },
         infile_lane_prefix_href => {
-            required    => 1,
-            defined     => 1,
             default     => {},
-            strict_type => 1,
+            defined     => 1,
+            required    => 1,
             store       => \$infile_lane_prefix_href,
+            strict_type => 1,
         },
         job_id_href => {
-            required    => 1,
-            defined     => 1,
             default     => {},
-            strict_type => 1,
+            defined     => 1,
+            required    => 1,
             store       => \$job_id_href,
+            strict_type => 1,
         },
         outaligner_dir => {
             default     => $arg_href->{active_parameter_href}{outaligner_dir},
-            strict_type => 1,
             store       => \$outaligner_dir,
-        },
-        outfamily_directory => {
-            required    => 1,
-            defined     => 1,
             strict_type => 1,
-            store       => \$outfamily_directory,
         },
         parameter_href => {
-            required    => 1,
-            defined     => 1,
             default     => {},
-            strict_type => 1,
+            defined     => 1,
+            required    => 1,
             store       => \$parameter_href,
+            strict_type => 1,
         },
         program_name => {
-            required    => 1,
             defined     => 1,
-            strict_type => 1,
+            required    => 1,
             store       => \$program_name,
+            strict_type => 1,
         },
         sample_info_href => {
-            required    => 1,
-            defined     => 1,
             default     => {},
-            strict_type => 1,
+            defined     => 1,
+            required    => 1,
             store       => \$sample_info_href,
+            strict_type => 1,
         },
         temp_directory => {
             default     => $arg_href->{active_parameter_href}{temp_directory},
-            strict_type => 1,
             store       => \$temp_directory,
+            strict_type => 1,
         },
     };
 
@@ -168,7 +152,7 @@ sub analysis_gatk_concatenate_genotypegvcfs {
     ## Retrieve logger object
     my $log = Log::Log4perl->get_logger(q{MIP});
 
-    ## Set MIP program name
+    ## Set program mode
     my $program_mode = $active_parameter_href->{$program_name};
 
     ## Alias
@@ -182,13 +166,18 @@ sub analysis_gatk_concatenate_genotypegvcfs {
       get_module_parameters(
         {
             active_parameter_href => $active_parameter_href,
-            program_name      => $program_name,
+            program_name          => $program_name,
         }
       );
 
     ## Filehandles
     # Create anonymous filehandle
     my $FILEHANDLE = IO::Handle->new();
+
+    ## Assign directories
+    my $infamily_directory = my $outfamily_directory =
+      catfile( $active_parameter_href->{outdata_dir},
+        $family_id, $outaligner_dir, q{gatk}, );
 
     ## Assign file_tags
     my $infile_tag =
@@ -216,7 +205,7 @@ sub analysis_gatk_concatenate_genotypegvcfs {
     ## Set file suffix for next module within jobid chain
     my $outfile_suffix = set_file_suffix(
         {
-            file_suffix => $parameter_href->{$program_name}{outfile_suffix},
+            file_suffix    => $parameter_href->{$program_name}{outfile_suffix},
             job_id_chain   => $job_id_chain,
             parameter_href => $parameter_href,
             suffix_key     => q{variant_file_suffix},

--- a/lib/MIP/Recipes/Analysis/Gatk_variantevalexome.pm
+++ b/lib/MIP/Recipes/Analysis/Gatk_variantevalexome.pm
@@ -44,11 +44,9 @@ sub analysis_gatk_variantevalexome {
 ##          : $call_type               => Variant call type
 ##          : $family_id               => Family id
 ##          : $file_info_href          => File info hash {REF}
-##          : $infamily_directory      => In family directory
 ##          : $infile_lane_prefix_href => Infile(s) without the ".ending" {REF}
 ##          : $job_id_href             => Job id hash {REF}
 ##          : $outaligner_dir          => Outaligner_dir used in the analysis
-##          : $outsample_directory     => Out sample directory
 ##          : $parameter_href          => Parameter hash {REF}
 ##          : $program_name            => Program name {REF}
 ##          : $sample_id               => Sample id
@@ -61,11 +59,9 @@ sub analysis_gatk_variantevalexome {
     my $active_parameter_href;
     my $parameter_href;
     my $file_info_href;
-    my $infamily_directory;
     my $infile_lane_prefix_href;
     my $job_id_href;
     my $program_name;
-    my $outsample_directory;
     my $sample_id;
     my $sample_info_href;
 
@@ -97,12 +93,6 @@ sub analysis_gatk_variantevalexome {
             store       => \$file_info_href,
             strict_type => 1,
         },
-        infamily_directory => {
-            defined     => 1,
-            required    => 1,
-            store       => \$infamily_directory,
-            strict_type => 1,
-        },
         infile_lane_prefix_href => {
             default     => {},
             defined     => 1,
@@ -120,12 +110,6 @@ sub analysis_gatk_variantevalexome {
         outaligner_dir => {
             default     => $arg_href->{active_parameter_href}{outaligner_dir},
             store       => \$outaligner_dir,
-            strict_type => 1,
-        },
-        outsample_directory => {
-            defined     => 1,
-            required    => 1,
-            store       => \$outsample_directory,
             strict_type => 1,
         },
         parameter_href => {
@@ -177,7 +161,7 @@ sub analysis_gatk_variantevalexome {
     ## Retrieve logger object
     my $log = Log::Log4perl->get_logger(q{MIP});
 
-    ## Set MIP program name
+    ## Set program mode
     my $program_mode = $active_parameter_href->{$program_name};
 
     ## Unpack parameters
@@ -185,12 +169,13 @@ sub analysis_gatk_variantevalexome {
     my $referencefile_path = $active_parameter_href->{human_genome_reference};
     my $gatk_jar =
       catfile( $active_parameter_href->{gatk_path}, q{GenomeAnalysisTK.jar} );
-    my ( $core_number, $time, @source_environment_cmds ) = get_module_parameters(
+    my ( $core_number, $time, @source_environment_cmds ) =
+      get_module_parameters(
         {
             active_parameter_href => $active_parameter_href,
-            program_name      => $program_name,
+            program_name          => $program_name,
         }
-    );
+      );
 
     ## Filehandles
     # Create anonymous filehandle
@@ -234,12 +219,20 @@ sub analysis_gatk_variantevalexome {
     );
     my $outfile_suffix = set_file_suffix(
         {
-            file_suffix => $parameter_href->{$program_name}{outfile_suffix},
+            file_suffix    => $parameter_href->{$program_name}{outfile_suffix},
             job_id_chain   => $job_id_chain,
             parameter_href => $parameter_href,
             suffix_key     => q{variant_eval_file_suffix},
         }
     );
+
+    ## Assign directories
+    my $infamily_directory = catdir( $active_parameter_href->{outdata_dir},
+        $family_id, $outaligner_dir );
+
+    ## Assign directories
+    my $outsample_directory = catdir( $active_parameter_href->{outdata_dir},
+        $sample_id, $outaligner_dir, $program_name );
 
     ## Assign file_tags
     my $infile_tag  = $file_info_href->{$family_id}{rankvariant}{file_tag};

--- a/lib/MIP/Recipes/Analysis/Gatk_variantfiltration.pm
+++ b/lib/MIP/Recipes/Analysis/Gatk_variantfiltration.pm
@@ -25,7 +25,7 @@ BEGIN {
     use base qw{ Exporter };
 
     # Set the version for version checking
-    our $VERSION = 1.00;
+    our $VERSION = 1.01;
 
     # Functions and variables which can be optionally exported
     our @EXPORT_OK = qw{ analysis_gatk_variantfiltration };
@@ -43,11 +43,9 @@ sub analysis_gatk_variantfiltration {
 ## Arguments: $active_parameter_href   => Active parameters for this analysis hash {REF}
 ##          : $family_id               => Family id
 ##          : $file_info_href          => File info hash {REF}
+##          : $indir_path_ref          => Indirectories path(s) hash {REF}
 ##          : $infile_lane_prefix_href => Infile(s) without the ".ending" {REF}
-##          : $insample_directory      => In sample directory
 ##          : $job_id_href             => Job id hash {REF}
-##          : $outaligner_dir          => Outaligner_dir used in the analysis
-##          : $outsample_directory     => Out sample directory
 ##          : $parameter_href          => Parameter hash {REF}
 ##          : $program_name            => Program name
 ##          : $sample_id               => Sample id
@@ -59,10 +57,9 @@ sub analysis_gatk_variantfiltration {
     ## Flatten argument(s)
     my $active_parameter_href;
     my $file_info_href;
+    my $indir_path_href;
     my $infile_lane_prefix_href;
-    my $insample_directory;
     my $job_id_href;
-    my $outsample_directory;
     my $parameter_href;
     my $program_name;
     my $sample_id;
@@ -70,7 +67,6 @@ sub analysis_gatk_variantfiltration {
 
     ## Default(s)
     my $family_id;
-    my $outaligner_dir;
     my $temp_directory;
 
     my $tmpl = {
@@ -93,6 +89,11 @@ sub analysis_gatk_variantfiltration {
             store       => \$file_info_href,
             strict_type => 1,
         },
+        indir_path_href => {
+            default     => {},
+            store       => \$indir_path_href,
+            strict_type => 1,
+        },
         infile_lane_prefix_href => {
             default     => {},
             defined     => 1,
@@ -100,28 +101,11 @@ sub analysis_gatk_variantfiltration {
             store       => \$infile_lane_prefix_href,
             strict_type => 1,
         },
-        insample_directory => {
-            defined     => 1,
-            required    => 1,
-            store       => \$insample_directory,
-            strict_type => 1,
-        },
         job_id_href => {
             default     => {},
             defined     => 1,
             required    => 1,
             store       => \$job_id_href,
-            strict_type => 1,
-        },
-        outaligner_dir => {
-            default     => $arg_href->{active_parameter_href}{outaligner_dir},
-            store       => \$outaligner_dir,
-            strict_type => 1,
-        },
-        outsample_directory => {
-            defined     => 1,
-            required    => 1,
-            store       => \$outsample_directory,
             strict_type => 1,
         },
         parameter_href => {
@@ -186,13 +170,19 @@ sub analysis_gatk_variantfiltration {
       get_module_parameters(
         {
             active_parameter_href => $active_parameter_href,
-            program_name      => $program_name,
+            program_name          => $program_name,
         }
       );
 
     ## Filehandles
     # Create anonymous filehandle
     my $FILEHANDLE = IO::Handle->new();
+
+    ## Assign directories
+    my $insample_directory = catdir( $active_parameter_href->{outdata_dir},
+        $sample_id, $active_parameter_href->{outaligner_dir} );
+    my $outsample_directory = catdir( $active_parameter_href->{outdata_dir},
+        $sample_id, $active_parameter_href->{outaligner_dir} );
 
     ## Creates program directories (info & programData & programScript), program script filenames and writes sbatch header
     my ( $file_path, $program_info_path ) = setup_script(
@@ -204,8 +194,9 @@ sub analysis_gatk_variantfiltration {
             job_id_href           => $job_id_href,
             log                   => $log,
             process_time          => $time,
-            program_directory     => catfile( $outaligner_dir, q{gatk} ),
-            program_name          => $program_name,
+            program_directory =>
+              catfile( $active_parameter_href->{outaligner_dir}, q{gatk} ),
+            program_name                    => $program_name,
             source_environment_commands_ref => \@source_environment_cmds,
             temp_directory                  => $temp_directory,
         }
@@ -266,7 +257,7 @@ sub analysis_gatk_variantfiltration {
     ## Set file suffix for next module within jobid chain
     my $outfile_suffix = set_file_suffix(
         {
-            file_suffix => $parameter_href->{$program_name}{outfile_suffix},
+            file_suffix    => $parameter_href->{$program_name}{outfile_suffix},
             job_id_chain   => $job_id_chain,
             parameter_href => $parameter_href,
             suffix_key     => q{variant_file_suffix},

--- a/lib/MIP/Recipes/Analysis/Gatk_variantrecalibration.pm
+++ b/lib/MIP/Recipes/Analysis/Gatk_variantrecalibration.pm
@@ -22,7 +22,7 @@ BEGIN {
     use base qw{ Exporter };
 
     # Set the version for version checking
-    our $VERSION = 1.02;
+    our $VERSION = 1.03;
 
     # Functions and variables which can be optionally exported
     our @EXPORT_OK =
@@ -46,11 +46,9 @@ sub analysis_gatk_variantrecalibration_wgs {
 ##          : $call_type               => Variant call type
 ##          : $family_id               => Family id
 ##          : $file_info_href          => File info hash {REF}
-##          : $infamily_directory      => In family directory
 ##          : $infile_lane_prefix_href => Infile(s) without the ".ending" {REF}
 ##          : $job_id_href             => Job id hash {REF}
 ##          : $outaligner_dir          => Outaligner_dir used in the analysis
-##          : $outfamily_directory     => Out family directory
 ##          : $parameter_href          => Parameter hash {REF}
 ##          : $program_name            => Program name
 ##          : $sample_info_href        => Info on samples and family hash {REF}
@@ -63,8 +61,6 @@ sub analysis_gatk_variantrecalibration_wgs {
     my $file_info_href;
     my $infile_lane_prefix_href;
     my $job_id_href;
-    my $infamily_directory;
-    my $outfamily_directory;
     my $parameter_href;
     my $program_name;
     my $sample_info_href;
@@ -77,81 +73,69 @@ sub analysis_gatk_variantrecalibration_wgs {
 
     my $tmpl = {
         active_parameter_href => {
-            required    => 1,
-            defined     => 1,
             default     => {},
-            strict_type => 1,
+            defined     => 1,
+            required    => 1,
             store       => \$active_parameter_href,
+            strict_type => 1,
         },
         call_type =>
-          { default => q{BOTH}, strict_type => 1, store => \$call_type, },
+          { default => q{BOTH}, store => \$call_type, strict_type => 1, },
         family_id => {
             default     => $arg_href->{active_parameter_href}{family_id},
-            strict_type => 1,
             store       => \$family_id,
+            strict_type => 1,
         },
         file_info_href => {
-            required    => 1,
-            defined     => 1,
             default     => {},
-            strict_type => 1,
-            store       => \$file_info_href,
-        },
-        infamily_directory => {
-            required    => 1,
             defined     => 1,
+            required    => 1,
+            store       => \$file_info_href,
             strict_type => 1,
-            store       => \$infamily_directory,
         },
         infile_lane_prefix_href => {
-            required    => 1,
-            defined     => 1,
             default     => {},
-            strict_type => 1,
+            defined     => 1,
+            required    => 1,
             store       => \$infile_lane_prefix_href,
+            strict_type => 1,
         },
         job_id_href => {
-            required    => 1,
-            defined     => 1,
             default     => {},
-            strict_type => 1,
+            defined     => 1,
+            required    => 1,
             store       => \$job_id_href,
+            strict_type => 1,
         },
         outaligner_dir => {
             default     => $arg_href->{active_parameter_href}{outaligner_dir},
-            strict_type => 1,
             store       => \$outaligner_dir,
-        },
-        outfamily_directory => {
-            required    => 1,
-            defined     => 1,
             strict_type => 1,
-            store       => \$outfamily_directory,
         },
         parameter_href => {
-            required    => 1,
-            defined     => 1,
             default     => {},
-            strict_type => 1,
+            defined     => 1,
+            required    => 1,
             store       => \$parameter_href,
+            strict_type => 1,
         },
         program_name => {
-            required    => 1,
             defined     => 1,
-            strict_type => 1,
+            required    => 1,
             store       => \$program_name,
+            strict_type => 1,
         },
         sample_info_href => {
-            required    => 1,
-            defined     => 1,
             default     => {},
-            strict_type => 1,
+            defined     => 1,
+            required    => 1,
             store       => \$sample_info_href,
+            strict_type => 1,
         },
         temp_directory => {
             default     => $arg_href->{active_parameter_href}{temp_directory},
-            strict_type => 1,
             store       => \$temp_directory,
+            strict_type => 1,
         },
     };
 
@@ -198,12 +182,13 @@ sub analysis_gatk_variantrecalibration_wgs {
       $active_parameter_href->{gatk_variantrecalibration_resource_indel};
     my $resource_snv_href =
       $active_parameter_href->{gatk_variantrecalibration_resource_snv};
-    my ( $core_number, $time, @source_environment_cmds ) = get_module_parameters(
+    my ( $core_number, $time, @source_environment_cmds ) =
+      get_module_parameters(
         {
             active_parameter_href => $active_parameter_href,
-            program_name      => $program_name,
+            program_name          => $program_name,
         }
-    );
+      );
 
     ## Filehandles
     # Create anonymous filehandle
@@ -214,6 +199,9 @@ sub analysis_gatk_variantrecalibration_wgs {
       $parameter_href->{$program_name}{outdir_name};
 
     ## For ".fam" file
+    my $infamily_directory = catfile( $active_parameter_href->{outdata_dir},
+        $family_id, $outaligner_dir, $program_outdirectory_name );
+    my $outfamily_directory = $infamily_directory;
     my $outfamily_file_directory =
       catdir( $active_parameter_href->{outdata_dir}, $family_id );
 
@@ -246,7 +234,7 @@ sub analysis_gatk_variantrecalibration_wgs {
     ## Set file suffix for next module within jobid chain
     my $outfile_suffix = set_file_suffix(
         {
-            file_suffix => $parameter_href->{$program_name}{outfile_suffix},
+            file_suffix    => $parameter_href->{$program_name}{outfile_suffix},
             job_id_chain   => $job_id_chain,
             parameter_href => $parameter_href,
             suffix_key     => q{variant_file_suffix},
@@ -579,11 +567,9 @@ sub analysis_gatk_variantrecalibration_wes {
 ##          : $call_type               => Variant call type
 ##          : $family_id               => Family id
 ##          : $file_info_href          => File info hash {REF}
-##          : $infamily_directory      => In family directory
 ##          : $infile_lane_prefix_href => Infile(s) without the ".ending" {REF}
 ##          : $job_id_href             => Job id hash {REF}
 ##          : $outaligner_dir          => Outaligner_dir used in the analysis
-##          : $outfamily_directory     => Out family directory
 ##          : $parameter_href          => Parameter hash {REF}
 ##          : $program_name            => Program name
 ##          : $sample_info_href        => Info on samples and family hash {REF}
@@ -594,10 +580,8 @@ sub analysis_gatk_variantrecalibration_wes {
     ## Flatten argument(s)
     my $active_parameter_href;
     my $file_info_href;
-    my $infamily_directory;
     my $infile_lane_prefix_href;
     my $job_id_href;
-    my $outfamily_directory;
     my $parameter_href;
     my $program_name;
     my $sample_info_href;
@@ -610,81 +594,69 @@ sub analysis_gatk_variantrecalibration_wes {
 
     my $tmpl = {
         active_parameter_href => {
-            required    => 1,
-            defined     => 1,
             default     => {},
-            strict_type => 1,
+            defined     => 1,
+            required    => 1,
             store       => \$active_parameter_href,
+            strict_type => 1,
         },
         call_type =>
-          { default => q{BOTH}, strict_type => 1, store => \$call_type, },
+          { default => q{BOTH}, store => \$call_type, strict_type => 1, },
         family_id => {
             default     => $arg_href->{active_parameter_href}{family_id},
-            strict_type => 1,
             store       => \$family_id,
+            strict_type => 1,
         },
         file_info_href => {
-            required    => 1,
-            defined     => 1,
             default     => {},
-            strict_type => 1,
-            store       => \$file_info_href,
-        },
-        infamily_directory => {
-            required    => 1,
             defined     => 1,
+            required    => 1,
+            store       => \$file_info_href,
             strict_type => 1,
-            store       => \$infamily_directory,
         },
         infile_lane_prefix_href => {
-            required    => 1,
-            defined     => 1,
             default     => {},
-            strict_type => 1,
+            defined     => 1,
+            required    => 1,
             store       => \$infile_lane_prefix_href,
+            strict_type => 1,
         },
         job_id_href => {
-            required    => 1,
-            defined     => 1,
             default     => {},
-            strict_type => 1,
+            defined     => 1,
+            required    => 1,
             store       => \$job_id_href,
+            strict_type => 1,
         },
         outaligner_dir => {
             default     => $arg_href->{active_parameter_href}{outaligner_dir},
-            strict_type => 1,
             store       => \$outaligner_dir,
-        },
-        outfamily_directory => {
-            required    => 1,
-            defined     => 1,
             strict_type => 1,
-            store       => \$outfamily_directory,
         },
         parameter_href => {
-            required    => 1,
-            defined     => 1,
             default     => {},
-            strict_type => 1,
+            defined     => 1,
+            required    => 1,
             store       => \$parameter_href,
+            strict_type => 1,
         },
         program_name => {
-            required    => 1,
             defined     => 1,
-            strict_type => 1,
+            required    => 1,
             store       => \$program_name,
+            strict_type => 1,
         },
         sample_info_href => {
-            required    => 1,
-            defined     => 1,
             default     => {},
-            strict_type => 1,
+            defined     => 1,
+            required    => 1,
             store       => \$sample_info_href,
+            strict_type => 1,
         },
         temp_directory => {
             default     => $arg_href->{active_parameter_href}{temp_directory},
-            strict_type => 1,
             store       => \$temp_directory,
+            strict_type => 1,
         },
     };
 
@@ -711,7 +683,7 @@ sub analysis_gatk_variantrecalibration_wes {
     ## Retrieve logger object
     my $log = Log::Log4perl->get_logger(q{MIP});
 
-    ## Set MIP program name
+    ## Set program mode
     my $program_mode = $active_parameter_href->{$program_name};
 
     ## Alias
@@ -729,12 +701,13 @@ sub analysis_gatk_variantrecalibration_wes {
       $active_parameter_href->{gatk_variantrecalibration_resource_indel};
     my $resource_snv_href =
       $active_parameter_href->{gatk_variantrecalibration_resource_snv};
-    my ( $core_number, $time, @source_environment_cmds ) = get_module_parameters(
+    my ( $core_number, $time, @source_environment_cmds ) =
+      get_module_parameters(
         {
             active_parameter_href => $active_parameter_href,
-            program_name      => $program_name,
+            program_name          => $program_name,
         }
-    );
+      );
 
     ## Filehandles
     # Create anonymous filehandle
@@ -744,6 +717,9 @@ sub analysis_gatk_variantrecalibration_wes {
     my $program_outdirectory_name =
       $parameter_href->{$program_name}{outdir_name};
 
+    my $infamily_directory = catfile( $active_parameter_href->{outdata_dir},
+        $family_id, $outaligner_dir, $program_outdirectory_name );
+    my $outfamily_directory = $infamily_directory;
     ## For ".fam" file
     my $outfamily_file_directory =
       catdir( $active_parameter_href->{outdata_dir}, $family_id );
@@ -777,7 +753,7 @@ sub analysis_gatk_variantrecalibration_wes {
     ## Set file suffix for next module within jobid chain
     my $outfile_suffix = set_file_suffix(
         {
-            file_suffix => $parameter_href->{$program_name}{outfile_suffix},
+            file_suffix    => $parameter_href->{$program_name}{outfile_suffix},
             job_id_chain   => $job_id_chain,
             parameter_href => $parameter_href,
             suffix_key     => q{variant_file_suffix},

--- a/lib/MIP/Recipes/Analysis/Manta.pm
+++ b/lib/MIP/Recipes/Analysis/Manta.pm
@@ -21,7 +21,7 @@ BEGIN {
     use base qw{ Exporter };
 
     # Set the version for version checking
-    our $VERSION = 1.04;
+    our $VERSION = 1.05;
 
     # Functions and variables which can be optionally exported
     our @EXPORT_OK = qw{ analysis_manta };
@@ -44,7 +44,6 @@ sub analysis_manta {
 ##          : $infile_lane_prefix_href => Infile(s) without the ".ending" {REF}
 ##          : $job_id_href             => Job id hash {REF}
 ##          : $outaligner_dir          => Outaligner_dir used in the analysis
-##          : $outfamily_directory     => Out family directory
 ##          : $parameter_href          => Parameter hash {REF}
 ##          : $program_name            => Program name
 ##          : $referencefile_path      => Path to reference file
@@ -58,7 +57,6 @@ sub analysis_manta {
     my $file_info_href;
     my $infile_lane_prefix_href;
     my $job_id_href;
-    my $outfamily_directory;
     my $parameter_href;
     my $program_name;
     my $sample_info_href;
@@ -112,12 +110,6 @@ sub analysis_manta {
         outaligner_dir => {
             default     => $arg_href->{active_parameter_href}{outaligner_dir},
             store       => \$outaligner_dir,
-            strict_type => 1,
-        },
-        outfamily_directory => {
-            defined     => 1,
-            required    => 1,
-            store       => \$outfamily_directory,
             strict_type => 1,
         },
         parameter_href => {
@@ -179,12 +171,13 @@ sub analysis_manta {
     my $job_id_chain = $parameter_href->{$program_name}{chain};
     my $program_outdirectory_name =
       $parameter_href->{$program_name}{outdir_name};
-    my ( $core_number, $time, @source_environment_cmds ) = get_module_parameters(
+    my ( $core_number, $time, @source_environment_cmds ) =
+      get_module_parameters(
         {
             active_parameter_href => $active_parameter_href,
-            program_name      => $program_name,
+            program_name          => $program_name,
         }
-    );
+      );
 
     ## Filehandles
     # Create anonymous filehandle
@@ -208,6 +201,14 @@ sub analysis_manta {
         }
     );
 
+    ## Assign directories
+    my $outfamily_directory = catfile(
+        $active_parameter_href->{outdata_dir},
+        $active_parameter_href->{family_id},
+        $active_parameter_href->{outaligner_dir},
+        $program_outdirectory_name,
+    );
+
     # Used downstream
     $parameter_href->{$program_name}{indirectory} = $outfamily_directory;
 
@@ -229,7 +230,7 @@ sub analysis_manta {
     ## Set file suffix for next module within jobid chain
     my $outfile_suffix = set_file_suffix(
         {
-            file_suffix => $parameter_href->{$program_name}{outfile_suffix},
+            file_suffix    => $parameter_href->{$program_name}{outfile_suffix},
             job_id_chain   => $job_id_chain,
             parameter_href => $parameter_href,
             suffix_key     => q{variant_file_suffix},

--- a/lib/MIP/Recipes/Analysis/Multiqc.pm
+++ b/lib/MIP/Recipes/Analysis/Multiqc.pm
@@ -21,7 +21,7 @@ BEGIN {
     use base qw{ Exporter };
 
     # Set the version for version checking
-    our $VERSION = 1.02;
+    our $VERSION = 1.03;
 
     # Functions and variables which can be optionally exported
     our @EXPORT_OK = qw{ analysis_multiqc };
@@ -37,6 +37,7 @@ sub analysis_multiqc {
 ## Returns  :
 ## Arguments: $active_parameter_href   => Active parameters for this analysis hash {REF}
 ##          : $family_id               => Family id
+##          : $file_info_href          => File info hash {REF}
 ##          : $infile_lane_prefix_href => Infile(s) without the ".ending" {REF}
 ##          : $job_id_href             => Job id hash {REF}
 ##          : $parameter_href          => Parameter hash {REF}
@@ -47,6 +48,7 @@ sub analysis_multiqc {
 
     ## Flatten argument(s)
     my $active_parameter_href;
+    my $file_info_href;
     my $infile_lane_prefix_href;
     my $job_id_href;
     my $parameter_href;
@@ -67,6 +69,13 @@ sub analysis_multiqc {
         family_id => {
             default     => $arg_href->{active_parameter_href}{family_id},
             store       => \$family_id,
+            strict_type => 1,
+        },
+        file_info_href => {
+            default     => {},
+            defined     => 1,
+            required    => 1,
+            store       => \$file_info_href,
             strict_type => 1,
         },
         infile_lane_prefix_href => {
@@ -117,7 +126,7 @@ sub analysis_multiqc {
     ## Retrieve logger object
     my $log = Log::Log4perl->get_logger(q{MIP});
 
-    ## Set MIP program name
+    ## Set program mode
     my $program_mode = $active_parameter_href->{$program_name};
 
     ## Alias
@@ -126,7 +135,7 @@ sub analysis_multiqc {
       get_module_parameters(
         {
             active_parameter_href => $active_parameter_href,
-            program_name      => $program_name,
+            program_name          => $program_name,
         }
       );
 

--- a/lib/MIP/Recipes/Analysis/Peddy.pm
+++ b/lib/MIP/Recipes/Analysis/Peddy.pm
@@ -21,7 +21,7 @@ BEGIN {
     use base qw{ Exporter };
 
     # Set the version for version checking
-    our $VERSION = 1.01;
+    our $VERSION = 1.02;
 
     # Functions and variables which can be optionally exported
     our @EXPORT_OK = qw{ analysis_peddy };
@@ -36,17 +36,15 @@ Readonly my $UNDERSCORE => q{_};
 
 sub analysis_peddy {
 
-## Function : Compares familial-relationships and sexes.
+## Function : Compares family-relationships and sexes.
 ## Returns  :
 ## Arguments: $active_parameter_href   => Active parameters for this analysis hash {REF}
 ##          : $call_type               => Variant call type
 ##          : $family_id               => Family id
 ##          : $file_info_href          => File_info hash {REF}
-##          : $infamily_directory      => In family directory
 ##          : $infile_lane_prefix_href => Infile(s) without the ".ending" {REF}
 ##          : $job_id_href             => Job id hash {REF}
 ##          : $outaligner_dir          => Outaligner_dir used in the analysis
-##          : $outfamily_directory     => Out family directory
 ##          : $parameter_href          => Parameter hash {REF}
 ##          : $program_name            => Program name
 ##          : $sample_info_href        => Info on samples and family hash {REF}
@@ -57,10 +55,8 @@ sub analysis_peddy {
     ## Flatten argument(s)
     my $active_parameter_href;
     my $file_info_href;
-    my $infamily_directory;
     my $infile_lane_prefix_href;
     my $job_id_href;
-    my $outfamily_directory;
     my $parameter_href;
     my $program_name;
     my $sample_info_href;
@@ -73,81 +69,69 @@ sub analysis_peddy {
 
     my $tmpl = {
         active_parameter_href => {
-            required    => 1,
-            defined     => 1,
             default     => {},
-            strict_type => 1,
+            defined     => 1,
+            required    => 1,
             store       => \$active_parameter_href,
+            strict_type => 1,
         },
         call_type =>
-          { default => q{BOTH}, strict_type => 1, store => \$call_type, },
+          { default => q{BOTH}, store => \$call_type, strict_type => 1, },
         family_id => {
             default     => $arg_href->{active_parameter_href}{family_id},
-            strict_type => 1,
             store       => \$family_id,
+            strict_type => 1,
         },
         file_info_href => {
-            required    => 1,
-            defined     => 1,
             default     => {},
-            strict_type => 1,
-            store       => \$file_info_href,
-        },
-        infamily_directory => {
-            required    => 1,
             defined     => 1,
+            required    => 1,
+            store       => \$file_info_href,
             strict_type => 1,
-            store       => \$infamily_directory,
         },
         infile_lane_prefix_href => {
-            required    => 1,
-            defined     => 1,
             default     => {},
-            strict_type => 1,
+            defined     => 1,
+            required    => 1,
             store       => \$infile_lane_prefix_href,
+            strict_type => 1,
         },
         job_id_href => {
-            required    => 1,
-            defined     => 1,
             default     => {},
-            strict_type => 1,
+            defined     => 1,
+            required    => 1,
             store       => \$job_id_href,
+            strict_type => 1,
         },
         outaligner_dir => {
             default     => $arg_href->{active_parameter_href}{outaligner_dir},
-            strict_type => 1,
             store       => \$outaligner_dir,
-        },
-        outfamily_directory => {
-            required    => 1,
-            defined     => 1,
             strict_type => 1,
-            store       => \$outfamily_directory,
         },
         parameter_href => {
-            required    => 1,
-            defined     => 1,
             default     => {},
-            strict_type => 1,
+            defined     => 1,
+            required    => 1,
             store       => \$parameter_href,
+            strict_type => 1,
         },
         program_name => {
-            required    => 1,
             defined     => 1,
-            strict_type => 1,
+            required    => 1,
             store       => \$program_name,
+            strict_type => 1,
         },
         sample_info_href => {
-            required    => 1,
-            defined     => 1,
             default     => {},
-            strict_type => 1,
+            defined     => 1,
+            required    => 1,
             store       => \$sample_info_href,
+            strict_type => 1,
         },
         temp_directory => {
             default     => $arg_href->{active_parameter_href}{temp_directory},
-            strict_type => 1,
             store       => \$temp_directory,
+            strict_type => 1,
         },
     };
 
@@ -168,17 +152,18 @@ sub analysis_peddy {
     ## Retrieve logger object
     my $log = Log::Log4perl->get_logger(q{MIP});
 
-    ## Set MIP program name
+    ## Set program mode
     my $program_mode = $active_parameter_href->{$program_name};
 
     ## Unpack parameters
     my $job_id_chain = $parameter_href->{$program_name}{chain};
-    my ( $core_number, $time, @source_environment_cmds ) = get_module_parameters(
+    my ( $core_number, $time, @source_environment_cmds ) =
+      get_module_parameters(
         {
             active_parameter_href => $active_parameter_href,
-            program_name      => $program_name,
+            program_name          => $program_name,
         }
-    );
+      );
 
     ## Filehandles
     # Create anonymous filehandle
@@ -214,8 +199,14 @@ sub analysis_peddy {
     #To enable submission to &sample_info_qc later
     my $stdout_file = $program_info_file . $DOT . q{stdout.txt};
 
+    ## Assign directories
     my $outfamily_file_directory =
       catfile( $active_parameter_href->{outdata_dir}, $family_id );
+
+    my $infamily_directory = catdir( $active_parameter_href->{outdata_dir},
+        $family_id, $outaligner_dir );
+    my $outfamily_directory = catfile( $active_parameter_href->{outdata_dir},
+        $family_id, $outaligner_dir, q{casecheck}, $program_name );
 
     ## Files
     my $infile_tag =

--- a/lib/MIP/Recipes/Analysis/Picardtools_collecthsmetrics.pm
+++ b/lib/MIP/Recipes/Analysis/Picardtools_collecthsmetrics.pm
@@ -21,7 +21,7 @@ BEGIN {
     use base qw{ Exporter };
 
     # Set the version for version checking
-    our $VERSION = 1.01;
+    our $VERSION = 1.02;
 
     # Functions and variables which can be optionally exported
     our @EXPORT_OK = qw{ analysis_picardtools_collecthsmetrics };
@@ -41,10 +41,7 @@ sub analysis_picardtools_collecthsmetrics {
 ##          : $family_id               => Family id
 ##          : $file_info_href          => File info hash {REF}
 ##          : $infile_lane_prefix_href => Infile(s) without the ".ending" {REF}
-##          : $insample_directory      => In sample directory
 ##          : $job_id_href             => Job id hash {REF}
-##          : $outaligner_dir          => Outaligner_dir used in the analysis
-##          : $outsample_directory     => Out sample directory
 ##          : $parameter_href          => Parameter hash {REF}
 ##          : $program_name            => Program name
 ##          : $sample_id               => Sample id
@@ -57,100 +54,80 @@ sub analysis_picardtools_collecthsmetrics {
     my $active_parameter_href;
     my $file_info_href;
     my $infile_lane_prefix_href;
-    my $insample_directory;
     my $job_id_href;
     my $parameter_href;
     my $program_name;
-    my $outsample_directory;
     my $sample_id;
     my $sample_info_href;
 
     ## Default(s)
     my $family_id;
-    my $outaligner_dir;
     my $temp_directory;
 
     my $tmpl = {
         active_parameter_href => {
-            required    => 1,
             defined     => 1,
             default     => {},
+            required    => 1,
+            store       => \$active_parameter_href,
             strict_type => 1,
-            store       => \$active_parameter_href
         },
         family_id => {
             default     => $arg_href->{active_parameter_href}{family_id},
+            store       => \$family_id,
             strict_type => 1,
-            store       => \$family_id
         },
         file_info_href => {
-            required    => 1,
-            defined     => 1,
             default     => {},
+            defined     => 1,
+            required    => 1,
+            store       => \$file_info_href,
             strict_type => 1,
-            store       => \$file_info_href
         },
         infile_lane_prefix_href => {
-            required    => 1,
-            defined     => 1,
             default     => {},
-            strict_type => 1,
-            store       => \$infile_lane_prefix_href
-        },
-        insample_directory => {
-            required    => 1,
             defined     => 1,
+            required    => 1,
+            store       => \$infile_lane_prefix_href,
             strict_type => 1,
-            store       => \$insample_directory,
         },
         job_id_href => {
-            required    => 1,
-            defined     => 1,
             default     => {},
-            strict_type => 1,
-            store       => \$job_id_href
-        },
-        outaligner_dir => {
-            default     => $arg_href->{active_parameter_href}{outaligner_dir},
-            strict_type => 1,
-            store       => \$outaligner_dir
-        },
-        outsample_directory => {
-            required    => 1,
             defined     => 1,
+            required    => 1,
+            store       => \$job_id_href,
             strict_type => 1,
-            store       => \$outsample_directory,
         },
         parameter_href => {
-            required    => 1,
-            defined     => 1,
             default     => {},
+            defined     => 1,
+            required    => 1,
+            store       => \$parameter_href,
             strict_type => 1,
-            store       => \$parameter_href
         },
         program_name => {
-            required    => 1,
             defined     => 1,
+            required    => 1,
+            store       => \$program_name,
             strict_type => 1,
-            store       => \$program_name
         },
         sample_id => {
-            required    => 1,
             defined     => 1,
+            required    => 1,
+            store       => \$sample_id,
             strict_type => 1,
-            store       => \$sample_id
         },
         sample_info_href => {
-            required    => 1,
-            defined     => 1,
             default     => {},
+            defined     => 1,
+            required    => 1,
+            store       => \$sample_info_href,
             strict_type => 1,
-            store       => \$sample_info_href
         },
         temp_directory => {
             default     => $arg_href->{active_parameter_href}{temp_directory},
+            store       => \$temp_directory,
             strict_type => 1,
-            store       => \$temp_directory
         },
     };
 
@@ -170,17 +147,18 @@ sub analysis_picardtools_collecthsmetrics {
     ## Retrieve logger object
     my $log = Log::Log4perl->get_logger(q{MIP});
 
-    ## Set MIP program name
+    ## Set program name
     my $program_mode = $active_parameter_href->{$program_name};
 
     ## Alias
     my $job_id_chain = $parameter_href->{$program_name}{chain};
-    my ( $core_number, $time, @source_environment_cmds ) = get_module_parameters(
+    my ( $core_number, $time, @source_environment_cmds ) =
+      get_module_parameters(
         {
             active_parameter_href => $active_parameter_href,
-            program_name      => $program_name,
+            program_name          => $program_name,
         }
-    );
+      );
 
     ## Filehandles
     # Create anonymous filehandle
@@ -192,6 +170,14 @@ sub analysis_picardtools_collecthsmetrics {
             file_info_href => $file_info_href,
             sample_id      => $sample_id,
         }
+    );
+
+    ## Assign directories
+    my $insample_directory = catdir( $active_parameter_href->{outdata_dir},
+        $sample_id, $active_parameter_href->{outaligner_dir} );
+    my $outsample_directory = catdir(
+        $active_parameter_href->{outdata_dir},    $sample_id,
+        $active_parameter_href->{outaligner_dir}, q{coveragereport}
     );
 
     ## Assign file_tags
@@ -227,8 +213,11 @@ sub analysis_picardtools_collecthsmetrics {
             job_id_href           => $job_id_href,
             log                   => $log,
             process_time          => $time,
-            program_directory => catfile( $outaligner_dir, q{coveragereport} ),
-            program_name      => $program_name,
+            program_directory     => catfile(
+                $active_parameter_href->{outaligner_dir},
+                q{coveragereport}
+            ),
+            program_name                    => $program_name,
             source_environment_commands_ref => \@source_environment_cmds,
             temp_directory                  => $temp_directory,
         }

--- a/lib/MIP/Recipes/Analysis/Plink.pm
+++ b/lib/MIP/Recipes/Analysis/Plink.pm
@@ -21,7 +21,7 @@ BEGIN {
     use base qw{ Exporter };
 
     # Set the version for version checking
-    our $VERSION = 1.01;
+    our $VERSION = 1.02;
 
     # Functions and variables which can be optionally exported
     our @EXPORT_OK = qw{ analysis_plink };
@@ -45,11 +45,9 @@ sub analysis_plink {
 ##          : $call_type               => Variant call type
 ##          : $family_id               => Family id
 ##          : $file_info_href          => File_info hash {REF}
-##          : $infamily_directory      => In family directory
 ##          : $infile_lane_prefix_href => Infile(s) without the ".ending" {REF}
 ##          : $job_id_href             => Job id hash {REF}
 ##          : $outaligner_dir          => Outaligner_dir used in the analysis
-##          : $outfamily_directory     => Out family directory
 ##          : $parameter_href          => Parameter hash {REF}
 ##          : $program_name            => Program name
 ##          : $sample_info_href        => Info on samples and family hash {REF}
@@ -59,11 +57,9 @@ sub analysis_plink {
 
     ## Flatten argument(s)
     my $active_parameter_href;
-    my $infamily_directory;
     my $file_info_href;
     my $infile_lane_prefix_href;
     my $job_id_href;
-    my $outfamily_directory;
     my $parameter_href;
     my $program_name;
     my $sample_info_href;
@@ -99,12 +95,6 @@ sub analysis_plink {
             store       => \$file_info_href,
             strict_type => 1,
         },
-        infamily_directory => {
-            defined     => 1,
-            required    => 1,
-            store       => \$infamily_directory,
-            strict_type => 1,
-        },
         infile_lane_prefix_href => {
             default     => {},
             defined     => 1,
@@ -122,12 +112,6 @@ sub analysis_plink {
         outaligner_dir => {
             default     => $arg_href->{active_parameter_href}{outaligner_dir},
             store       => \$outaligner_dir,
-            strict_type => 1,
-        },
-        outfamily_directory => {
-            defined     => 1,
-            required    => 1,
-            store       => \$outfamily_directory,
             strict_type => 1,
         },
         parameter_href => {
@@ -177,7 +161,7 @@ sub analysis_plink {
     ## Retrieve logger object
     my $log = Log::Log4perl->get_logger(q{MIP});
 
-    ## Set MIP program name
+    ## Set program mode
     my $program_mode = $active_parameter_href->{$program_name};
 
     ## Unpack parameters
@@ -188,12 +172,13 @@ sub analysis_plink {
     my $human_genome_reference_source =
       $file_info_href->{human_genome_reference_source};
     my $job_id_chain = $parameter_href->{$program_name}{chain};
-    my ( $core_number, $time, @source_environment_cmds ) = get_module_parameters(
+    my ( $core_number, $time, @source_environment_cmds ) =
+      get_module_parameters(
         {
             active_parameter_href => $active_parameter_href,
-            program_name      => $program_name,
+            program_name          => $program_name,
         }
-    );
+      );
 
     ## Filehandles
     # Create anonymous filehandle
@@ -223,12 +208,18 @@ sub analysis_plink {
     my ( $volume, $directory, $program_info_file ) =
       splitpath($program_info_path);
 
-    # To enable submission to &sample_info_qc later
+    # To enable submission to %sample_info_qc later
     my $stderr_file = $program_info_file . q{.stderr.txt};
 
-    # To enable submission to &sample_info_qc later
+    # To enable submission to %sample_info_qc later
     my $stdout_file = $program_info_file . q{.stdout.txt};
 
+    ## Assign directories
+    my $infamily_directory = catdir( $active_parameter_href->{outdata_dir},
+        $family_id, $outaligner_dir );
+
+    my $outfamily_directory = catfile( $active_parameter_href->{outdata_dir},
+        $family_id, $outaligner_dir, q{casecheck}, $program_name );
     ## Paths
     my $outfamily_file_directory =
       catfile( $active_parameter_href->{outdata_dir}, $family_id );

--- a/lib/MIP/Recipes/Analysis/Prepareforvariantannotationblock.pm
+++ b/lib/MIP/Recipes/Analysis/Prepareforvariantannotationblock.pm
@@ -428,79 +428,80 @@ sub analysis_prepareforvariantannotationblock_rio {
 
     my $tmpl = {
         active_parameter_href => {
-            required    => 1,
-            defined     => 1,
             default     => {},
-            strict_type => 1,
+            defined     => 1,
+            required    => 1,
             store       => \$active_parameter_href,
+            strict_type => 1,
         },
         call_type =>
-          { default => q{BOTH}, strict_type => 1, store => \$call_type, },
+          { default => q{BOTH}, store => \$call_type, strict_type => 1, },
         family_id => {
             default     => $arg_href->{active_parameter_href}{family_id},
-            strict_type => 1,
             store       => \$family_id,
+            strict_type => 1,
         },
         FILEHANDLE     => { required => 1, store => \$FILEHANDLE, },
         file_info_href => {
-            required    => 1,
-            defined     => 1,
             default     => {},
-            strict_type => 1,
+            defined     => 1,
+            required    => 1,
             store       => \$file_info_href,
-        },
-        file_path               => { strict_type => 1, store => \$file_path },
-        infile_lane_prefix_href => {
-            required    => 1,
-            defined     => 1,
-            default     => {},
             strict_type => 1,
+        },
+        file_path               => { store => \$file_path, strict_type => 1, },
+        infile_lane_prefix_href => {
+            default     => {},
+            defined     => 1,
+            required    => 1,
             store       => \$infile_lane_prefix_href,
+            strict_type => 1,
         },
         job_id_href => {
-            required    => 1,
-            defined     => 1,
             default     => {},
-            strict_type => 1,
+            defined     => 1,
+            required    => 1,
             store       => \$job_id_href,
+            strict_type => 1,
         },
         outaligner_dir => {
             default     => $arg_href->{active_parameter_href}{outaligner_dir},
-            strict_type => 1,
             store       => \$outaligner_dir,
+            strict_type => 1,
         },
         parameter_href => {
-            required    => 1,
-            defined     => 1,
             default     => {},
-            strict_type => 1,
-            store       => \$parameter_href,
-        },
-        program_info_path => { strict_type => 1, store => \$program_info_path },
-        program_name      => {
-            required    => 1,
             defined     => 1,
+            required    => 1,
+            store       => \$parameter_href,
             strict_type => 1,
+        },
+        program_info_path =>
+          { store => \$program_info_path, strict_type => 1, },
+        program_name => {
+            defined     => 1,
+            required    => 1,
             store       => \$program_name,
+            strict_type => 1,
         },
         sample_info_href => {
-            required    => 1,
-            defined     => 1,
             default     => {},
-            strict_type => 1,
+            defined     => 1,
+            required    => 1,
             store       => \$sample_info_href,
+            strict_type => 1,
         },
-        stderr_path    => { strict_type => 1, store => \$stderr_path },
+        stderr_path    => { store => \$stderr_path, strict_type => 1, },
         temp_directory => {
             default     => $arg_href->{active_parameter_href}{temp_directory},
-            strict_type => 1,
             store       => \$temp_directory,
+            strict_type => 1,
         },
         xargs_file_counter => {
-            default     => 0,
             allow       => qr/ ^\d+$ /xsm,
-            strict_type => 1,
+            default     => 0,
             store       => \$xargs_file_counter,
+            strict_type => 1,
         },
     };
 
@@ -519,7 +520,7 @@ sub analysis_prepareforvariantannotationblock_rio {
     ## Retrieve logger object
     my $log = Log::Log4perl->get_logger(q{MIP});
 
-    ## Set MIP program name
+    ## Set program mode
     my $program_mode = $active_parameter_href->{$program_name};
 
     ## Unpack parameters

--- a/lib/MIP/Recipes/Analysis/Prepareforvariantannotationblock.pm
+++ b/lib/MIP/Recipes/Analysis/Prepareforvariantannotationblock.pm
@@ -81,78 +81,79 @@ sub analysis_prepareforvariantannotationblock {
 
     my $tmpl = {
         active_parameter_href => {
-            required    => 1,
-            defined     => 1,
             default     => {},
-            strict_type => 1,
+            defined     => 1,
+            required    => 1,
             store       => \$active_parameter_href,
+            strict_type => 1,
         },
         call_type =>
-          { default => q{BOTH}, strict_type => 1, store => \$call_type, },
+          { default => q{BOTH}, store => \$call_type, strict_type => 1, },
         family_id => {
             default     => $arg_href->{active_parameter_href}{family_id},
-            strict_type => 1,
             store       => \$family_id,
+            strict_type => 1,
         },
         file_info_href => {
-            required    => 1,
-            defined     => 1,
             default     => {},
-            strict_type => 1,
+            defined     => 1,
+            required    => 1,
             store       => \$file_info_href,
-        },
-        file_path               => { strict_type => 1, store => \$file_path },
-        infile_lane_prefix_href => {
-            required    => 1,
-            defined     => 1,
-            default     => {},
             strict_type => 1,
+        },
+        file_path               => { store => \$file_path, strict_type => 1, },
+        infile_lane_prefix_href => {
+            default     => {},
+            defined     => 1,
+            required    => 1,
             store       => \$infile_lane_prefix_href,
+            strict_type => 1,
         },
         job_id_href => {
-            required    => 1,
-            defined     => 1,
             default     => {},
-            strict_type => 1,
+            defined     => 1,
+            required    => 1,
             store       => \$job_id_href,
+            strict_type => 1,
         },
         outaligner_dir => {
             default     => $arg_href->{active_parameter_href}{outaligner_dir},
-            strict_type => 1,
             store       => \$outaligner_dir,
+            strict_type => 1,
         },
         parameter_href => {
-            required    => 1,
-            defined     => 1,
             default     => {},
-            strict_type => 1,
-            store       => \$parameter_href,
-        },
-        program_info_path => { strict_type => 1, store => \$program_info_path },
-        program_name      => {
-            required    => 1,
             defined     => 1,
+            required    => 1,
+            store       => \$parameter_href,
             strict_type => 1,
+        },
+        program_info_path =>
+          { store => \$program_info_path, strict_type => 1, },
+        program_name => {
+            defined     => 1,
+            required    => 1,
             store       => \$program_name,
+            strict_type => 1,
         },
         sample_info_href => {
-            required    => 1,
-            defined     => 1,
             default     => {},
-            strict_type => 1,
+            defined     => 1,
+            required    => 1,
             store       => \$sample_info_href,
+            strict_type => 1,
         },
-        stderr_path    => { strict_type => 1, store => \$stderr_path },
+        stderr_path    => { store => \$stderr_path, strict_type => 1, },
         temp_directory => {
             default     => $arg_href->{active_parameter_href}{temp_directory},
-            strict_type => 1,
             store       => \$temp_directory,
+            strict_type => 1,
         },
         xargs_file_counter => {
-            default     => 0,
             allow       => qr/ ^\d+$ /xsm,
-            strict_type => 1,
+            default     => 0,
             store       => \$xargs_file_counter,
+            strict_type => 1,
         },
     };
 
@@ -172,17 +173,18 @@ sub analysis_prepareforvariantannotationblock {
     ## Retrieve logger object
     my $log = Log::Log4perl->get_logger(q{MIP});
 
-    ## Set MIP program name
+    ## Set program mode
     my $program_mode = $active_parameter_href->{$program_name};
 
     ## Unpack parameters
     my $job_id_chain = $parameter_href->{$program_name}{chain};
-    my ( $core_number, $time, @source_environment_cmds ) = get_module_parameters(
+    my ( $core_number, $time, @source_environment_cmds ) =
+      get_module_parameters(
         {
             active_parameter_href => $active_parameter_href,
-            program_name      => $program_name,
+            program_name          => $program_name,
         }
-    );
+      );
     my $xargs_file_path_prefix;
 
     ## Filehandles
@@ -250,8 +252,8 @@ sub analysis_prepareforvariantannotationblock {
     );
     my $outfile_suffix = set_file_suffix(
         {
-            job_id_chain => $job_id_chain,
-            file_suffix => $parameter_href->{$program_name}{outfile_suffix},
+            job_id_chain   => $job_id_chain,
+            file_suffix    => $parameter_href->{$program_name}{outfile_suffix},
             parameter_href => $parameter_href,
             suffix_key     => q{variant_file_suffix},
         }
@@ -522,12 +524,13 @@ sub analysis_prepareforvariantannotationblock_rio {
 
     ## Unpack parameters
     my $job_id_chain = $parameter_href->{$program_name}{chain};
-    my ( $core_number, $time, @source_environment_cmds ) = get_module_parameters(
+    my ( $core_number, $time, @source_environment_cmds ) =
+      get_module_parameters(
         {
             active_parameter_href => $active_parameter_href,
-            program_name      => $program_name,
+            program_name          => $program_name,
         }
-    );
+      );
     my $xargs_file_path_prefix;
 
     ## Filehandles
@@ -575,8 +578,8 @@ sub analysis_prepareforvariantannotationblock_rio {
     );
     my $outfile_suffix = set_file_suffix(
         {
-            job_id_chain => $job_id_chain,
-            file_suffix => $parameter_href->{$program_name}{outfile_suffix},
+            job_id_chain   => $job_id_chain,
+            file_suffix    => $parameter_href->{$program_name}{outfile_suffix},
             parameter_href => $parameter_href,
             suffix_key     => q{variant_file_suffix},
         }

--- a/lib/MIP/Recipes/Analysis/Qccollect.pm
+++ b/lib/MIP/Recipes/Analysis/Qccollect.pm
@@ -132,6 +132,7 @@ sub analysis_qccollect {
     check( $tmpl, $arg_href, 1 ) or croak q{Could not parse arguments!};
 
     use MIP::Get::File qw{ get_file_suffix get_merged_infile_prefix };
+    use MIP::Get::Parameter qw{ get_module_parameters };
     use MIP::Processmanagement::Slurm_processes
       qw{ slurm_submit_chain_job_ids_dependency_add_to_path };
     use MIP::Program::Qc::Qccollect qw{ qccollect };
@@ -146,9 +147,13 @@ sub analysis_qccollect {
 
     ## Unpack parameters
     my $job_id_chain = $parameter_href->{$program_name}{chain};
-    my $core_number =
-      $active_parameter_href->{module_core_number}{$program_name};
-    my $time = $active_parameter_href->{module_time}{$program_name};
+    my ( $core_number, $time, @source_environment_cmds ) =
+      get_module_parameters(
+        {
+            active_parameter_href => $active_parameter_href,
+            program_name          => $program_name,
+        }
+      );
 
     ## Filehandles
     # Create anonymous filehandle
@@ -157,15 +162,16 @@ sub analysis_qccollect {
     ## Creates program directories (info & programData & programScript), program script filenames and writes sbatch header
     my ($file_path) = setup_script(
         {
-            active_parameter_href => $active_parameter_href,
-            job_id_href           => $job_id_href,
-            FILEHANDLE            => $FILEHANDLE,
-            directory_id          => $family_id,
-            log                   => $log,
-            program_name          => $program_name,
-            program_directory     => $program_name,
-            core_number           => $core_number,
-            process_time          => $time,
+            active_parameter_href           => $active_parameter_href,
+            core_number                     => $core_number,
+            directory_id                    => $family_id,
+            FILEHANDLE                      => $FILEHANDLE,
+            job_id_href                     => $job_id_href,
+            log                             => $log,
+            program_directory               => $program_name,
+            program_name                    => $program_name,
+            process_time                    => $time,
+            source_environment_commands_ref => \@source_environment_cmds,
         }
     );
 

--- a/lib/MIP/Recipes/Analysis/Rankvariant.pm
+++ b/lib/MIP/Recipes/Analysis/Rankvariant.pm
@@ -193,12 +193,13 @@ sub analysis_rankvariant {
     my $job_id_chain            = $parameter_href->{$program_name}{chain};
     my $vcfparser_analysis_type = $EMPTY_STR;
     my $xargs_file_path_prefix;
-    my ( $core_number, $time, @source_environment_cmds ) = get_module_parameters(
+    my ( $core_number, $time, @source_environment_cmds ) =
+      get_module_parameters(
         {
             active_parameter_href => $active_parameter_href,
-            program_name      => $program_name,
+            program_name          => $program_name,
         }
-    );
+      );
 
     ## Set default contigs
     my @contigs_size_ordered = @{ $file_info_href->{contigs_size_ordered} };
@@ -279,7 +280,7 @@ sub analysis_rankvariant {
             parameter_href => $parameter_href,
             suffix_key     => q{variant_file_suffix},
             job_id_chain   => $job_id_chain,
-            file_suffix => $parameter_href->{$program_name}{outfile_suffix},
+            file_suffix    => $parameter_href->{$program_name}{outfile_suffix},
         }
     );
 
@@ -603,6 +604,7 @@ sub analysis_rankvariant_rio {
 ##          : $program_info_path       => The program info path
 ##          : $program_name            => Program name
 ##          : $sample_info_href        => Info on samples and family hash {REF}
+##          : $stderr_path             => Stderr path of the block script
 ##          : $temp_directory          => Temporary directory
 ##          : $xargs_file_counter      => The xargs file counter
 
@@ -619,6 +621,7 @@ sub analysis_rankvariant_rio {
     my $program_info_path;
     my $program_name;
     my $sample_info_href;
+    my $stderr_path;
 
     ## Default(s)
     my $call_type;
@@ -692,6 +695,12 @@ sub analysis_rankvariant_rio {
             store       => \$sample_info_href,
             strict_type => 1,
         },
+        stderr_path => {
+            defined     => 1,
+            required    => 1,
+            store       => \$stderr_path,
+            strict_type => 1,
+        },
         temp_directory => {
             default     => $arg_href->{active_parameter_href}{temp_directory},
             store       => \$temp_directory,
@@ -742,12 +751,13 @@ sub analysis_rankvariant_rio {
     my $job_id_chain            = $parameter_href->{$program_name}{chain};
     my $vcfparser_analysis_type = $EMPTY_STR;
     my $xargs_file_path_prefix;
-    my ( $core_number, $time, @source_environment_cmds ) = get_module_parameters(
+    my ( $core_number, $time, @source_environment_cmds ) =
+      get_module_parameters(
         {
             active_parameter_href => $active_parameter_href,
-            program_name      => $program_name,
+            program_name          => $program_name,
         }
-    );
+      );
 
     ## Set default contigs
     my @contigs_size_ordered = @{ $file_info_href->{contigs_size_ordered} };
@@ -821,7 +831,7 @@ sub analysis_rankvariant_rio {
             parameter_href => $parameter_href,
             suffix_key     => q{variant_file_suffix},
             job_id_chain   => $job_id_chain,
-            file_suffix => $parameter_href->{$program_name}{outfile_suffix},
+            file_suffix    => $parameter_href->{$program_name}{outfile_suffix},
         }
     );
 
@@ -1117,6 +1127,7 @@ sub analysis_rankvariant_rio_unaffected {
 ##          : $program_info_path       => The program info path
 ##          : $program_name            => Program name
 ##          : $sample_info_href        => Info on samples and family hash {REF}
+##          : $stderr_path             => Stderr path of the block script
 ##          : $temp_directory          => Temporary directory
 ##          : $xargs_file_counter      => The xargs file counter
 
@@ -1133,6 +1144,7 @@ sub analysis_rankvariant_rio_unaffected {
     my $program_info_path;
     my $program_name;
     my $sample_info_href;
+    my $stderr_path;
 
     ## Default(s)
     my $call_type;
@@ -1206,6 +1218,12 @@ sub analysis_rankvariant_rio_unaffected {
             store       => \$sample_info_href,
             strict_type => 1,
         },
+        stderr_path => {
+            defined     => 1,
+            required    => 1,
+            store       => \$stderr_path,
+            strict_type => 1,
+        },
         temp_directory => {
             default     => $arg_href->{active_parameter_href}{temp_directory},
             store       => \$temp_directory,
@@ -1256,12 +1274,13 @@ sub analysis_rankvariant_rio_unaffected {
     my $job_id_chain            = $parameter_href->{$program_name}{chain};
     my $vcfparser_analysis_type = $EMPTY_STR;
     my $xargs_file_path_prefix;
-    my ( $core_number, $time, @source_environment_cmds ) = get_module_parameters(
+    my ( $core_number, $time, @source_environment_cmds ) =
+      get_module_parameters(
         {
             active_parameter_href => $active_parameter_href,
-            program_name      => $program_name,
+            program_name          => $program_name,
         }
-    );
+      );
 
     ## Set default contigs
     my @contigs_size_ordered = @{ $file_info_href->{contigs_size_ordered} };
@@ -1335,7 +1354,7 @@ sub analysis_rankvariant_rio_unaffected {
             parameter_href => $parameter_href,
             suffix_key     => q{variant_file_suffix},
             job_id_chain   => $job_id_chain,
-            file_suffix => $parameter_href->{$program_name}{outfile_suffix},
+            file_suffix    => $parameter_href->{$program_name}{outfile_suffix},
         }
     );
 
@@ -1677,12 +1696,13 @@ sub analysis_rankvariant_unaffected {
     my $job_id_chain            = $parameter_href->{$program_name}{chain};
     my $vcfparser_analysis_type = $EMPTY_STR;
     my $xargs_file_path_prefix;
-    my ( $core_number, $time, @source_environment_cmds ) = get_module_parameters(
+    my ( $core_number, $time, @source_environment_cmds ) =
+      get_module_parameters(
         {
             active_parameter_href => $active_parameter_href,
-            program_name      => $program_name,
+            program_name          => $program_name,
         }
-    );
+      );
 
     ## Set default contigs
     my @contigs_size_ordered = @{ $file_info_href->{contigs_size_ordered} };
@@ -1763,7 +1783,7 @@ sub analysis_rankvariant_unaffected {
             parameter_href => $parameter_href,
             suffix_key     => q{variant_file_suffix},
             job_id_chain   => $job_id_chain,
-            file_suffix => $parameter_href->{$program_name}{outfile_suffix},
+            file_suffix    => $parameter_href->{$program_name}{outfile_suffix},
         }
     );
 
@@ -2120,12 +2140,13 @@ sub analysis_sv_rankvariant {
     my $consensus_analysis_type =
       $parameter_href->{dynamic_parameter}{consensus_analysis_type};
     my $job_id_chain = $parameter_href->{$program_name}{chain};
-    my ( $core_number, $time, @source_environment_cmds ) = get_module_parameters(
+    my ( $core_number, $time, @source_environment_cmds ) =
+      get_module_parameters(
         {
             active_parameter_href => $active_parameter_href,
-            program_name      => $program_name,
+            program_name          => $program_name,
         }
-    );
+      );
 
     ## Filehandles
     # Create anonymous filehandle
@@ -2552,12 +2573,13 @@ sub analysis_sv_rankvariant_unaffected {
     my $consensus_analysis_type =
       $parameter_href->{dynamic_parameter}{consensus_analysis_type};
     my $job_id_chain = $parameter_href->{$program_name}{chain};
-    my ( $core_number, $time, @source_environment_cmds ) = get_module_parameters(
+    my ( $core_number, $time, @source_environment_cmds ) =
+      get_module_parameters(
         {
             active_parameter_href => $active_parameter_href,
-            program_name      => $program_name,
+            program_name          => $program_name,
         }
-    );
+      );
 
     ## Filehandles
     # Create anonymous filehandle

--- a/lib/MIP/Recipes/Analysis/Rcoverageplots.pm
+++ b/lib/MIP/Recipes/Analysis/Rcoverageplots.pm
@@ -41,11 +41,7 @@ sub analysis_rcoverageplots {
 ##          : $family_id               => Family id
 ##          : $file_info_href          => File info hash {REF}
 ##          : $infile_lane_prefix_href => Infile(s) without the ".ending" {REF}
-##          : $insample_directory      => In sample directory
 ##          : $job_id_href             => Job id hash {REF}
-##          : $lane_href               => The lane info hash {REF}
-##          : $outaligner_dir          => Outaligner_dir used in the analysis
-##          : $outsample_directory     => Out sample directory
 ##          : $parameter_href          => Parameter hash {REF}
 ##          : $program_name            => Program name
 ##          : $sample_id               => Sample id
@@ -58,10 +54,7 @@ sub analysis_rcoverageplots {
     my $active_parameter_href;
     my $file_info_href;
     my $infile_lane_prefix_href;
-    my $insample_directory;
     my $job_id_href;
-    my $lane_href;
-    my $outsample_directory;
     my $parameter_href;
     my $program_name;
     my $sample_id;
@@ -69,97 +62,73 @@ sub analysis_rcoverageplots {
 
     ## Default(s)
     my $family_id;
-    my $outaligner_dir;
     my $temp_directory;
 
     my $tmpl = {
         active_parameter_href => {
-            required    => 1,
-            defined     => 1,
             default     => {},
+            defined     => 1,
+            required    => 1,
+            store       => \$active_parameter_href,
             strict_type => 1,
-            store       => \$active_parameter_href
         },
         family_id => {
-            default     => $arg_href->{active_parameter_href}{family_id},
+            default => $arg_href->{active_parameter_href}{family_id},
+            store   => \$family_id,
+            ,
             strict_type => 1,
-            store       => \$family_id,
         },
         file_info_href => {
-            required    => 1,
-            defined     => 1,
             default     => {},
+            defined     => 1,
+            required    => 1,
+            store       => \$file_info_href,
             strict_type => 1,
-            store       => \$file_info_href
         },
         infile_lane_prefix_href => {
-            required    => 1,
-            defined     => 1,
             default     => {},
-            strict_type => 1,
-            store       => \$infile_lane_prefix_href
-        },
-        insample_directory => {
-            required    => 1,
             defined     => 1,
+            required    => 1,
+            store       => \$infile_lane_prefix_href,
             strict_type => 1,
-            store       => \$insample_directory,
         },
         job_id_href => {
-            required    => 1,
-            defined     => 1,
             default     => {},
-            strict_type => 1,
-            store       => \$job_id_href
-        },
-        lane_href => {
-            required    => 1,
             defined     => 1,
-            default     => {},
-            strict_type => 1,
-            store       => \$lane_href
-        },
-        outaligner_dir => {
-            default     => $arg_href->{active_parameter_href}{outaligner_dir},
-            strict_type => 1,
-            store       => \$outaligner_dir
-        },
-        outsample_directory => {
             required    => 1,
-            defined     => 1,
+            store       => \$job_id_href,
             strict_type => 1,
-            store       => \$outsample_directory,
         },
         parameter_href => {
-            required    => 1,
-            defined     => 1,
             default     => {},
+            defined     => 1,
+            required    => 1,
+            store       => \$parameter_href,
             strict_type => 1,
-            store       => \$parameter_href
         },
         program_name => {
-            required    => 1,
             defined     => 1,
+            required    => 1,
+            store       => \$program_name,
             strict_type => 1,
-            store       => \$program_name
         },
         sample_id => {
-            required    => 1,
             defined     => 1,
+            required    => 1,
+            store       => \$sample_id,
             strict_type => 1,
-            store       => \$sample_id
         },
         sample_info_href => {
-            required    => 1,
-            defined     => 1,
             default     => {},
+            defined     => 1,
+            required    => 1,
+            store       => \$sample_info_href,
             strict_type => 1,
-            store       => \$sample_info_href
         },
         temp_directory => {
             default     => $arg_href->{active_parameter_href}{temp_directory},
+            store       => \$temp_directory,
             strict_type => 1,
-            store       => \$temp_directory
         },
     };
 
@@ -175,17 +144,18 @@ sub analysis_rcoverageplots {
     ## Retrieve logger object
     my $log = Log::Log4perl->get_logger(q{MIP});
 
-    ## Set MIP program name
+    ## Set program mode
     my $program_mode = $active_parameter_href->{$program_name};
 
     ## Alias
     my $job_id_chain = $parameter_href->{$program_name}{chain};
-    my ( $core_number, $time, @source_environment_cmds ) = get_module_parameters(
+    my ( $core_number, $time, @source_environment_cmds ) =
+      get_module_parameters(
         {
             active_parameter_href => $active_parameter_href,
-            program_name      => $program_name,
+            program_name          => $program_name,
         }
-    );
+      );
 
     ## Filehandles
     # Create anonymous filehandle
@@ -197,6 +167,14 @@ sub analysis_rcoverageplots {
             file_info_href => $file_info_href,
             sample_id      => $sample_id,
         }
+    );
+
+    ## Assign directories
+    my $insample_directory = catdir( $active_parameter_href->{outdata_dir},
+        $sample_id, $active_parameter_href->{outaligner_dir} );
+    my $outsample_directory = catdir(
+        $active_parameter_href->{outdata_dir},    $sample_id,
+        $active_parameter_href->{outaligner_dir}, q{coveragereport}
     );
 
     ## Assign file_tags
@@ -215,8 +193,11 @@ sub analysis_rcoverageplots {
             job_id_href           => $job_id_href,
             log                   => $log,
             process_time          => $time,
-            program_directory => catfile( $outaligner_dir, q{coveragereport} ),
-            program_name      => $program_name,
+            program_directory     => catfile(
+                $active_parameter_href->{outaligner_dir},
+                q{coveragereport}
+            ),
+            program_name                    => $program_name,
             source_environment_commands_ref => \@source_environment_cmds,
             temp_directory                  => $temp_directory,
         }

--- a/lib/MIP/Recipes/Analysis/Rhocall.pm
+++ b/lib/MIP/Recipes/Analysis/Rhocall.pm
@@ -21,7 +21,7 @@ BEGIN {
     use base qw{ Exporter };
 
     # Set the version for version checking
-    our $VERSION = 1.00;
+    our $VERSION = 1.01;
 
     # Functions and variables which can be optionally exported
     our @EXPORT_OK =
@@ -397,10 +397,8 @@ sub analysis_rhocall_annotate_rio {
 ##          : $file_info_href          => File_info hash {REF}
 ##          : $file_path               => File path
 ##          : $infile_lane_prefix_href => Infile(s) without the ".ending" {REF}
-##          : $infamily_directory      => In family directory
 ##          : $job_id_href             => Job id hash {REF}
 ##          : $outaligner_dir          => Outaligner_dir used in the analysis
-##          : $outfamily_directory     => Out family directory
 ##          : $parameter_href          => Parameter hash {REF}
 ##          : $program_info_path       => The program info path
 ##          : $program_name            => Program name
@@ -416,10 +414,8 @@ sub analysis_rhocall_annotate_rio {
     my $FILEHANDLE;
     my $file_info_href;
     my $file_path;
-    my $infamily_directory;
     my $infile_lane_prefix_href;
     my $job_id_href;
-    my $outfamily_directory;
     my $parameter_href;
     my $program_info_path;
     my $program_name;
@@ -435,91 +431,80 @@ sub analysis_rhocall_annotate_rio {
 
     my $tmpl = {
         active_parameter_href => {
-            required    => 1,
-            defined     => 1,
             default     => {},
-            strict_type => 1,
+            defined     => 1,
+            required    => 1,
             store       => \$active_parameter_href,
+            strict_type => 1,
         },
         call_type =>
-          { default => q{BOTH}, strict_type => 1, store => \$call_type, },
+          { default => q{BOTH}, store => \$call_type, strict_type => 1, },
         family_id => {
             default     => $arg_href->{active_parameter_href}{family_id},
-            strict_type => 1,
             store       => \$family_id,
+            strict_type => 1,
         },
         FILEHANDLE     => { store => \$FILEHANDLE, },
         file_info_href => {
-            required    => 1,
-            defined     => 1,
             default     => {},
-            strict_type => 1,
+            defined     => 1,
+            required    => 1,
             store       => \$file_info_href,
+            strict_type => 1,
         },
-        file_path               => { strict_type => 1, store => \$file_path },
+        file_path               => { store => \$file_path, strict_type => 1, },
         infile_lane_prefix_href => {
-            required    => 1,
-            defined     => 1,
             default     => {},
-            strict_type => 1,
-            store       => \$infile_lane_prefix_href,
-        },
-        infamily_directory => {
-            required    => 1,
             defined     => 1,
+            required    => 1,
+            store       => \$infile_lane_prefix_href,
             strict_type => 1,
-            store       => \$infamily_directory,
         },
         job_id_href => {
-            required    => 1,
-            defined     => 1,
             default     => {},
-            strict_type => 1,
+            defined     => 1,
+            required    => 1,
             store       => \$job_id_href,
+            strict_type => 1,
         },
         outaligner_dir => {
             default     => $arg_href->{active_parameter_href}{outaligner_dir},
-            strict_type => 1,
             store       => \$outaligner_dir,
-        },
-        outfamily_directory => {
-            required    => 1,
-            defined     => 1,
             strict_type => 1,
-            store       => \$outfamily_directory,
         },
         parameter_href => {
-            required    => 1,
-            defined     => 1,
             default     => {},
-            strict_type => 1,
-            store       => \$parameter_href,
-        },
-        program_info_path => { strict_type => 1, store => \$program_info_path },
-        program_name      => {
-            required    => 1,
             defined     => 1,
+            required    => 1,
+            store       => \$parameter_href,
             strict_type => 1,
+        },
+        program_info_path =>
+          { store => \$program_info_path, strict_type => 1, },
+        program_name => {
+            defined     => 1,
+            required    => 1,
             store       => \$program_name,
+            strict_type => 1,
         },
         sample_info_href => {
-            required    => 1,
-            defined     => 1,
             default     => {},
-            strict_type => 1,
+            defined     => 1,
+            required    => 1,
             store       => \$sample_info_href,
+            strict_type => 1,
         },
-        stderr_path    => { strict_type => 1, store => \$stderr_path },
+        stderr_path    => { store => \$stderr_path, strict_type => 1, },
         temp_directory => {
             default     => $arg_href->{active_parameter_href}{temp_directory},
-            strict_type => 1,
             store       => \$temp_directory,
+            strict_type => 1,
         },
         xargs_file_counter => {
-            default     => 0,
             allow       => qr/ ^\d+$ /xsm,
-            strict_type => 1,
+            default     => 0,
             store       => \$xargs_file_counter,
+            strict_type => 1,
         },
     };
 
@@ -540,7 +525,7 @@ sub analysis_rhocall_annotate_rio {
     ## Retrieve logger object
     my $log = Log::Log4perl->get_logger(q{MIP});
 
-    ## Set MIP program name
+    ## Set program mode
     my $program_mode = $active_parameter_href->{$program_name};
 
     ## Unpack parameters
@@ -565,6 +550,11 @@ sub analysis_rhocall_annotate_rio {
             max_cores_per_node => $active_parameter_href->{max_cores_per_node},
         }
     );
+
+    ## Assign directories
+    my $infamily_directory = catdir( $active_parameter_href->{outdata_dir},
+        $family_id, $outaligner_dir );
+    my $outfamily_directory = $infamily_directory;
 
     # Used downstream
     $parameter_href->{$program_name}{indirectory} = $outfamily_directory;

--- a/lib/MIP/Recipes/Analysis/Sacct.pm
+++ b/lib/MIP/Recipes/Analysis/Sacct.pm
@@ -38,6 +38,7 @@ sub analysis_sacct {
 ## Returns  :
 ## Arguments: $active_parameter_href   => Active parameters for this analysis hash {REF}
 ##          : $family_id               => Family id
+##          : $file_info_href          => File info hash {REF}
 ##          : $infile_lane_prefix_href => Infile(s) without the ".ending" {REF}
 ##          : $job_id_href             => Job id hash {REF}
 ##          : $parameter_href          => Parameter hash {REF}
@@ -48,6 +49,7 @@ sub analysis_sacct {
 
     ## Flatten argument(s)
     my $active_parameter_href;
+    my $file_info_href;
     my $infile_lane_prefix_href;
     my $job_id_href;
     my $parameter_href;
@@ -68,6 +70,13 @@ sub analysis_sacct {
         family_id => {
             default     => $arg_href->{active_parameter_href}{family_id},
             store       => \$family_id,
+            strict_type => 1,
+        },
+        file_info_href => {
+            default     => {},
+            defined     => 1,
+            required    => 1,
+            store       => \$file_info_href,
             strict_type => 1,
         },
         infile_lane_prefix_href => {
@@ -117,17 +126,18 @@ sub analysis_sacct {
     ## Retrieve logger object
     my $log = Log::Log4perl->get_logger(q{MIP});
 
-    ## Set MIP program name
+    ## Set program mode
     my $program_mode = $active_parameter_href->{$program_name};
 
     ## Unpack parameters
     my $job_id_chain = $parameter_href->{$program_name}{chain};
-    my ( $core_number, $time, @source_environment_cmds ) = get_module_parameters(
+    my ( $core_number, $time, @source_environment_cmds ) =
+      get_module_parameters(
         {
             active_parameter_href => $active_parameter_href,
-            program_name      => $program_name,
+            program_name          => $program_name,
         }
-    );
+      );
 
     ## Filehandles
     # Create anonymous filehandle

--- a/lib/MIP/Recipes/Analysis/Salmon_quant.pm
+++ b/lib/MIP/Recipes/Analysis/Salmon_quant.pm
@@ -21,7 +21,7 @@ BEGIN {
     use base qw{ Exporter };
 
     # Set the version for version checking
-    our $VERSION = 1.01;
+    our $VERSION = 1.02;
 
     # Functions and variables which can be optionally exported
     our @EXPORT_OK = qw{ analysis_salmon_quant };
@@ -41,12 +41,9 @@ sub analysis_salmon_quant {
 ## Arguments: $active_parameter_href   => Active parameters for this analysis hash {REF}
 ##          : $family_id               => Family id
 ##          : $file_info_href          => File_info hash {REF}
-##          : $infiles_ref             => Infiles hash {REF}
+##          : $indir_path_href         => Indirectories path(s) hash {REF}
 ##          : $infile_lane_prefix_href => Infile(s) without the ".ending" {REF}
-##          : $insample_directory      => In sample directory
 ##          : $job_id_href             => Job id hash {REF}
-##          : $outaligner_dir          => Outaligner_dir used in the analysis
-##          : $outsample_directory     => Out sample directory
 ##          : $parameter_href          => Parameter hash {REF}
 ##          : $program_name            => Program name
 ##          : $sample_id               => Sample id
@@ -58,11 +55,9 @@ sub analysis_salmon_quant {
     ## Flatten argument(s)
     my $active_parameter_href;
     my $file_info_href;
-    my $infiles_ref;
+    my $indir_path_href;
     my $infile_lane_prefix_href;
-    my $insample_directory;
     my $job_id_href;
-    my $outsample_directory;
     my $parameter_href;
     my $program_name;
     my $sample_id;
@@ -70,7 +65,6 @@ sub analysis_salmon_quant {
 
     ## Default(s)
     my $family_id;
-    my $outaligner_dir;
     my $temp_directory;
 
     my $tmpl = {
@@ -93,11 +87,11 @@ sub analysis_salmon_quant {
             store       => \$file_info_href,
             strict_type => 1,
         },
-        infiles_ref => {
-            default     => [],
+        indir_path_href => {
+            default     => {},
             defined     => 1,
             required    => 1,
-            store       => \$infiles_ref,
+            store       => \$indir_path_href,
             strict_type => 1,
         },
         infile_lane_prefix_href => {
@@ -107,28 +101,11 @@ sub analysis_salmon_quant {
             store       => \$infile_lane_prefix_href,
             strict_type => 1,
         },
-        insample_directory => {
-            defined     => 1,
-            required    => 1,
-            store       => \$insample_directory,
-            strict_type => 1,
-        },
         job_id_href => {
             default     => {},
             defined     => 1,
             required    => 1,
             store       => \$job_id_href,
-            strict_type => 1,
-        },
-        outaligner_dir => {
-            default     => $arg_href->{active_parameter_href}{outaligner_dir},
-            store       => \$outaligner_dir,
-            strict_type => 1,
-        },
-        outsample_directory => {
-            defined     => 1,
-            required    => 1,
-            store       => \$outsample_directory,
             strict_type => 1,
         },
         parameter_href => {
@@ -180,22 +157,31 @@ sub analysis_salmon_quant {
     ## Retrieve logger object
     my $log = Log::Log4perl->get_logger(q{MIP});
 
-    ## Set MIP program name
+    ## Set MIP program mode
     my $program_mode = $active_parameter_href->{$program_name};
 
-    ## Unpack parameters
+    ## Get job_id_chain
     my $job_id_chain = $parameter_href->{$program_name}{chain};
+
     my ( $core_number, $time, @source_environment_cmds ) =
       get_module_parameters(
         {
             active_parameter_href => $active_parameter_href,
-            program_name      => $program_name,
+            program_name          => $program_name,
         }
       );
 
     ## Filehandles
     # Create anonymous filehandle
     my $FILEHANDLE = IO::Handle->new();
+
+    ## Get infiles
+    my @infiles = @{ $file_info_href->{$sample_id}{mip_infiles} };
+
+    ## Directories
+    my $insample_directory  = $indir_path_href->{$sample_id};
+    my $outsample_directory = catdir( $active_parameter_href->{outdata_dir},
+        $sample_id, $active_parameter_href->{outaligner_dir} );
 
     ## Assign file_tags
     my $outfile_tag =
@@ -205,7 +191,7 @@ sub analysis_salmon_quant {
     ## Set file suffix for next module within jobid chain
     my $outfile_suffix = set_file_suffix(
         {
-            file_suffix => $parameter_href->{$program_name}{outfile_suffix},
+            file_suffix    => $parameter_href->{$program_name}{outfile_suffix},
             job_id_chain   => $job_id_chain,
             parameter_href => $parameter_href,
             suffix_key     => q{sailfish_quantification_file_suffix},
@@ -238,13 +224,14 @@ sub analysis_salmon_quant {
         ## Creates program directories (info & programData & programScript), program script filenames and writes sbatch header
         my ( $file_name, $program_info_path ) = setup_script(
             {
-                active_parameter_href           => $active_parameter_href,
-                core_number                     => $core_number,
-                directory_id                    => $sample_id,
-                FILEHANDLE                      => $FILEHANDLE,
-                job_id_href                     => $job_id_href,
-                log                             => $log,
-                program_directory               => lc $outaligner_dir,
+                active_parameter_href => $active_parameter_href,
+                core_number           => $core_number,
+                directory_id          => $sample_id,
+                FILEHANDLE            => $FILEHANDLE,
+                job_id_href           => $job_id_href,
+                log                   => $log,
+                program_directory =>
+                  lc $active_parameter_href->{outaligner_dir},
                 program_name                    => $program_name,
                 process_time                    => $time,
                 source_environment_commands_ref => \@source_environment_cmds,
@@ -257,7 +244,7 @@ sub analysis_salmon_quant {
 
         # Read 1
         my $insample_dir_fastqc_path_read_one =
-          catfile( $insample_directory, $infiles_ref->[$paired_end_tracker] );
+          catfile( $insample_directory, $infiles[$paired_end_tracker] );
         migrate_file(
             {
                 FILEHANDLE   => $FILEHANDLE,
@@ -271,7 +258,7 @@ sub analysis_salmon_quant {
 
             my $insample_dir_fastqc_path_read_two =
               catfile( $insample_directory,
-                $infiles_ref->[ $paired_end_tracker + 1 ] );
+                $infiles[ $paired_end_tracker + 1 ] );
 
             # Read 2
             migrate_file(
@@ -291,7 +278,7 @@ sub analysis_salmon_quant {
 
         ## Infile(s)
         my @fastq_files =
-          ( catfile( $temp_directory, $infiles_ref->[$paired_end_tracker] ) );
+          ( catfile( $temp_directory, $infiles[$paired_end_tracker] ) );
 
         # If second read direction is present
         if ( $sequence_run_mode eq q{paired-end} ) {
@@ -299,8 +286,9 @@ sub analysis_salmon_quant {
             # Increment to collect correct read 2 from %infile
             $paired_end_tracker = $paired_end_tracker + 1;
             push @fastq_files,
-              catfile( $temp_directory, $infiles_ref->[$paired_end_tracker] );
-            catfile( $temp_directory, $infiles_ref->[$paired_end_tracker] );
+              catfile( $temp_directory, $infiles[$paired_end_tracker] );
+
+            #catfile( $temp_directory, $infiles[$paired_end_tracker] );
         }
         my $referencefile_dir_path = $active_parameter_href->{reference_dir};
 

--- a/lib/MIP/Recipes/Analysis/Salmon_quant.pm
+++ b/lib/MIP/Recipes/Analysis/Salmon_quant.pm
@@ -41,7 +41,6 @@ sub analysis_salmon_quant {
 ## Arguments: $active_parameter_href   => Active parameters for this analysis hash {REF}
 ##          : $family_id               => Family id
 ##          : $file_info_href          => File_info hash {REF}
-##          : $indir_path_href         => Indirectories path(s) hash {REF}
 ##          : $infile_lane_prefix_href => Infile(s) without the ".ending" {REF}
 ##          : $job_id_href             => Job id hash {REF}
 ##          : $parameter_href          => Parameter hash {REF}
@@ -55,7 +54,6 @@ sub analysis_salmon_quant {
     ## Flatten argument(s)
     my $active_parameter_href;
     my $file_info_href;
-    my $indir_path_href;
     my $infile_lane_prefix_href;
     my $job_id_href;
     my $parameter_href;
@@ -85,13 +83,6 @@ sub analysis_salmon_quant {
             defined     => 1,
             required    => 1,
             store       => \$file_info_href,
-            strict_type => 1,
-        },
-        indir_path_href => {
-            default     => {},
-            defined     => 1,
-            required    => 1,
-            store       => \$indir_path_href,
             strict_type => 1,
         },
         infile_lane_prefix_href => {
@@ -179,7 +170,7 @@ sub analysis_salmon_quant {
     my @infiles = @{ $file_info_href->{$sample_id}{mip_infiles} };
 
     ## Directories
-    my $insample_directory  = $indir_path_href->{$sample_id};
+    my $insample_directory  = $file_info_href->{$sample_id}{mip_infiles_dir};
     my $outsample_directory = catdir( $active_parameter_href->{outdata_dir},
         $sample_id, $active_parameter_href->{outaligner_dir} );
 

--- a/lib/MIP/Recipes/Analysis/Samtools_subsample_mt.pm
+++ b/lib/MIP/Recipes/Analysis/Samtools_subsample_mt.pm
@@ -46,7 +46,6 @@ sub analysis_samtools_subsample_mt {
 ## Arguments: $active_parameter_href   => Active parameters for this analysis hash {REF}
 ##          : $family_id               => Family id
 ##          : $file_info_href          => File_info hash {REF}
-##          : $indir_path_href         => Indirectories path(s) hash {REF}
 ##          : $infile_lane_prefix_href => Infile(s) without the ".ending" {REF}
 ##          : $job_id_href             => Job id hash {REF}
 ##          : $parameter_href          => Parameter hash {REF}
@@ -59,7 +58,6 @@ sub analysis_samtools_subsample_mt {
     ## Flatten argument(s)
     my $active_parameter_href;
     my $file_info_href;
-    my $indir_path_href;
     my $infile_lane_prefix_href;
     my $job_id_href;
     my $parameter_href;
@@ -88,13 +86,6 @@ sub analysis_samtools_subsample_mt {
             defined     => 1,
             required    => 1,
             store       => \$file_info_href,
-            strict_type => 1,
-        },
-        indir_path_href => {
-            default     => {},
-            defined     => 1,
-            required    => 1,
-            store       => \$indir_path_href,
             strict_type => 1,
         },
         infile_lane_prefix_href => {
@@ -170,7 +161,9 @@ sub analysis_samtools_subsample_mt {
     # Create anonymous filehandle
     my $FILEHANDLE = IO::Handle->new();
 
-    my $insample_directory  = $indir_path_href->{$sample_id};
+    ## Assign directories
+    my $insample_directory = catdir( $active_parameter_href->{outdata_dir},
+        $sample_id, $active_parameter_href->{outaligner_dir} );
     my $outsample_directory = catdir( $active_parameter_href->{outdata_dir},
         $sample_id, $active_parameter_href->{outaligner_dir} );
 

--- a/lib/MIP/Recipes/Analysis/Snpeff.pm
+++ b/lib/MIP/Recipes/Analysis/Snpeff.pm
@@ -21,7 +21,7 @@ BEGIN {
     use base qw{ Exporter };
 
     # Set the version for version checking
-    our $VERSION = 1.00;
+    our $VERSION = 1.01;
 
     # Functions and variables which can be optionally exported
     our @EXPORT_OK = qw{ analysis_snpeff analysis_snpeff_rio };
@@ -45,11 +45,9 @@ sub analysis_snpeff {
 ##          : $family_id               => Family id
 ##          : $file_info_href          => File_info hash {REF
 ##          : $file_path               => File path
-##          : $infamily_directory      => In family directory
 ##          : $infile_lane_prefix_href => Infile(s) without the ".ending" {REF}
 ##          : $job_id_href             => Job id hash {REF}
 ##          : $outaligner_dir          => Outaligner_dir used in the analysis
-##          : $outfamily_directory     => Out family directory
 ##          : $parameter_href          => Parameter hash {REF}
 ##          : $program_info_path       => The program info path
 ##          : $program_name            => Program name
@@ -62,10 +60,8 @@ sub analysis_snpeff {
     my $active_parameter_href;
     my $file_info_href;
     my $file_path;
-    my $infamily_directory;
     my $infile_lane_prefix_href;
     my $job_id_href;
-    my $outfamily_directory;
     my $parameter_href;
     my $program_info_path;
     my $program_name;
@@ -80,90 +76,78 @@ sub analysis_snpeff {
 
     my $tmpl = {
         active_parameter_href => {
-            required    => 1,
-            defined     => 1,
             default     => {},
-            strict_type => 1,
+            defined     => 1,
+            required    => 1,
             store       => \$active_parameter_href,
+            strict_type => 1,
         },
         call_type =>
-          { default => q{BOTH}, strict_type => 1, store => \$call_type, },
+          { default => q{BOTH}, store => \$call_type, strict_type => 1, },
         family_id => {
             default     => $arg_href->{active_parameter_href}{family_id},
-            strict_type => 1,
             store       => \$family_id,
+            strict_type => 1,
         },
         file_info_href => {
-            required    => 1,
-            defined     => 1,
             default     => {},
-            strict_type => 1,
+            defined     => 1,
+            required    => 1,
             store       => \$file_info_href,
-        },
-        file_path          => { strict_type => 1, store => \$file_path, },
-        infamily_directory => {
-            required    => 1,
-            defined     => 1,
             strict_type => 1,
-            store       => \$infamily_directory,
         },
+        file_path               => { store => \$file_path, strict_type => 1, },
         infile_lane_prefix_href => {
-            required    => 1,
-            defined     => 1,
             default     => {},
-            strict_type => 1,
+            defined     => 1,
+            required    => 1,
             store       => \$infile_lane_prefix_href,
+            strict_type => 1,
         },
         job_id_href => {
-            required    => 1,
-            defined     => 1,
             default     => {},
-            strict_type => 1,
+            defined     => 1,
+            required    => 1,
             store       => \$job_id_href,
+            strict_type => 1,
         },
         outaligner_dir => {
             default     => $arg_href->{active_parameter_href}{outaligner_dir},
-            strict_type => 1,
             store       => \$outaligner_dir,
-        },
-        outfamily_directory => {
-            required    => 1,
-            defined     => 1,
             strict_type => 1,
-            store       => \$outfamily_directory,
         },
         parameter_href => {
-            required    => 1,
-            defined     => 1,
             default     => {},
-            strict_type => 1,
+            defined     => 1,
+            required    => 1,
             store       => \$parameter_href,
+            strict_type => 1,
         },
         program_info_path =>
-          { strict_type => 1, store => \$program_info_path, },
+          { store => \$program_info_path, strict_type => 1, },
         program_name => {
-            required    => 1,
             defined     => 1,
-            strict_type => 1,
+            required    => 1,
             store       => \$program_name,
+            strict_type => 1,
         },
         sample_info_href => {
-            required    => 1,
-            defined     => 1,
             default     => {},
-            strict_type => 1,
+            defined     => 1,
+            required    => 1,
             store       => \$sample_info_href,
+            strict_type => 1,
         },
         temp_directory => {
             default     => $arg_href->{active_parameter_href}{temp_directory},
-            strict_type => 1,
             store       => \$temp_directory,
+            strict_type => 1,
         },
         xargs_file_counter => {
-            default     => 0,
             allow       => qr/ ^\d+$ /xsm,
-            strict_type => 1,
+            default     => 0,
             store       => \$xargs_file_counter,
+            strict_type => 1,
         },
     };
 
@@ -190,18 +174,19 @@ sub analysis_snpeff {
     ## Retrieve logger object
     my $log = Log::Log4perl->get_logger(q{MIP});
 
-    ## Set MIP program name
+    ## Set program mode
     my $program_mode = $active_parameter_href->{$program_name};
 
     ## Unpack parameters
     my $job_id_chain = $parameter_href->{$program_name}{chain};
 
-    my ( $core_number, $time, @source_environment_cmds ) = get_module_parameters(
+    my ( $core_number, $time, @source_environment_cmds ) =
+      get_module_parameters(
         {
             active_parameter_href => $active_parameter_href,
-            program_name      => $program_name,
+            program_name          => $program_name,
         }
-    );
+      );
 
     my $config_file_path =
       catfile( $active_parameter_href->{snpeff_path}, q{snpEff.config} );
@@ -238,6 +223,11 @@ sub analysis_snpeff {
         }
     );
 
+    ## Assign directories
+    my $infamily_directory = catdir( $active_parameter_href->{outdata_dir},
+        $family_id, $outaligner_dir );
+    my $outfamily_directory = $infamily_directory;
+
     # Used downstream
     $parameter_href->{$program_name}{indirectory} = $outfamily_directory;
 
@@ -266,7 +256,7 @@ sub analysis_snpeff {
 
     my $outfile_suffix = set_file_suffix(
         {
-            file_suffix => $parameter_href->{$program_name}{outfile_suffix},
+            file_suffix    => $parameter_href->{$program_name}{outfile_suffix},
             job_id_chain   => $job_id_chain,
             parameter_href => $parameter_href,
             suffix_key     => q{variant_file_suffix},
@@ -659,15 +649,14 @@ sub analysis_snpeff_rio {
 ##          : $FILEHANDLE              => Filehandle to write to
 ##          : $file_info_href          => File_info hash {REF
 ##          : $file_path               => File path
-##          : $infamily_directory      => In family directory
 ##          : $infile_lane_prefix_href => Infile(s) without the ".ending" {REF}
 ##          : $job_id_href             => Job id hash {REF}
 ##          : $outaligner_dir          => Outaligner_dir used in the analysis
-##          : $outfamily_directory     => Out family directory
 ##          : $parameter_href          => Parameter hash {REF}
 ##          : $program_info_path       => The program info path
 ##          : $program_name            => Program name
 ##          : $sample_info_href        => Info on samples and family hash {REF}
+##          : $stderr_path             => Stderr path of the block script
 ##          : $temp_directory          => Temporary directory
 
     my ($arg_href) = @_;
@@ -677,14 +666,13 @@ sub analysis_snpeff_rio {
     my $FILEHANDLE;
     my $file_info_href;
     my $file_path;
-    my $infamily_directory;
     my $infile_lane_prefix_href;
     my $job_id_href;
-    my $outfamily_directory;
     my $parameter_href;
     my $program_info_path;
     my $program_name;
     my $sample_info_href;
+    my $stderr_path;
 
     ## Default(s)
     my $call_type;
@@ -695,91 +683,85 @@ sub analysis_snpeff_rio {
 
     my $tmpl = {
         active_parameter_href => {
-            required    => 1,
-            defined     => 1,
             default     => {},
-            strict_type => 1,
+            defined     => 1,
+            required    => 1,
             store       => \$active_parameter_href,
+            strict_type => 1,
         },
         call_type =>
-          { default => q{BOTH}, strict_type => 1, store => \$call_type, },
+          { default => q{BOTH}, store => \$call_type, strict_type => 1, },
         family_id => {
             default     => $arg_href->{active_parameter_href}{family_id},
-            strict_type => 1,
             store       => \$family_id,
+            strict_type => 1,
         },
         FILEHANDLE     => { required => 1, store => \$FILEHANDLE },
         file_info_href => {
-            required    => 1,
-            defined     => 1,
             default     => {},
-            strict_type => 1,
+            defined     => 1,
+            required    => 1,
             store       => \$file_info_href,
-        },
-        file_path          => { strict_type => 1, store => \$file_path, },
-        infamily_directory => {
-            required    => 1,
-            defined     => 1,
             strict_type => 1,
-            store       => \$infamily_directory,
         },
+        file_path               => { store => \$file_path, strict_type => 1, },
         infile_lane_prefix_href => {
-            required    => 1,
-            defined     => 1,
             default     => {},
-            strict_type => 1,
+            defined     => 1,
+            required    => 1,
             store       => \$infile_lane_prefix_href,
+            strict_type => 1,
         },
         job_id_href => {
-            required    => 1,
-            defined     => 1,
             default     => {},
-            strict_type => 1,
+            defined     => 1,
+            required    => 1,
             store       => \$job_id_href,
+            strict_type => 1,
         },
         outaligner_dir => {
             default     => $arg_href->{active_parameter_href}{outaligner_dir},
-            strict_type => 1,
             store       => \$outaligner_dir,
-        },
-        outfamily_directory => {
-            required    => 1,
-            defined     => 1,
             strict_type => 1,
-            store       => \$outfamily_directory,
         },
         parameter_href => {
-            required    => 1,
-            defined     => 1,
             default     => {},
-            strict_type => 1,
+            defined     => 1,
+            required    => 1,
             store       => \$parameter_href,
+            strict_type => 1,
         },
         program_info_path =>
-          { strict_type => 1, store => \$program_info_path, },
+          { store => \$program_info_path, strict_type => 1, },
         program_name => {
-            required    => 1,
             defined     => 1,
-            strict_type => 1,
+            required    => 1,
             store       => \$program_name,
+            strict_type => 1,
         },
         sample_info_href => {
-            required    => 1,
-            defined     => 1,
             default     => {},
-            strict_type => 1,
+            defined     => 1,
+            required    => 1,
             store       => \$sample_info_href,
+            strict_type => 1,
+        },
+        stderr_path => {
+            defined     => 1,
+            required    => 1,
+            store       => \$stderr_path,
+            strict_type => 1,
         },
         temp_directory => {
             default     => $arg_href->{active_parameter_href}{temp_directory},
-            strict_type => 1,
             store       => \$temp_directory,
+            strict_type => 1,
         },
         xargs_file_counter => {
-            default     => 0,
             allow       => qr/ ^\d+$ /xsm,
-            strict_type => 1,
+            default     => 0,
             store       => \$xargs_file_counter,
+            strict_type => 1,
         },
     };
 
@@ -806,18 +788,19 @@ sub analysis_snpeff_rio {
     ## Retrieve logger object
     my $log = Log::Log4perl->get_logger(q{MIP});
 
-    ## Set MIP program name
+    ## Set program mode
     my $program_mode = $active_parameter_href->{$program_name};
 
     ## Unpack parameters
     my $job_id_chain = $parameter_href->{$program_name}{chain};
 
-    my ( $core_number, $time, @source_environment_cmds ) = get_module_parameters(
+    my ( $core_number, $time, @source_environment_cmds ) =
+      get_module_parameters(
         {
             active_parameter_href => $active_parameter_href,
-            program_name      => $program_name,
+            program_name          => $program_name,
         }
-    );
+      );
 
     my $config_file_path =
       catfile( $active_parameter_href->{snpeff_path}, q{snpEff.config} );
@@ -834,6 +817,11 @@ sub analysis_snpeff_rio {
             max_cores_per_node => $active_parameter_href->{max_cores_per_node},
         }
     );
+
+    ## Assign directories
+    my $infamily_directory = catdir( $active_parameter_href->{outdata_dir},
+        $family_id, $outaligner_dir );
+    my $outfamily_directory = $infamily_directory;
 
     # Used downstream
     $parameter_href->{$program_name}{indirectory} = $outfamily_directory;
@@ -863,7 +851,7 @@ sub analysis_snpeff_rio {
 
     my $outfile_suffix = set_file_suffix(
         {
-            file_suffix => $parameter_href->{$program_name}{outfile_suffix},
+            file_suffix    => $parameter_href->{$program_name}{outfile_suffix},
             job_id_chain   => $job_id_chain,
             parameter_href => $parameter_href,
             suffix_key     => q{variant_file_suffix},

--- a/lib/MIP/Recipes/Analysis/Star_aln.pm
+++ b/lib/MIP/Recipes/Analysis/Star_aln.pm
@@ -41,7 +41,6 @@ sub analysis_star_aln {
 ## Arguments: $active_parameter_href   => Active parameters for this analysis hash {REF}
 ##          : $family_id               => Family id
 ##          : $file_info_href          => File_info hash {REF}
-##          : $indir_path_href         => Indirectories path(s) hash {REF}
 ##          : $infile_lane_prefix_href => Infile(s) without the ".ending" {REF}
 ##          : $job_id_href             => Job id hash {REF}
 ##          : $parameter_href          => Parameter hash {REF}
@@ -55,7 +54,6 @@ sub analysis_star_aln {
     ## Flatten argument(s)
     my $active_parameter_href;
     my $file_info_href;
-    my $indir_path_href;
     my $infile_lane_prefix_href;
     my $job_id_href;
     my $parameter_href;
@@ -85,13 +83,6 @@ sub analysis_star_aln {
             defined     => 1,
             required    => 1,
             store       => \$file_info_href,
-            strict_type => 1,
-        },
-        indir_path_href => {
-            default     => {},
-            defined     => 1,
-            required    => 1,
-            store       => \$indir_path_href,
             strict_type => 1,
         },
         infile_lane_prefix_href => {
@@ -181,7 +172,7 @@ sub analysis_star_aln {
     my @infiles = @{ $file_info_href->{$sample_id}{mip_infiles} };
 
     ## Assign directories
-    my $insample_directory  = $indir_path_href->{$sample_id};
+    my $insample_directory  = $file_info_href->{$sample_id}{mip_infiles_dir};
     my $outsample_directory = catdir( $active_parameter_href->{outdata_dir},
         $sample_id, $active_parameter_href->{outaligner_dir} );
 

--- a/lib/MIP/Recipes/Analysis/Star_aln.pm
+++ b/lib/MIP/Recipes/Analysis/Star_aln.pm
@@ -21,7 +21,7 @@ BEGIN {
     use base qw{ Exporter };
 
     # Set the version for version checking
-    our $VERSION = 1.01;
+    our $VERSION = 1.02;
 
     # Functions and variables which can be optionally exported
     our @EXPORT_OK = qw{ analysis_star_aln };
@@ -41,12 +41,9 @@ sub analysis_star_aln {
 ## Arguments: $active_parameter_href   => Active parameters for this analysis hash {REF}
 ##          : $family_id               => Family id
 ##          : $file_info_href          => File_info hash {REF}
-##          : $infiles_ref             => Infiles hash {REF}
+##          : $indir_path_href         => Indirectories path(s) hash {REF}
 ##          : $infile_lane_prefix_href => Infile(s) without the ".ending" {REF}
-##          : $insample_directory      => In sample directory
 ##          : $job_id_href             => Job id hash {REF}
-##          : $outaligner_dir          => Outaligner_dir used in the analysis
-##          : $outsample_directory     => Out sample directory
 ##          : $parameter_href          => Parameter hash {REF}
 ##          : $program_name            => Program name
 ##          : $sample_id               => Sample id
@@ -58,11 +55,9 @@ sub analysis_star_aln {
     ## Flatten argument(s)
     my $active_parameter_href;
     my $file_info_href;
-    my $infiles_ref;
+    my $indir_path_href;
     my $infile_lane_prefix_href;
-    my $insample_directory;
     my $job_id_href;
-    my $outsample_directory;
     my $parameter_href;
     my $program_name;
     my $sample_id;
@@ -70,7 +65,6 @@ sub analysis_star_aln {
 
     ## Default(s)
     my $family_id;
-    my $outaligner_dir;
     my $temp_directory;
 
     my $tmpl = {
@@ -93,11 +87,11 @@ sub analysis_star_aln {
             store       => \$file_info_href,
             strict_type => 1,
         },
-        infiles_ref => {
-            default     => [],
+        indir_path_href => {
+            default     => {},
             defined     => 1,
             required    => 1,
-            store       => \$infiles_ref,
+            store       => \$indir_path_href,
             strict_type => 1,
         },
         infile_lane_prefix_href => {
@@ -107,28 +101,11 @@ sub analysis_star_aln {
             store       => \$infile_lane_prefix_href,
             strict_type => 1,
         },
-        insample_directory => {
-            defined     => 1,
-            required    => 1,
-            store       => \$insample_directory,
-            strict_type => 1,
-        },
         job_id_href => {
             default     => {},
             defined     => 1,
             required    => 1,
             store       => \$job_id_href,
-            strict_type => 1,
-        },
-        outaligner_dir => {
-            default     => $arg_href->{active_parameter_href}{outaligner_dir},
-            store       => \$outaligner_dir,
-            strict_type => 1,
-        },
-        outsample_directory => {
-            defined     => 1,
-            required    => 1,
-            store       => \$outsample_directory,
             strict_type => 1,
         },
         parameter_href => {
@@ -182,22 +159,31 @@ sub analysis_star_aln {
     ## Retrieve logger object
     my $log = Log::Log4perl->get_logger(q{MIP});
 
-    ## Set MIP program name
+    ## Set MIP program mode
     my $program_mode = $active_parameter_href->{$program_name};
 
-    ## Unpack parameters
-    my $job_id_chain = $parameter_href->{$program_name}{chain};
     my ( $core_number, $time, @source_environment_cmds ) =
       get_module_parameters(
         {
             active_parameter_href => $active_parameter_href,
-            program_name      => $program_name,
+            program_name          => $program_name,
         }
       );
 
     ## Filehandles
     # Create anonymous filehandle
     my $FILEHANDLE = IO::Handle->new();
+
+    ## Assign job_id_chain
+    my $job_id_chain = $parameter_href->{$program_name}{chain};
+
+    ## Get infiles
+    my @infiles = @{ $file_info_href->{$sample_id}{mip_infiles} };
+
+    ## Assign directories
+    my $insample_directory  = $indir_path_href->{$sample_id};
+    my $outsample_directory = catdir( $active_parameter_href->{outdata_dir},
+        $sample_id, $active_parameter_href->{outaligner_dir} );
 
     ## Assign file_tags
     my $outfile_tag =
@@ -207,7 +193,7 @@ sub analysis_star_aln {
     ## Set file suffix for next module within jobid chain
     my $outfile_suffix = set_file_suffix(
         {
-            file_suffix => $parameter_href->{$program_name}{outfile_suffix},
+            file_suffix    => $parameter_href->{$program_name}{outfile_suffix},
             job_id_chain   => $job_id_chain,
             parameter_href => $parameter_href,
             suffix_key     => q{alignment_file_suffix},
@@ -240,13 +226,14 @@ sub analysis_star_aln {
         ## Creates program directories (info & programData & programScript), program script filenames and writes sbatch header
         my ( $file_name, $program_info_path ) = setup_script(
             {
-                active_parameter_href           => $active_parameter_href,
-                core_number                     => $core_number,
-                directory_id                    => $sample_id,
-                FILEHANDLE                      => $FILEHANDLE,
-                job_id_href                     => $job_id_href,
-                log                             => $log,
-                program_directory               => lc $outaligner_dir,
+                active_parameter_href => $active_parameter_href,
+                core_number           => $core_number,
+                directory_id          => $sample_id,
+                FILEHANDLE            => $FILEHANDLE,
+                job_id_href           => $job_id_href,
+                log                   => $log,
+                program_directory =>
+                  lc $active_parameter_href->{outaligner_dir},
                 program_name                    => $program_name,
                 process_time                    => $time,
                 source_environment_commands_ref => \@source_environment_cmds,
@@ -259,7 +246,7 @@ sub analysis_star_aln {
 
         # Read 1
         my $insample_dir_fastqc_path_read_one =
-          catfile( $insample_directory, $infiles_ref->[$paired_end_tracker] );
+          catfile( $insample_directory, $infiles[$paired_end_tracker] );
         migrate_file(
             {
                 FILEHANDLE   => $FILEHANDLE,
@@ -273,7 +260,7 @@ sub analysis_star_aln {
 
             my $insample_dir_fastqc_path_read_two =
               catfile( $insample_directory,
-                $infiles_ref->[ $paired_end_tracker + 1 ] );
+                $infiles[ $paired_end_tracker + 1 ] );
 
             # Read 2
             migrate_file(
@@ -292,7 +279,7 @@ sub analysis_star_aln {
         ### Get parameters
         ## Infile(s)
         my @fastq_files =
-          ( catfile( $temp_directory, $infiles_ref->[$paired_end_tracker] ) );
+          ( catfile( $temp_directory, $infiles[$paired_end_tracker] ) );
 
         # If second read direction is present
         if ( $sequence_run_mode eq q{paired-end} ) {
@@ -300,8 +287,8 @@ sub analysis_star_aln {
             # Increment to collect correct read 2 from %infile
             $paired_end_tracker++;
             push @fastq_files,
-              catfile( $temp_directory, $infiles_ref->[$paired_end_tracker] );
-            catfile( $temp_directory, $infiles_ref->[$paired_end_tracker] );
+              catfile( $temp_directory, $infiles[$paired_end_tracker] );
+            catfile( $temp_directory, $infiles[$paired_end_tracker] );
         }
         my $referencefile_dir_path = $active_parameter_href->{reference_dir};
 

--- a/lib/MIP/Recipes/Analysis/Star_fusion.pm
+++ b/lib/MIP/Recipes/Analysis/Star_fusion.pm
@@ -44,7 +44,6 @@ sub analysis_star_fusion {
 ##          : $family_id               => Family id
 ##          : $file_info_href          => File_info hash {REF}
 ##          : $genome_lib_dir_path     => Path to the directory containing the genome library
-##          : indir_path_href          => Indirectories path(s) hash {REF}
 ##          : $infile_lane_prefix_href => Infile(s) without the ".ending" {REF}
 ##          : $job_id_href             => Job id hash {REF}
 ##          : $outaligner_dir          => Outaligner_dir used in the analysis
@@ -60,7 +59,6 @@ sub analysis_star_fusion {
     my $active_parameter_href;
     my $file_info_href;
     my $genome_lib_dir_path;
-    my $indir_path_href;
     my $infile_lane_prefix_href;
     my $job_id_href;
     my $parameter_href;
@@ -95,13 +93,6 @@ sub analysis_star_fusion {
             defined     => 1,
             required    => 1,
             store       => \$file_info_href,
-            strict_type => 1,
-        },
-        indir_path_href => {
-            default     => {},
-            defined     => 1,
-            required    => 1,
-            store       => \$indir_path_href,
             strict_type => 1,
         },
         infile_lane_prefix_href => {
@@ -190,7 +181,7 @@ sub analysis_star_fusion {
     my @infiles = @{ $file_info_href->{$sample_id}{mip_infiles} };
 
     ## Directories
-    my $insample_directory  = $indir_path_href->{$sample_id};
+    my $insample_directory  = $file_info_href->{$sample_id}{mip_infiles_dir};
     my $outsample_directory = catdir( $active_parameter_href->{outdata_dir},
         $sample_id, $active_parameter_href->{outaligner_dir} );
 

--- a/lib/MIP/Recipes/Analysis/Sv_combinevariantcallsets.pm
+++ b/lib/MIP/Recipes/Analysis/Sv_combinevariantcallsets.pm
@@ -185,7 +185,7 @@ sub analysis_sv_combinevariantcallsets {
       get_module_parameters(
         {
             active_parameter_href => $active_parameter_href,
-            program_name      => $program_name,
+            program_name          => $program_name,
         }
       );
 
@@ -217,6 +217,7 @@ sub analysis_sv_combinevariantcallsets {
     ## Assign directories
     my $outfamily_directory = catdir( $active_parameter_href->{outdata_dir},
         $family_id, $outaligner_dir );
+
     ## Used downstream
     $parameter_href->{$program_name}{indirectory} = $outfamily_directory;
 
@@ -237,7 +238,7 @@ sub analysis_sv_combinevariantcallsets {
     ## Set file suffix for next module within jobid chain
     my $outfile_suffix = set_file_suffix(
         {
-            file_suffix => $parameter_href->{$program_name}{outfile_suffix},
+            file_suffix    => $parameter_href->{$program_name}{outfile_suffix},
             job_id_chain   => $job_id_chain,
             parameter_href => $parameter_href,
             suffix_key     => q{variant_file_suffix},
@@ -469,7 +470,7 @@ sub analysis_sv_combinevariantcallsets {
         my @program_source_commands = get_program_parameters(
             {
                 active_parameter_href => $active_parameter_href,
-                program_name      => q{genmod},
+                program_name          => q{genmod},
             }
         );
 

--- a/lib/MIP/Recipes/Analysis/Tiddit.pm
+++ b/lib/MIP/Recipes/Analysis/Tiddit.pm
@@ -46,7 +46,6 @@ sub analysis_tiddit {
 ##          : $infile_lane_prefix_href => Infile(s) without the ".ending" {REF}
 ##          : $job_id_href             => Job id hash {REF}
 ##          : $outaligner_dir          => Outaligner directory used in the analysis
-##          : $outfamily_directory     => Out family directory
 ##          : $parameter_href          => Parameter hash {REF}
 ##          : $reference_dir           => MIP reference directory
 ##          : $sample_info_href        => Info on samples and family hash {REF}
@@ -59,7 +58,6 @@ sub analysis_tiddit {
     my $file_info_href;
     my $infile_lane_prefix_href;
     my $job_id_href;
-    my $outfamily_directory;
     my $parameter_href;
     my $program_name;
     my $sample_info_href;
@@ -115,12 +113,6 @@ sub analysis_tiddit {
             store       => \$outaligner_dir,
             strict_type => 1,
         },
-        outfamily_directory => {
-            defined     => 1,
-            required    => 1,
-            store       => \$outfamily_directory,
-            strict_type => 1,
-        },
         parameter_href => {
             default     => {},
             defined     => 1,
@@ -171,7 +163,7 @@ sub analysis_tiddit {
     ## Retrieve logger object
     my $log = Log::Log4perl->get_logger(q{MIP});
 
-    ## Set MIP program name
+    ## Set program name
     my $program_mode = $active_parameter_href->{$program_name};
 
     ## Alias
@@ -181,12 +173,13 @@ sub analysis_tiddit {
       scalar( @{ $active_parameter_href->{sample_ids} } );
     my $program_outdirectory_name =
       $parameter_href->{$program_name}{outdir_name};
-    my ( $core_number, $time, @source_environment_cmds ) = get_module_parameters(
+    my ( $core_number, $time, @source_environment_cmds ) =
+      get_module_parameters(
         {
             active_parameter_href => $active_parameter_href,
-            program_name      => $program_name,
+            program_name          => $program_name,
         }
-    );
+      );
 
     ## Filehandles
     # Create anonymous filehandle
@@ -218,6 +211,14 @@ sub analysis_tiddit {
         }
     );
 
+## Assign directories
+    my $outfamily_directory = catfile(
+        $active_parameter_href->{outdata_dir},
+        $active_parameter_href->{family_id},
+        $active_parameter_href->{outaligner_dir},
+        $program_outdirectory_name,
+    );
+
     # Used downstream
     $parameter_href->{$program_name}{indirectory} = $outfamily_directory;
 
@@ -240,7 +241,7 @@ sub analysis_tiddit {
     ## Set file suffix for next module within jobid chain
     my $outfile_suffix = set_file_suffix(
         {
-            file_suffix => $parameter_href->{$program_name}{outfile_suffix},
+            file_suffix    => $parameter_href->{$program_name}{outfile_suffix},
             job_id_chain   => $job_id_chain,
             parameter_href => $parameter_href,
             suffix_key     => q{variant_file_suffix},
@@ -530,12 +531,13 @@ sub analysis_tiddit_coverage {
       scalar( @{ $active_parameter_href->{sample_ids} } );
     my $program_outdirectory_name =
       $parameter_href->{$program_name}{outdir_name};
-    my ( $core_number, $time, @source_environment_cmds ) = get_module_parameters(
+    my ( $core_number, $time, @source_environment_cmds ) =
+      get_module_parameters(
         {
             active_parameter_href => $active_parameter_href,
-            program_name      => $program_name,
+            program_name          => $program_name,
         }
-    );
+      );
 
     ## Filehandles
     # Create anonymous filehandle

--- a/lib/MIP/Recipes/Analysis/Variant_integrity.pm
+++ b/lib/MIP/Recipes/Analysis/Variant_integrity.pm
@@ -21,7 +21,7 @@ BEGIN {
     use base qw{ Exporter };
 
     # Set the version for version checking
-    our $VERSION = 1.04;
+    our $VERSION = 1.05;
 
     # Functions and variables which can be optionally exported
     our @EXPORT_OK = qw{ analysis_variant_integrity };
@@ -43,11 +43,9 @@ sub analysis_variant_integrity {
 ##          : $call_type               => The variant call type
 ##          : $family_id               => Family id
 ##          : $file_info_href          => The file_info hash {REF}
-##          : $infamily_directory      => In family directory
 ##          : $infile_lane_prefix_href => Infile(s) without the ".ending" {REF}
 ##          : $job_id_href             => Job id hash {REF}
 ##          : $outaligner_dir          => Outaligner_dir used in the analysis
-##          : $outfamily_directory     => Out family directory
 ##          : $parameter_href          => Parameter hash {REF}
 ##          : $program_name            => Program name
 ##          : $sample_info_href        => Info on samples and family hash {REF}
@@ -58,10 +56,8 @@ sub analysis_variant_integrity {
     ## Flatten argument(s)
     my $active_parameter_href;
     my $file_info_href;
-    my $infamily_directory;
     my $infile_lane_prefix_href;
     my $job_id_href;
-    my $outfamily_directory;
     my $parameter_href;
     my $program_name;
     my $sample_info_href;
@@ -94,12 +90,6 @@ sub analysis_variant_integrity {
             store       => \$file_info_href,
             strict_type => 1,
         },
-        infamily_directory => {
-            defined     => 1,
-            required    => 1,
-            store       => \$infamily_directory,
-            strict_type => 1,
-        },
         infile_lane_prefix_href => {
             default     => {},
             defined     => 1,
@@ -117,12 +107,6 @@ sub analysis_variant_integrity {
         outaligner_dir => {
             default     => $arg_href->{active_parameter_href}{outaligner_dir},
             store       => \$outaligner_dir,
-            strict_type => 1,
-        },
-        outfamily_directory => {
-            defined     => 1,
-            required    => 1,
-            store       => \$outfamily_directory,
             strict_type => 1,
         },
         parameter_href => {
@@ -168,17 +152,18 @@ sub analysis_variant_integrity {
     ## Retrieve logger object
     my $log = Log::Log4perl->get_logger(q{MIP});
 
-    ## Set MIP program name
+    ## Set program mode
     my $program_mode = $active_parameter_href->{$program_name};
 
     ## Alias
     my $job_id_chain = $parameter_href->{$program_name}{chain};
-    my ( $core_number, $time, @source_environment_cmds ) = get_module_parameters(
+    my ( $core_number, $time, @source_environment_cmds ) =
+      get_module_parameters(
         {
             active_parameter_href => $active_parameter_href,
-            program_name      => $program_name,
+            program_name          => $program_name,
         }
-    );
+      );
 
     ## Filehandles
     # Create anonymous filehandle
@@ -215,6 +200,11 @@ sub analysis_variant_integrity {
     ## Assign Directories
     my $outfamily_file_directory =
       catfile( $active_parameter_href->{outdata_dir}, $family_id );
+
+    my $infamily_directory = catdir( $active_parameter_href->{outdata_dir},
+        $family_id, $outaligner_dir );
+    my $outfamily_directory = catfile( $active_parameter_href->{outdata_dir},
+        $family_id, $outaligner_dir, q{casecheck}, $program_name );
 
     ## Assign file_tags
     my $infile_tag =

--- a/lib/MIP/Recipes/Analysis/Variantannotationblock.pm
+++ b/lib/MIP/Recipes/Analysis/Variantannotationblock.pm
@@ -174,12 +174,12 @@ sub analysis_variantannotationblock {
 
     check( $tmpl, $arg_href, 1 ) or croak q{Could not parse arguments!};
 
+    use MIP::Get::Parameter qw{ get_module_parameters };
     use MIP::Script::Setup_script qw{ setup_script };
 
     ## Constants
     Readonly my $PROCESS_TIME => 80;
-
-    my $core_number = $active_parameter_href->{max_cores_per_node};
+    Readonly my $CORE_NUMBER  => $active_parameter_href->{max_cores_per_node};
 
     ## Filehandles
     # Create anonymous filehandle
@@ -198,18 +198,26 @@ sub analysis_variantannotationblock {
               . $CLOSE_BRACKET );
     }
 
+    my ( $c_n, $t, @source_environment_cmds ) = get_module_parameters(
+        {
+            active_parameter_href => $active_parameter_href,
+            program_name          => $program_name,
+        }
+    );
+
     ## Creates program directories (info & programData & programScript), program script filenames and writes sbatch header
     my ( $file_path, $program_info_path ) = setup_script(
         {
-            active_parameter_href => $active_parameter_href,
-            core_number           => $core_number,
-            directory_id          => $family_id,
-            FILEHANDLE            => $FILEHANDLE,
-            job_id_href           => $job_id_href,
-            log                   => $log,
-            process_time          => $PROCESS_TIME,
-            program_directory     => $outaligner_dir,
-            program_name          => $program_name,
+            active_parameter_href           => $active_parameter_href,
+            core_number                     => $CORE_NUMBER,
+            directory_id                    => $family_id,
+            FILEHANDLE                      => $FILEHANDLE,
+            job_id_href                     => $job_id_href,
+            log                             => $log,
+            process_time                    => $PROCESS_TIME,
+            program_directory               => $outaligner_dir,
+            program_name                    => $program_name,
+            source_environment_commands_ref => \@source_environment_cmds,
         }
     );
 

--- a/lib/MIP/Recipes/Analysis/Variantannotationblock.pm
+++ b/lib/MIP/Recipes/Analysis/Variantannotationblock.pm
@@ -21,7 +21,7 @@ BEGIN {
     use base qw{ Exporter };
 
     # Set the version for version checking
-    our $VERSION = 1.00;
+    our $VERSION = 1.01;
 
     # Functions and variables which can be optionally exported
     our @EXPORT_OK = qw{ analysis_variantannotationblock };
@@ -29,10 +29,12 @@ BEGIN {
 }
 
 ## Constants
-Readonly my $DOT        => q{.};
-Readonly my $NEWLINE    => qq{\n};
-Readonly my $TAB        => qq{\t};
-Readonly my $UNDERSCORE => q{_};
+Readonly my $CLOSE_BRACKET => q{]};
+Readonly my $DOT           => q{.};
+Readonly my $NEWLINE       => qq{\n};
+Readonly my $OPEN_BRACKET  => q{[};
+Readonly my $TAB           => qq{\t};
+Readonly my $UNDERSCORE    => q{_};
 
 sub analysis_variantannotationblock {
 
@@ -45,10 +47,13 @@ sub analysis_variantannotationblock {
 ##          : $infile_lane_prefix_href => Infile(s) without the ".ending" {REF}
 ##          : $job_id_href             => Job id hash {REF}
 ##          : $outaligner_dir          => Outaligner dir used in the analysis
+##          : $order_programs_ref      => Order of programs
 ##          : $parameter_href          => Parameter hash {REF}
 ##          : $program_name            => Program name
+##          : $program_name_href       => Program name hash for log messages {REF}
 ##          : $sample_info_href        => Info on samples and family hash {REF}
 ##          : $xargs_file_counter      => The xargs file counter
+##          : $varann_ar_href          => Analysis recipes for variant annotation block
 
     my ($arg_href) = @_;
 
@@ -57,9 +62,12 @@ sub analysis_variantannotationblock {
     my $file_info_href;
     my $infile_lane_prefix_href;
     my $job_id_href;
+    my $order_programs_ref;
     my $parameter_href;
     my $program_name;
+    my $program_name_href;
     my $sample_info_href;
+    my $varann_ar_href;
 
     ## Default(s)
     my $call_type;
@@ -69,70 +77,91 @@ sub analysis_variantannotationblock {
 
     my $tmpl = {
         active_parameter_href => {
-            required    => 1,
-            defined     => 1,
             default     => {},
-            strict_type => 1,
+            defined     => 1,
+            required    => 1,
             store       => \$active_parameter_href,
+            strict_type => 1,
         },
         call_type =>
-          { default => q{BOTH}, strict_type => 1, store => \$call_type, },
+          { default => q{BOTH}, store => \$call_type, strict_type => 1, },
         family_id => {
             default     => $arg_href->{active_parameter_href}{family_id},
-            strict_type => 1,
             store       => \$family_id,
+            strict_type => 1,
         },
         file_info_href => {
-            required    => 1,
-            defined     => 1,
             default     => {},
-            strict_type => 1,
+            defined     => 1,
+            required    => 1,
             store       => \$file_info_href,
+            strict_type => 1,
         },
         infile_lane_prefix_href => {
-            required    => 1,
-            defined     => 1,
             default     => {},
-            strict_type => 1,
+            defined     => 1,
+            required    => 1,
             store       => \$infile_lane_prefix_href,
+            strict_type => 1,
         },
         job_id_href => {
-            required    => 1,
-            defined     => 1,
             default     => {},
-            strict_type => 1,
+            defined     => 1,
+            required    => 1,
             store       => \$job_id_href,
+            strict_type => 1,
         },
         outaligner_dir => {
             default     => $arg_href->{active_parameter_href}{outaligner_dir},
-            strict_type => 1,
             store       => \$outaligner_dir,
+            strict_type => 1,
+        },
+        order_programs_ref => {
+            default     => [],
+            defined     => 1,
+            required    => 1,
+            store       => \$order_programs_ref,
+            strict_type => 1,
         },
         parameter_href => {
-            required    => 1,
-            defined     => 1,
             default     => {},
-            strict_type => 1,
+            defined     => 1,
+            required    => 1,
             store       => \$parameter_href,
+            strict_type => 1,
         },
         program_name => {
-            required    => 1,
             defined     => 1,
-            strict_type => 1,
+            required    => 1,
             store       => \$program_name,
+            strict_type => 1,
+        },
+        program_name_href => {
+            default     => {},
+            defined     => 1,
+            required    => 1,
+            store       => \$program_name_href,
+            strict_type => 1,
         },
         sample_info_href => {
-            required    => 1,
-            defined     => 1,
             default     => {},
-            strict_type => 1,
+            defined     => 1,
+            required    => 1,
             store       => \$sample_info_href,
+            strict_type => 1,
+        },
+        varann_ar_href => {
+            default     => {},
+            defined     => 1,
+            required    => 1,
+            store       => \$varann_ar_href,
+            strict_type => 1,
         },
         xargs_file_counter => {
-            default     => 0,
             allow       => qr/ ^\d+$ /xsm,
-            strict_type => 1,
+            default     => 0,
             store       => \$xargs_file_counter,
+            strict_type => 1,
         },
     };
 
@@ -140,17 +169,8 @@ sub analysis_variantannotationblock {
 
     use MIP::Recipes::Analysis::Endvariantannotationblock
       qw{ analysis_endvariantannotationblock_rio };
-    use MIP::Recipes::Analysis::Frequency_filter
-      qw{ analysis_frequency_filter_rio };
-    use MIP::Recipes::Analysis::Mip_vcfparser qw{ analysis_mip_vcfparser_rio };
-    use MIP::Recipes::Analysis::Prepareforvariantannotationblock
-      qw{ analysis_prepareforvariantannotationblock_rio };
     use MIP::Recipes::Analysis::Rankvariant
       qw{ analysis_rankvariant_rio analysis_rankvariant_rio_unaffected };
-    use MIP::Recipes::Analysis::Rhocall qw{ analysis_rhocall_annotate_rio };
-    use MIP::Recipes::Analysis::Snpeff qw{ analysis_snpeff_rio };
-    use MIP::Recipes::Analysis::Vep qw{ analysis_vep_rio };
-    use MIP::Recipes::Analysis::Vt qw{ analysis_vt_rio };
     use MIP::Script::Setup_script qw{ setup_script };
 
     ## Constants
@@ -165,16 +185,27 @@ sub analysis_variantannotationblock {
     # Create anonymous filehandle
     my $FILEHANDLE = IO::Handle->new();
 
+    ## Broadcasting
+  PROGRAM:
+    foreach my $program ( @{$order_programs_ref} ) {
+
+        ## Only for active programs
+        next PROGRAM if ( not $active_parameter_href->{$program} );
+
+        $log->info( $TAB
+              . $OPEN_BRACKET
+              . $program_name_href->{$program}
+              . $CLOSE_BRACKET );
+    }
+
     # Set order of supplying user info
     my @rio_program_order =
-      qw{ prepareforvariantannotationblock rhocall vt frequency_filter varianteffectpredictor vcfparser snpeff rankvariant endvariantannotationblock };
+      qw{ frequency_filter varianteffectpredictor vcfparser snpeff rankvariant endvariantannotationblock };
 
     # Store what to supply to user
     my %rio_program = (
-        prepareforvariantannotationblock =>
-          q{[Prepareforvariantannotationblock]},
-        rhocall                   => q{[rhocall]},
-        vt                        => q{[Vt]},
+
+        #        vt                        => q{[Vt]},
         frequency_filter          => q{[Frequency filter]},
         varianteffectpredictor    => q{[Varianteffectpredictor]},
         vcfparser                 => q{[Vcfparser]},
@@ -182,17 +213,6 @@ sub analysis_variantannotationblock {
         rankvariant               => q{[Rankvariant]},
         endvariantannotationblock => q{[Endvariantannotationblock]},
     );
-
-  RIO_PROGRAM:
-    foreach my $program_name (@rio_program_order) {
-
-        if ( $active_parameter_href->{$program_name} ) {
-
-            my $program_header = $rio_program{$program_name};
-
-            $log->info( $TAB . $program_header );
-        }
-    }
 
     ## Creates program directories (info & programData & programScript), program script filenames and writes sbatch header
     my ( $file_path, $program_info_path ) = setup_script(
@@ -209,10 +229,13 @@ sub analysis_variantannotationblock {
         }
     );
 
-    ## Copy files for variantannotationblock to enable restart and skip of modules within block
-    if ( $active_parameter_href->{prepareforvariantannotationblock} ) {
+  PROGRAM:
+    foreach my $program ( @{$order_programs_ref} ) {
 
-        ($xargs_file_counter) = analysis_prepareforvariantannotationblock_rio(
+        ## Only for active programs
+        next PROGRAM if ( not $active_parameter_href->{$program} );
+
+        ($xargs_file_counter) = $varann_ar_href->{$program}->(
             {
                 active_parameter_href   => $active_parameter_href,
                 call_type               => $call_type,
@@ -223,162 +246,39 @@ sub analysis_variantannotationblock {
                 job_id_href             => $job_id_href,
                 parameter_href          => $parameter_href,
                 program_info_path       => $program_info_path,
-                program_name            => q{prepareforvariantannotationblock},
+                program_name            => $program,
                 sample_info_href        => $sample_info_href,
                 stderr_path        => $program_info_path . $DOT . q{stderr.txt},
                 xargs_file_counter => $xargs_file_counter,
             }
         );
     }
-    if ( $active_parameter_href->{rhocall} ) {
+  RIO_PROGRAM:
+    foreach my $program_name (@rio_program_order) {
 
-        my $infamily_directory = catdir( $active_parameter_href->{outdata_dir},
-            $family_id, $outaligner_dir );
-        my $outfamily_directory = $infamily_directory;
+        if ( $active_parameter_href->{$program_name} ) {
 
-        ($xargs_file_counter) = analysis_rhocall_annotate_rio(
-            {
-                active_parameter_href   => $active_parameter_href,
-                call_type               => $call_type,
-                FILEHANDLE              => $FILEHANDLE,
-                file_info_href          => $file_info_href,
-                file_path               => $file_path,
-                infamily_directory      => $infamily_directory,
-                infile_lane_prefix_href => $infile_lane_prefix_href,
-                job_id_href             => $job_id_href,
-                outfamily_directory     => $outfamily_directory,
-                parameter_href          => $parameter_href,
-                program_info_path       => $program_info_path,
-                program_name            => q{rhocall},
-                sample_info_href        => $sample_info_href,
-                stderr_path        => $program_info_path . $DOT . q{stderr.txt},
-                xargs_file_counter => $xargs_file_counter,
-            }
-        );
+            my $program_header = $rio_program{$program_name};
+
+            $log->info( $TAB . $program_header );
+        }
     }
-    if ( $active_parameter_href->{vt} ) {
 
-        my $infamily_directory = catdir( $active_parameter_href->{outdata_dir},
-            $family_id, $outaligner_dir );
-        my $outfamily_directory = $infamily_directory;
+    ## Creates program directories (info & programData & programScript), program script filenames and writes sbatch header
+    ( $file_path, $program_info_path ) = setup_script(
+        {
+            active_parameter_href => $active_parameter_href,
+            core_number           => $core_number,
+            directory_id          => $family_id,
+            FILEHANDLE            => $FILEHANDLE,
+            job_id_href           => $job_id_href,
+            log                   => $log,
+            process_time          => $PROCESS_TIME,
+            program_directory     => $outaligner_dir,
+            program_name          => $program_name,
+        }
+    );
 
-        ($xargs_file_counter) = analysis_vt_rio(
-            {
-                active_parameter_href   => $active_parameter_href,
-                call_type               => $call_type,
-                FILEHANDLE              => $FILEHANDLE,
-                file_info_href          => $file_info_href,
-                file_path               => $file_path,
-                infamily_directory      => $infamily_directory,
-                infile_lane_prefix_href => $infile_lane_prefix_href,
-                job_id_href             => $job_id_href,
-                parameter_href          => $parameter_href,
-                outfamily_directory     => $outfamily_directory,
-                program_info_path       => $program_info_path,
-                program_name            => q{vt},
-                sample_info_href        => $sample_info_href,
-                stderr_path        => $program_info_path . $DOT . q{stderr.txt},
-                xargs_file_counter => $xargs_file_counter,
-            }
-        );
-    }
-    if ( $active_parameter_href->{frequency_filter} ) {
-
-        my $infamily_directory = catdir( $active_parameter_href->{outdata_dir},
-            $family_id, $outaligner_dir );
-        my $outfamily_directory = $infamily_directory;
-
-        ($xargs_file_counter) = analysis_frequency_filter_rio(
-            {
-                active_parameter_href   => $active_parameter_href,
-                call_type               => $call_type,
-                FILEHANDLE              => $FILEHANDLE,
-                file_info_href          => $file_info_href,
-                file_path               => $file_path,
-                infamily_directory      => $infamily_directory,
-                infile_lane_prefix_href => $infile_lane_prefix_href,
-                job_id_href             => $job_id_href,
-                outfamily_directory     => $outfamily_directory,
-                parameter_href          => $parameter_href,
-                program_info_path       => $program_info_path,
-                program_name            => q{frequency_filter},
-                sample_info_href        => $sample_info_href,
-                stderr_path        => $program_info_path . $DOT . q{stderr.txt},
-                xargs_file_counter => $xargs_file_counter,
-            }
-        );
-    }
-    if ( $active_parameter_href->{varianteffectpredictor} ) {
-
-        ($xargs_file_counter) = analysis_vep_rio(
-            {
-                active_parameter_href   => $active_parameter_href,
-                call_type               => $call_type,
-                FILEHANDLE              => $FILEHANDLE,
-                file_info_href          => $file_info_href,
-                file_path               => $file_path,
-                infile_lane_prefix_href => $infile_lane_prefix_href,
-                job_id_href             => $job_id_href,
-                parameter_href          => $parameter_href,
-                program_info_path       => $program_info_path,
-                program_name            => q{varianteffectpredictor},
-                sample_info_href        => $sample_info_href,
-                stderr_path        => $program_info_path . $DOT . q{stderr.txt},
-                xargs_file_counter => $xargs_file_counter,
-            }
-        );
-    }
-    if ( $active_parameter_href->{vcfparser} ) {
-
-        my $infamily_directory = catdir( $active_parameter_href->{outdata_dir},
-            $family_id, $outaligner_dir );
-
-        my $outfamily_directory = $infamily_directory;
-
-        ($xargs_file_counter) = analysis_mip_vcfparser_rio(
-            {
-                active_parameter_href   => $active_parameter_href,
-                call_type               => $call_type,
-                FILEHANDLE              => $FILEHANDLE,
-                file_info_href          => $file_info_href,
-                file_path               => $file_path,
-                infamily_directory      => $infamily_directory,
-                infile_lane_prefix_href => $infile_lane_prefix_href,
-                job_id_href             => $job_id_href,
-                outfamily_directory     => $outfamily_directory,
-                parameter_href          => $parameter_href,
-                program_info_path       => $program_info_path,
-                program_name            => q{vcfparser},
-                sample_info_href        => $sample_info_href,
-                xargs_file_counter      => $xargs_file_counter,
-            }
-        );
-    }
-    if ( $active_parameter_href->{snpeff} ) {
-
-        my $infamily_directory = catdir( $active_parameter_href->{outdata_dir},
-            $family_id, $outaligner_dir );
-        my $outfamily_directory = $infamily_directory;
-
-        ($xargs_file_counter) = analysis_snpeff_rio(
-            {
-                active_parameter_href   => $active_parameter_href,
-                call_type               => $call_type,
-                FILEHANDLE              => $FILEHANDLE,
-                file_info_href          => $file_info_href,
-                file_path               => $file_path,
-                job_id_href             => $job_id_href,
-                infamily_directory      => $infamily_directory,
-                infile_lane_prefix_href => $infile_lane_prefix_href,
-                outfamily_directory     => $outfamily_directory,
-                parameter_href          => $parameter_href,
-                program_info_path       => $program_info_path,
-                program_name            => q{snpeff},
-                sample_info_href        => $sample_info_href,
-                xargs_file_counter      => $xargs_file_counter,
-            }
-        );
-    }
     if ( $active_parameter_href->{rankvariant} ) {
 
         my $rank_program_name = q{rankvariant};

--- a/lib/MIP/Recipes/Analysis/Vep.pm
+++ b/lib/MIP/Recipes/Analysis/Vep.pm
@@ -176,7 +176,7 @@ sub analysis_vep {
     ## Retrieve logger object
     my $log = Log::Log4perl->get_logger(q{MIP});
 
-    ## Set MIP program name
+    ## Set program mode
     my $program_mode = $active_parameter_href->{$program_name};
 
     ## Alias
@@ -631,7 +631,7 @@ sub analysis_vep_rio {
     ## Retrieve logger object
     my $log = Log::Log4perl->get_logger(q{MIP});
 
-    ## Set MIP program name
+    ## Set program mode
     my $program_mode = $active_parameter_href->{$program_name};
 
     ## Alias

--- a/lib/MIP/Recipes/Analysis/Vep.pm
+++ b/lib/MIP/Recipes/Analysis/Vep.pm
@@ -181,12 +181,13 @@ sub analysis_vep {
 
     ## Alias
     my $job_id_chain = $parameter_href->{$program_name}{chain};
-    my ( $core_number, $time, @source_environment_cmds ) = get_module_parameters(
+    my ( $core_number, $time, @source_environment_cmds ) =
+      get_module_parameters(
         {
             active_parameter_href => $active_parameter_href,
-            program_name      => $program_name,
+            program_name          => $program_name,
         }
-    );
+      );
     my $xargs_file_path_prefix;
 
     ## Filehandles
@@ -258,7 +259,7 @@ sub analysis_vep {
     );
     my $outfile_suffix = set_file_suffix(
         {
-            file_suffix => $parameter_href->{$program_name}{outfile_suffix},
+            file_suffix    => $parameter_href->{$program_name}{outfile_suffix},
             job_id_chain   => $job_id_chain,
             parameter_href => $parameter_href,
             suffix_key     => q{variant_file_suffix},
@@ -635,12 +636,13 @@ sub analysis_vep_rio {
 
     ## Alias
     my $job_id_chain = $parameter_href->{$program_name}{chain};
-    my ( $core_number, $time, @source_environment_cmds ) = get_module_parameters(
+    my ( $core_number, $time, @source_environment_cmds ) =
+      get_module_parameters(
         {
             active_parameter_href => $active_parameter_href,
-            program_name      => $program_name,
+            program_name          => $program_name,
         }
-    );
+      );
 
     my $reduce_io = $active_parameter_href->{reduce_io};
     my $xargs_file_path_prefix;
@@ -705,7 +707,7 @@ sub analysis_vep_rio {
     );
     my $outfile_suffix = set_file_suffix(
         {
-            file_suffix => $parameter_href->{$program_name}{outfile_suffix},
+            file_suffix    => $parameter_href->{$program_name}{outfile_suffix},
             job_id_chain   => $job_id_chain,
             parameter_href => $parameter_href,
             suffix_key     => q{variant_file_suffix},
@@ -915,7 +917,6 @@ sub analysis_vep_sv {
 ## Returns  :
 ## Arguments: $active_parameter_href   => Active parameters for this analysis hash {REF}
 ##          : $call_type               => The variant call type
-##          : $contigs_ref             => Contigs to analyse
 ##          : $family_id               => Family id
 ##          : $FILEHANDLE              => Filehandle to write to
 ##          : $file_info_href          => The file_info hash {REF}
@@ -933,7 +934,6 @@ sub analysis_vep_sv {
 
     ## Flatten argument(s)
     my $active_parameter_href;
-    my $contigs_ref;
     my $file_info_href;
     my $infile_lane_prefix_href;
     my $job_id_href;
@@ -960,13 +960,6 @@ sub analysis_vep_sv {
             allow       => [qw{ SV }],
             default     => q{SV},
             store       => \$call_type,
-            strict_type => 1,
-        },
-        contigs_ref => {
-            default     => [],
-            defined     => 1,
-            required    => 1,
-            store       => \$contigs_ref,
             strict_type => 1,
         },
         family_id => {
@@ -1060,15 +1053,17 @@ sub analysis_vep_sv {
     my $program_mode = $active_parameter_href->{$program_name};
 
     ## Alias
+    my $contigs_ref = \@{ $file_info_href->{contigs} };
     my $consensus_analysis_type =
       $parameter_href->{dynamic_parameter}{consensus_analysis_type};
     my $job_id_chain = $parameter_href->{$program_name}{chain};
-    my ( $core_number, $time, @source_environment_cmds ) = get_module_parameters(
+    my ( $core_number, $time, @source_environment_cmds ) =
+      get_module_parameters(
         {
             active_parameter_href => $active_parameter_href,
-            program_name      => $program_name,
+            program_name          => $program_name,
         }
-    );
+      );
     my $xargs_file_path_prefix;
 
     ## Filehandles

--- a/lib/MIP/Recipes/Analysis/Vt.pm
+++ b/lib/MIP/Recipes/Analysis/Vt.pm
@@ -433,11 +433,9 @@ sub analysis_vt_rio {
 ##          : $FILEHANDLE              => Filehandle to write to
 ##          : $file_path               => File path
 ##          : $file_info_href          => File_info hash {REF}
-##          : $infamily_directory      => In family directory
 ##          : $infile_lane_prefix_href => Infile(s) without the ".ending" {REF}
 ##          : $job_id_href             => Job id hash {REF}
 ##          : $outaligner_dir          => Outaligner_dir used in the analysis
-##          : $outfamily_directory     => Out family directory
 ##          : $parameter_href          => Parameter hash {REF}
 ##          : $program_name            => Program name
 ##          : $program_info_path       => The program info path
@@ -453,10 +451,8 @@ sub analysis_vt_rio {
     my $FILEHANDLE;
     my $file_path;
     my $file_info_href;
-    my $infamily_directory;
     my $infile_lane_prefix_href;
     my $job_id_href;
-    my $outfamily_directory;
     my $parameter_href;
     my $program_name;
     my $program_info_path;
@@ -472,91 +468,80 @@ sub analysis_vt_rio {
 
     my $tmpl = {
         active_parameter_href => {
-            required    => 1,
-            defined     => 1,
             default     => {},
-            strict_type => 1,
+            defined     => 1,
+            required    => 1,
             store       => \$active_parameter_href,
+            strict_type => 1,
         },
         call_type =>
-          { default => q{BOTH}, strict_type => 1, store => \$call_type, },
+          { default => q{BOTH}, store => \$call_type, strict_type => 1, },
         family_id => {
             default     => $arg_href->{active_parameter_href}{family_id},
-            strict_type => 1,
             store       => \$family_id,
+            strict_type => 1,
         },
         FILEHANDLE     => { store => \$FILEHANDLE, },
         file_info_href => {
-            required    => 1,
-            defined     => 1,
             default     => {},
-            strict_type => 1,
+            defined     => 1,
+            required    => 1,
             store       => \$file_info_href,
-        },
-        file_path          => { strict_type => 1, store => \$file_path, },
-        infamily_directory => {
-            required    => 1,
-            defined     => 1,
             strict_type => 1,
-            store       => \$infamily_directory,
         },
+        file_path               => { store => \$file_path, strict_type => 1, },
         infile_lane_prefix_href => {
-            required    => 1,
-            defined     => 1,
             default     => {},
-            strict_type => 1,
+            defined     => 1,
+            required    => 1,
             store       => \$infile_lane_prefix_href,
+            strict_type => 1,
         },
         job_id_href => {
-            required    => 1,
-            defined     => 1,
             default     => {},
-            strict_type => 1,
+            defined     => 1,
+            required    => 1,
             store       => \$job_id_href,
+            strict_type => 1,
         },
         outaligner_dir => {
             default     => $arg_href->{active_parameter_href}{outaligner_dir},
-            strict_type => 1,
             store       => \$outaligner_dir,
-        },
-        outfamily_directory => {
-            required    => 1,
-            defined     => 1,
             strict_type => 1,
-            store       => \$outfamily_directory,
         },
         parameter_href => {
-            required    => 1,
-            defined     => 1,
             default     => {},
-            strict_type => 1,
-            store       => \$parameter_href,
-        },
-        program_info_path => { strict_type => 1, store => \$program_info_path },
-        program_name      => {
-            required    => 1,
             defined     => 1,
+            required    => 1,
+            store       => \$parameter_href,
             strict_type => 1,
+        },
+        program_info_path =>
+          { store => \$program_info_path, strict_type => 1, },
+        program_name => {
+            defined     => 1,
+            required    => 1,
             store       => \$program_name,
+            strict_type => 1,
         },
         sample_info_href => {
-            required    => 1,
-            defined     => 1,
             default     => {},
-            strict_type => 1,
+            defined     => 1,
+            required    => 1,
             store       => \$sample_info_href,
+            strict_type => 1,
         },
-        stderr_path    => { strict_type => 1, store => \$stderr_path },
+        stderr_path    => { store => \$stderr_path, strict_type => 1, },
         temp_directory => {
             default     => $arg_href->{active_parameter_href}{temp_directory},
-            strict_type => 1,
             store       => \$temp_directory,
+            strict_type => 1,
         },
         xargs_file_counter => {
-            default     => 0,
             allow       => qr/ ^\d+$ /xsm,
-            strict_type => 1,
+            default     => 0,
             store       => \$xargs_file_counter,
+            strict_type => 1,
         },
     };
 
@@ -577,7 +562,7 @@ sub analysis_vt_rio {
     ## Retrieve logger object
     my $log = Log::Log4perl->get_logger(q{MIP});
 
-    ## Set MIP program name
+    ## Set program mode
     my $program_mode = $active_parameter_href->{$program_name};
 
     ## Unpack parameters
@@ -606,6 +591,11 @@ sub analysis_vt_rio {
 
     # Split to enable submission to &sample_info_qc later
     my ( $volume, $directory, $stderr_file ) = splitpath($stderr_path);
+
+    ## Assign directories
+    my $infamily_directory = catdir( $active_parameter_href->{outdata_dir},
+        $family_id, $outaligner_dir );
+    my $outfamily_directory = $infamily_directory;
 
     # Used downstream
     $parameter_href->{$program_name}{indirectory} = $outfamily_directory;

--- a/lib/MIP/Recipes/Analysis/Vt.pm
+++ b/lib/MIP/Recipes/Analysis/Vt.pm
@@ -22,7 +22,7 @@ BEGIN {
     use base qw{ Exporter };
 
     # Set the version for version checking
-    our $VERSION = 1.01;
+    our $VERSION = 1.02;
 
     # Functions and variables which can be optionally exported
     our @EXPORT_OK = qw{ analysis_vt analysis_vt_rio };
@@ -49,11 +49,9 @@ sub analysis_vt {
 ##          : $family_id               => Family id
 ##          : $file_path               => File path
 ##          : $file_info_href          => File_info hash {REF}
-##          : $infamily_directory      => In family directory
 ##          : $infile_lane_prefix_href => Infile(s) without the ".ending" {REF}
 ##          : $job_id_href             => Job id hash {REF}
 ##          : $outaligner_dir          => Outaligner_dir used in the analysis
-##          : $outfamily_directory     => Out family directory
 ##          : $parameter_href          => Parameter hash {REF}
 ##          : $program_name            => Program name
 ##          : $program_info_path       => The program info path
@@ -68,10 +66,8 @@ sub analysis_vt {
     my $active_parameter_href;
     my $file_path;
     my $file_info_href;
-    my $infamily_directory;
     my $infile_lane_prefix_href;
     my $job_id_href;
-    my $outfamily_directory;
     my $parameter_href;
     my $program_name;
     my $program_info_path;
@@ -87,90 +83,79 @@ sub analysis_vt {
 
     my $tmpl = {
         active_parameter_href => {
-            required    => 1,
-            defined     => 1,
             default     => {},
-            strict_type => 1,
+            defined     => 1,
+            required    => 1,
             store       => \$active_parameter_href,
+            strict_type => 1,
         },
         call_type =>
-          { default => q{BOTH}, strict_type => 1, store => \$call_type, },
+          { default => q{BOTH}, store => \$call_type, strict_type => 1, },
         family_id => {
             default     => $arg_href->{active_parameter_href}{family_id},
-            strict_type => 1,
             store       => \$family_id,
+            strict_type => 1,
         },
         file_info_href => {
-            required    => 1,
-            defined     => 1,
             default     => {},
-            strict_type => 1,
+            defined     => 1,
+            required    => 1,
             store       => \$file_info_href,
-        },
-        file_path          => { strict_type => 1, store => \$file_path, },
-        infamily_directory => {
-            required    => 1,
-            defined     => 1,
             strict_type => 1,
-            store       => \$infamily_directory,
         },
+        file_path               => { store => \$file_path, strict_type => 1, },
         infile_lane_prefix_href => {
-            required    => 1,
-            defined     => 1,
             default     => {},
-            strict_type => 1,
+            defined     => 1,
+            required    => 1,
             store       => \$infile_lane_prefix_href,
+            strict_type => 1,
         },
         job_id_href => {
-            required    => 1,
-            defined     => 1,
             default     => {},
-            strict_type => 1,
+            defined     => 1,
+            required    => 1,
             store       => \$job_id_href,
+            strict_type => 1,
         },
         outaligner_dir => {
             default     => $arg_href->{active_parameter_href}{outaligner_dir},
-            strict_type => 1,
             store       => \$outaligner_dir,
-        },
-        outfamily_directory => {
-            required    => 1,
-            defined     => 1,
             strict_type => 1,
-            store       => \$outfamily_directory,
         },
         parameter_href => {
-            required    => 1,
-            defined     => 1,
             default     => {},
-            strict_type => 1,
-            store       => \$parameter_href,
-        },
-        program_info_path => { strict_type => 1, store => \$program_info_path },
-        program_name      => {
-            required    => 1,
             defined     => 1,
+            required    => 1,
+            store       => \$parameter_href,
             strict_type => 1,
+        },
+        program_info_path =>
+          { store => \$program_info_path, strict_type => 1, },
+        program_name => {
+            defined     => 1,
+            required    => 1,
             store       => \$program_name,
+            strict_type => 1,
         },
         sample_info_href => {
-            required    => 1,
-            defined     => 1,
             default     => {},
-            strict_type => 1,
+            defined     => 1,
+            required    => 1,
             store       => \$sample_info_href,
+            strict_type => 1,
         },
-        stderr_path    => { strict_type => 1, store => \$stderr_path },
+        stderr_path    => { store => \$stderr_path, strict_type => 1, },
         temp_directory => {
             default     => $arg_href->{active_parameter_href}{temp_directory},
-            strict_type => 1,
             store       => \$temp_directory,
+            strict_type => 1,
         },
         xargs_file_counter => {
-            default     => 0,
             allow       => qr/ ^\d+$ /xsm,
-            strict_type => 1,
+            default     => 0,
             store       => \$xargs_file_counter,
+            strict_type => 1,
         },
     };
 
@@ -192,18 +177,19 @@ sub analysis_vt {
     ## Retrieve logger object
     my $log = Log::Log4perl->get_logger(q{MIP});
 
-    ## Set MIP program name
+    ## Set program mode
     my $program_mode = $active_parameter_href->{$program_name};
 
     ## Unpack parameters
     my $job_id_chain = $parameter_href->{$program_name}{chain};
 
-    my ( $core_number, $time, @source_environment_cmds ) = get_module_parameters(
+    my ( $core_number, $time, @source_environment_cmds ) =
+      get_module_parameters(
         {
             active_parameter_href => $active_parameter_href,
-            program_name      => $program_name,
+            program_name          => $program_name,
         }
-    );
+      );
 
     ## Filehandles
     # Create anonymous filehandle
@@ -241,6 +227,11 @@ sub analysis_vt {
     # Split to enable submission to &sample_info_qc later
     my ( $volume, $directory, $stderr_file ) = splitpath($stderr_path);
 
+    ## Assign directories
+    my $infamily_directory = catdir( $active_parameter_href->{outdata_dir},
+        $family_id, $outaligner_dir );
+    my $outfamily_directory = $infamily_directory;
+
     # Used downstream
     $parameter_href->{$program_name}{indirectory} = $outfamily_directory;
 
@@ -269,7 +260,7 @@ sub analysis_vt {
     );
     my $outfile_suffix = set_file_suffix(
         {
-            file_suffix => $parameter_href->{$program_name}{outfile_suffix},
+            file_suffix    => $parameter_href->{$program_name}{outfile_suffix},
             job_id_chain   => $job_id_chain,
             parameter_href => $parameter_href,
             suffix_key     => q{variant_file_suffix},
@@ -592,12 +583,13 @@ sub analysis_vt_rio {
     ## Unpack parameters
     my $job_id_chain = $parameter_href->{$program_name}{chain};
 
-    my ( $core_number, $time, @source_environment_cmds ) = get_module_parameters(
+    my ( $core_number, $time, @source_environment_cmds ) =
+      get_module_parameters(
         {
             active_parameter_href => $active_parameter_href,
-            program_name      => $program_name,
+            program_name          => $program_name,
         }
-    );
+      );
 
     ## Filehandles
     # Create anonymous filehandle
@@ -643,7 +635,7 @@ sub analysis_vt_rio {
     );
     my $outfile_suffix = set_file_suffix(
         {
-            file_suffix => $parameter_href->{$program_name}{outfile_suffix},
+            file_suffix    => $parameter_href->{$program_name}{outfile_suffix},
             job_id_chain   => $job_id_chain,
             parameter_href => $parameter_href,
             suffix_key     => q{variant_file_suffix},

--- a/lib/MIP/Recipes/Pipeline/Rare_disease.pm
+++ b/lib/MIP/Recipes/Pipeline/Rare_disease.pm
@@ -197,6 +197,7 @@ sub pipeline_rare_disease {
       qw{ analysis_gatk_variantevalexome };
     use MIP::Recipes::Analysis::Gatk_variantrecalibration
       qw{ analysis_gatk_variantrecalibration_wgs analysis_gatk_variantrecalibration_wes };
+    use MIP::Recipes::Analysis::Gzip_fastq qw{ analysis_gzip_fastq };
     use MIP::Recipes::Analysis::Manta qw{ analysis_manta };
     use MIP::Recipes::Analysis::Markduplicates
       qw{ analysis_markduplicates analysis_markduplicates_rio };
@@ -293,8 +294,9 @@ sub pipeline_rare_disease {
         gatk_realigner              => \&analysis_gatk_realigner,
         gatk_variantevalall         => \&analysis_gatk_variantevalall,
         gatk_variantevalexome       => \&analysis_gatk_variantevalexome,
-        gatk_variantrecalibration => undef,           # Depends on analysis type
-        manta                     => \&analysis_manta,
+        gatk_variantrecalibration => undef,    # Depends on analysis type
+        gzip_fastq                   => \&analysis_gzip_fastq,
+        manta                        => \&analysis_manta,
         markduplicates               => \&analysis_markduplicates,
         multiqc                      => \&analysis_multiqc,
         peddy                        => \&analysis_peddy,
@@ -354,6 +356,7 @@ sub pipeline_rare_disease {
         gatk_variantevalexome => q{GATK variantevalexome},
         gatk_variantrecalibration =>
           q{GATK variantrecalibrator/applyrecalibration},
+        gzip_fastq                   => q{Gzip for fastq files},
         manta                        => q{Manta},
         markduplicates               => q{Markduplicates},
         multiqc                      => q{Multiqc},

--- a/lib/MIP/Recipes/Pipeline/Rare_disease.pm
+++ b/lib/MIP/Recipes/Pipeline/Rare_disease.pm
@@ -227,6 +227,8 @@ sub pipeline_rare_disease {
     use MIP::Recipes::Analysis::Sambamba_depth qw{ analysis_sambamba_depth };
     use MIP::Recipes::Analysis::Samtools_subsample_mt
       qw{ analysis_samtools_subsample_mt };
+    use MIP::Recipes::Analysis::Split_fastq_file
+      qw{ analysis_split_fastq_file };
     use MIP::Recipes::Analysis::Sv_reformat qw{ analysis_sv_reformat };
     use MIP::Recipes::Analysis::Snpeff
       qw{ analysis_snpeff analysis_snpeff_rio };
@@ -316,6 +318,7 @@ sub pipeline_rare_disease {
         sambamba_depth            => \&analysis_sambamba_depth,
         samtools_subsample_mt     => \&analysis_samtools_subsample_mt,
         snpeff                    => \&analysis_snpeff,
+        split_fastq_file          => \&analysis_split_fastq_file,
         sv_combinevariantcallsets => \&analysis_sv_combinevariantcallsets,
         sv_rankvariant => undef,                    # Depends on sample features
         sv_reformat    => \&analysis_sv_reformat,
@@ -376,6 +379,7 @@ sub pipeline_rare_disease {
         sambamba_depth                   => q{Sambamba depth},
         samtools_subsample_mt            => q{Samtools subsample MT},
         snpeff                           => q{Snpeff},
+        split_fastq_file                 => q{Split fastq files in batches},
         sv_combinevariantcallsets        => q{SV combinevariantcallsets},
         sv_varianteffectpredictor        => q{SV varianteffectpredictor},
         sv_vcfparser                     => q{SV vcfparser},
@@ -554,6 +558,8 @@ sub pipeline_rare_disease {
                 );
             }
 
+            ## Special case
+            exit if ( $program eq q{split_fastq_file} );
         }
     }
     return;

--- a/lib/MIP/Recipes/Pipeline/Rare_disease.pm
+++ b/lib/MIP/Recipes/Pipeline/Rare_disease.pm
@@ -173,12 +173,12 @@ sub pipeline_rare_disease {
     use MIP::Recipes::Analysis::Delly_call qw{ analysis_delly_call };
     use MIP::Recipes::Analysis::Delly_reformat qw{ analysis_delly_reformat };
     use MIP::Recipes::Analysis::Endvariantannotationblock
-      qw{ analysis_endvariantannotationblock };
+      qw{ analysis_endvariantannotationblock analysis_endvariantannotationblock_rio };
     use MIP::Recipes::Analysis::Expansionhunter qw{ analysis_expansionhunter };
     use MIP::Recipes::Analysis::Fastqc qw{ analysis_fastqc };
     use MIP::Recipes::Analysis::Freebayes qw { analysis_freebayes_calling };
     use MIP::Recipes::Analysis::Frequency_filter
-      qw{ analysis_frequency_filter };
+      qw{ analysis_frequency_filter analysis_frequency_filter_rio };
     use MIP::Recipes::Analysis::Gatk_baserecalibration
       qw{ analysis_gatk_baserecalibration analysis_gatk_baserecalibration_rio };
     use MIP::Recipes::Analysis::Gatk_combinevariantcallsets
@@ -201,7 +201,7 @@ sub pipeline_rare_disease {
     use MIP::Recipes::Analysis::Markduplicates
       qw{ analysis_markduplicates analysis_markduplicates_rio };
     use MIP::Recipes::Analysis::Mip_vcfparser
-      qw{ analysis_mip_vcfparser analysis_sv_vcfparser };
+      qw{ analysis_mip_vcfparser analysis_sv_vcfparser analysis_mip_vcfparser_rio };
     use MIP::Recipes::Analysis::Multiqc qw{ analysis_multiqc };
     use MIP::Recipes::Analysis::Peddy qw{ analysis_peddy };
     use MIP::Recipes::Analysis::Picardtools_collecthsmetrics
@@ -214,19 +214,21 @@ sub pipeline_rare_disease {
       qw{ analysis_picardtools_mergesamfiles analysis_picardtools_mergesamfiles_rio };
     use MIP::Recipes::Analysis::Plink qw{ analysis_plink };
     use MIP::Recipes::Analysis::Prepareforvariantannotationblock
-      qw{ analysis_prepareforvariantannotationblock };
+      qw{ analysis_prepareforvariantannotationblock analysis_prepareforvariantannotationblock_rio };
     use MIP::Recipes::Analysis::Qccollect qw{ analysis_qccollect };
     use MIP::Recipes::Analysis::Rankvariant
-      qw{ analysis_rankvariant analysis_rankvariant_unaffected analysis_sv_rankvariant analysis_sv_rankvariant_unaffected };
+      qw{ analysis_rankvariant analysis_rankvariant_rio analysis_rankvariant_rio_unaffected analysis_rankvariant_unaffected analysis_sv_rankvariant analysis_sv_rankvariant_unaffected };
     use MIP::Recipes::Analysis::Rcoverageplots qw{ analysis_rcoverageplots };
-    use MIP::Recipes::Analysis::Rhocall qw{ analysis_rhocall_annotate };
+    use MIP::Recipes::Analysis::Rhocall
+      qw{ analysis_rhocall_annotate analysis_rhocall_annotate_rio };
     use MIP::Recipes::Analysis::Rtg_vcfeval qw{ analysis_rtg_vcfeval  };
     use MIP::Recipes::Analysis::Sacct qw{ analysis_sacct };
     use MIP::Recipes::Analysis::Sambamba_depth qw{ analysis_sambamba_depth };
     use MIP::Recipes::Analysis::Samtools_subsample_mt
       qw{ analysis_samtools_subsample_mt };
     use MIP::Recipes::Analysis::Sv_reformat qw{ analysis_sv_reformat };
-    use MIP::Recipes::Analysis::Snpeff qw{ analysis_snpeff };
+    use MIP::Recipes::Analysis::Snpeff
+      qw{ analysis_snpeff analysis_snpeff_rio };
     use MIP::Recipes::Analysis::Sv_combinevariantcallsets
       qw{ analysis_sv_combinevariantcallsets };
     use MIP::Recipes::Analysis::Tiddit qw{ analysis_tiddit };
@@ -235,8 +237,9 @@ sub pipeline_rare_disease {
     use MIP::Recipes::Analysis::Variant_integrity
       qw{ analysis_variant_integrity };
     use MIP::Recipes::Analysis::Vcf2cytosure qw{ analysis_vcf2cytosure };
-    use MIP::Recipes::Analysis::Vep qw{ analysis_vep analysis_vep_sv };
-    use MIP::Recipes::Analysis::Vt qw{ analysis_vt };
+    use MIP::Recipes::Analysis::Vep
+      qw{ analysis_vep analysis_vep_rio analysis_vep_sv };
+    use MIP::Recipes::Analysis::Vt qw{ analysis_vt analysis_vt_rio };
     use MIP::Recipes::Build::Rare_disease qw{build_rare_disease_meta_files};
 
     ## Copy information about the infiles to file_info hash
@@ -277,6 +280,7 @@ sub pipeline_rare_disease {
         evaluation             => \&analysis_picardtools_genotypeconcordance,
         fastqc                 => \&analysis_fastqc,
         freebayes              => \&analysis_freebayes_calling,
+        frequency_filter       => \&analysis_frequency_filter,
         gatk_baserecalibration => \&analysis_gatk_baserecalibration,
         gatk_genotypegvcfs     => \&analysis_gatk_genotypegvcfs,
         gatk_concatenate_genotypegvcfs =>
@@ -301,15 +305,18 @@ sub pipeline_rare_disease {
         rtg_vcfeval               => \&analysis_rtg_vcfeval,
         sambamba_depth            => \&analysis_sambamba_depth,
         samtools_subsample_mt     => \&analysis_samtools_subsample_mt,
+        snpeff                    => \&analysis_snpeff,
         sv_combinevariantcallsets => \&analysis_sv_combinevariantcallsets,
         sv_varianteffectpredictor => \&analysis_vep_sv,
         sv_vcfparser              => \&analysis_sv_vcfparser,
         sv_rankvariant => undef,                    # Depends on sample features
         sv_reformat    => \&analysis_sv_reformat,
         tiddit         => \&analysis_tiddit,
-        variant_integrity => \&analysis_variant_integrity,
-        vcf2cytosure      => \&analysis_vcf2cytosure,
-        vt                => \&analysis_vt,
+        varianteffectpredictor => \&analysis_vep,
+        variant_integrity      => \&analysis_variant_integrity,
+        vcfparser              => \&analysis_mip_vcfparser,
+        vcf2cytosure           => \&analysis_vcf2cytosure,
+        vt                     => \&analysis_vt,
     );
 
     ## Program names for the log
@@ -325,6 +332,7 @@ sub pipeline_rare_disease {
         evaluation             => q{Evaluation},
         fastqc                 => q{FastQC},
         freebayes              => q{Freebayes},
+        frequency_filter       => q{Frequency filter},
         gatk_baserecalibration => q{GATK BaseRecalibrator/PrintReads},
         gatk_genotypegvcfs     => q{GATK genotypegvcfs},
         gatk_concatenate_genotypegvcfs =>
@@ -344,18 +352,21 @@ sub pipeline_rare_disease {
         picardtools_mergesamfiles        => q{Picardtools MergeSamFiles},
         plink                            => q{Plink},
         prepareforvariantannotationblock => q{Prepareforvariantannotationblock},
-        sambamba_depth                   => q{Sambamba depth},
         rcovplots                        => q{Rcovplots},
         rhocall                          => q{Rhocall},
         rtg_vcfeval                      => q{Rtg evaluation},
+        sambamba_depth                   => q{Sambamba depth},
         samtools_subsample_mt            => q{Samtools subsample MT},
+        snpeff                           => q{Snpeff},
         sv_combinevariantcallsets        => q{SV combinevariantcallsets},
         sv_varianteffectpredictor        => q{SV varianteffectpredictor},
         sv_vcfparser                     => q{SV vcfparser},
         sv_rankvariant                   => q{SV rankvariant},
         sv_reformat                      => q{SV reformat},
         tiddit                           => q{Tiddit},
+        varianteffectpredictor           => q{Varianteffectpredictor},
         variant_integrity                => q{Variant_integrity},
+        vcfparser                        => q{Vcfparser},
         vcf2cytosure                     => q{Vcf2cytosure},
         vt                               => q{Vt},
     );
@@ -371,6 +382,17 @@ sub pipeline_rare_disease {
             bamcal_ar_href        => \%bamcal_ar,
             order_bamcalibration_programs_ref =>
               \@order_bamcalibration_programs,
+        }
+    );
+
+    my $is_variantannotationblock_done;
+    my @order_varann_programs;
+    my %varann_ar;
+    _define_variantannotationblock_ar(
+        {
+            active_parameter_href     => $active_parameter_href,
+            order_varann_programs_ref => \@order_varann_programs,
+            varann_ar_href            => \%varann_ar,
         }
     );
 
@@ -409,6 +431,12 @@ sub pipeline_rare_disease {
           if ( $is_bamcalibrationblock_done
             and any { $_ eq $program } @order_bamcalibration_programs );
 
+        ## Skip program if variant annotation block is done
+        ## and program is part of variantannotation  block
+        next PROGRAM
+          if ( $is_variantannotationblock_done
+            and any { $_ eq $program } @order_varann_programs );
+
         ### Analysis recipes
         ## rio enabled and bamcalibration block analysis recipe
         if ( $active_parameter_href->{reduce_io}
@@ -435,6 +463,33 @@ sub pipeline_rare_disease {
 
             ## Done with bamcalibration block
             $is_bamcalibrationblock_done = 1;
+        }
+        elsif ( $active_parameter_href->{reduce_io}
+            and any { $_ eq $program } @order_varann_programs )
+        {
+            ## rio enabled and variantannotation block analysis recipe
+
+            $log->info(q{[Variantannotationblock]});
+
+            analysis_variantannotationblock(
+                {
+                    active_parameter_href   => $active_parameter_href,
+                    call_type               => q{BOTH},
+                    file_info_href          => $file_info_href,
+                    infile_lane_prefix_href => $infile_lane_prefix_href,
+                    job_id_href             => $job_id_href,
+                    outaligner_dir => $active_parameter_href->{outaligner_dir},
+                    order_programs_ref => \@order_varann_programs,
+                    parameter_href     => $parameter_href,
+                    program_name       => q{variantannotationblock},
+                    program_name_href  => \%program_name,
+                    sample_info_href   => $sample_info_href,
+                    varann_ar_href     => \%varann_ar,
+                }
+            );
+
+            ## Done with variantannotationblock block
+            $is_variantannotationblock_done = 1;
         }
         else {
 
@@ -506,103 +561,6 @@ sub pipeline_rare_disease {
     }
     else {
 
-        if ( $active_parameter_href->{frequency_filter} ) {
-
-            $log->info(q{[Frequency_filter]});
-
-            my $infamily_directory = catdir(
-                $active_parameter_href->{outdata_dir},
-                $active_parameter_href->{family_id},
-                $active_parameter_href->{outaligner_dir}
-            );
-            my $outfamily_directory = $infamily_directory;
-
-            analysis_frequency_filter(
-                {
-                    parameter_href          => $parameter_href,
-                    active_parameter_href   => $active_parameter_href,
-                    sample_info_href        => $sample_info_href,
-                    file_info_href          => $file_info_href,
-                    infile_lane_prefix_href => $infile_lane_prefix_href,
-                    infamily_directory      => $infamily_directory,
-                    job_id_href             => $job_id_href,
-                    call_type               => q{BOTH},
-                    outfamily_directory     => $outfamily_directory,
-                    program_name            => q{frequency_filter},
-                }
-            );
-        }
-
-        if ( $active_parameter_href->{varianteffectpredictor} ) {
-
-            $log->info(q{[Varianteffectpredictor]});
-
-            analysis_vep(
-                {
-                    parameter_href          => $parameter_href,
-                    active_parameter_href   => $active_parameter_href,
-                    sample_info_href        => $sample_info_href,
-                    file_info_href          => $file_info_href,
-                    infile_lane_prefix_href => $infile_lane_prefix_href,
-                    job_id_href             => $job_id_href,
-                    call_type               => q{BOTH},
-                    program_name            => q{varianteffectpredictor},
-                }
-            );
-        }
-        if ( $active_parameter_href->{vcfparser} ) {
-
-            $log->info(q{[Vcfparser]});
-
-            my $infamily_directory = catdir(
-                $active_parameter_href->{outdata_dir},
-                $active_parameter_href->{family_id},
-                $active_parameter_href->{outaligner_dir}
-            );
-            my $outfamily_directory = $infamily_directory;
-
-            analysis_mip_vcfparser(
-                {
-                    active_parameter_href   => $active_parameter_href,
-                    call_type               => q{BOTH},
-                    file_info_href          => $file_info_href,
-                    infamily_directory      => $infamily_directory,
-                    infile_lane_prefix_href => $infile_lane_prefix_href,
-                    job_id_href             => $job_id_href,
-                    outfamily_directory     => $outfamily_directory,
-                    parameter_href          => $parameter_href,
-                    program_name            => q{vcfparser},
-                    sample_info_href        => $sample_info_href,
-                }
-            );
-        }
-
-        if ( $active_parameter_href->{snpeff} ) {
-
-            $log->info(q{[Snpeff]});
-
-            my $infamily_directory = catdir(
-                $active_parameter_href->{outdata_dir},
-                $active_parameter_href->{family_id},
-                $active_parameter_href->{outaligner_dir}
-            );
-            my $outfamily_directory = $infamily_directory;
-
-            analysis_snpeff(
-                {
-                    active_parameter_href   => $active_parameter_href,
-                    call_type               => q{BOTH},
-                    file_info_href          => $file_info_href,
-                    infamily_directory      => $infamily_directory,
-                    infile_lane_prefix_href => $infile_lane_prefix_href,
-                    job_id_href             => $job_id_href,
-                    outfamily_directory     => $outfamily_directory,
-                    parameter_href          => $parameter_href,
-                    program_name            => q{snpeff},
-                    sample_info_href        => $sample_info_href,
-                }
-            );
-        }
         if ( $active_parameter_href->{rankvariant} ) {
 
             $log->info(q{[Rankvariant]});
@@ -837,6 +795,73 @@ sub _define_bamcalibration_ar {
 
         ## Dry run
         $active_parameter_href->{bamcalibrationblock} = 2;
+    }
+    return;
+}
+
+sub _define_variantannotationblock_ar {
+
+## Function : Define variantannotationblock recipes, order, coderefs and activate
+## Returns  :
+## Arguments: $active_parameter_href     => Active parameters for this analysis hash {REF}
+##          : $order_varann_programs_ref => Order of programs in variant annotation block {REF}
+##          : $varann_ar_href            => Variant annotation analysis recipe hash {REF}
+
+    my ($arg_href) = @_;
+
+    ## Flatten argument(s)
+    my $active_parameter_href;
+    my $order_varann_programs_ref;
+    my $varann_ar_href;
+
+    my $tmpl = {
+        active_parameter_href => {
+            default     => {},
+            defined     => 1,
+            required    => 1,
+            store       => \$active_parameter_href,
+            strict_type => 1,
+        },
+        order_varann_programs_ref => {
+            default     => [],
+            defined     => 1,
+            required    => 1,
+            store       => \$order_varann_programs_ref,
+            strict_type => 1,
+        },
+        varann_ar_href => {
+            default     => {},
+            defined     => 1,
+            required    => 1,
+            store       => \$varann_ar_href,
+            strict_type => 1,
+        },
+    };
+
+    check( $tmpl, $arg_href, 1 ) or croak q{Could not parse arguments!};
+
+    ## Define rio blocks programs and order
+    @{$order_varann_programs_ref} =
+      qw{ prepareforvariantannotationblock rhocall vt frequency_filter varianteffectpredictor vcfparser snpeff };
+
+    %{$varann_ar_href} = (
+        frequency_filter => \&analysis_frequency_filter_rio,
+        prepareforvariantannotationblock =>
+          \&analysis_prepareforvariantannotationblock_rio,
+        rhocall                => \&analysis_rhocall_annotate_rio,
+        snpeff                 => \&analysis_snpeff_rio,
+        varianteffectpredictor => \&analysis_vep_rio,
+        vcfparser              => \&analysis_mip_vcfparser_rio,
+        vt                     => \&analysis_vt_rio,
+    );
+
+    ## Enable varann as analysis recipe
+    $active_parameter_href->{variantannotationblock} = 1;
+
+    if ( $active_parameter_href->{dry_run_all} ) {
+
+        ## Dry run
+        $active_parameter_href->{variantannotationblock} = 2;
     }
     return;
 }

--- a/lib/MIP/Recipes/Pipeline/Rare_disease.pm
+++ b/lib/MIP/Recipes/Pipeline/Rare_disease.pm
@@ -4,12 +4,12 @@ use Carp;
 use charnames qw{ :full :short };
 use English qw{ -no_match_vars };
 use File::Spec::Functions qw{ catdir catfile };
+use open qw{ :encoding(UTF-8) :std };
+use Params::Check qw{ check allow last_error };
 use strict;
 use utf8;
 use warnings;
 use warnings qw{ FATAL utf8 };
-use open qw{ :encoding(UTF-8) :std };
-use Params::Check qw{ check allow last_error };
 
 ## CPANM
 use List::MoreUtils qw { any };
@@ -19,6 +19,7 @@ use Readonly;
 use MIP::Delete::List qw{ delete_male_contig };
 
 BEGIN {
+
     require Exporter;
     use base qw{ Exporter };
 
@@ -38,7 +39,6 @@ sub pipeline_rare_disease {
 
 ## Function : Pipeline recipe for wes and or wgs data analysis.
 ## Returns  :
-
 ## Arguments: $active_parameter_href   => Active parameters for this analysis hash {REF}
 ##          : $file_info_href          => File info hash {REF}
 ##          : $indir_path_href         => Indirectory hash {REF}
@@ -267,84 +267,96 @@ sub pipeline_rare_disease {
         }
     );
 
+    ### Analysis recipes
     ## Create code reference table for pipeline analysis recipes
     my %analysis_recipe = (
-        bwa_mem                => \&analysis_bwa_mem,
-        bcftools_mpileup       => \&analysis_bcftools_mpileup,
-        bedtools_genomecov     => \&analysis_bedtools_genomecov,
-        chanjo_sexcheck        => \&analysis_chanjo_sex_check,
-        cnvnator               => \&analysis_cnvnator,
-        delly_call             => \&analysis_delly_call,
-        delly_reformat         => \&analysis_delly_reformat,
-        expansionhunter        => \&analysis_expansionhunter,
-        evaluation             => \&analysis_picardtools_genotypeconcordance,
-        fastqc                 => \&analysis_fastqc,
-        freebayes              => \&analysis_freebayes_calling,
-        frequency_filter       => \&analysis_frequency_filter,
-        gatk_baserecalibration => \&analysis_gatk_baserecalibration,
-        gatk_genotypegvcfs     => \&analysis_gatk_genotypegvcfs,
+        analysisrunstatus         => \&analysis_analysisrunstatus,
+        bcftools_mpileup          => \&analysis_bcftools_mpileup,
+        bedtools_genomecov        => \&analysis_bedtools_genomecov,
+        bwa_mem                   => \&analysis_bwa_mem,
+        chanjo_sexcheck           => \&analysis_chanjo_sex_check,
+        cnvnator                  => \&analysis_cnvnator,
+        delly_call                => \&analysis_delly_call,
+        delly_reformat            => \&analysis_delly_reformat,
+        endvariantannotationblock => \&analysis_endvariantannotationblock,
+        expansionhunter           => \&analysis_expansionhunter,
+        evaluation                => \&analysis_picardtools_genotypeconcordance,
+        fastqc                    => \&analysis_fastqc,
+        freebayes                 => \&analysis_freebayes_calling,
+        frequency_filter          => \&analysis_frequency_filter,
+        gatk_baserecalibration    => \&analysis_gatk_baserecalibration,
         gatk_concatenate_genotypegvcfs =>
           \&analysis_gatk_concatenate_genotypegvcfs,
         gatk_combinevariantcallsets => \&analysis_gatk_combinevariantcallsets,
+        gatk_genotypegvcfs          => \&analysis_gatk_genotypegvcfs,
         gatk_haplotypecaller        => \&analysis_gatk_haplotypecaller,
         gatk_realigner              => \&analysis_gatk_realigner,
-        gatk_variantrecalibration => undef,    # Depends on analysis type
-        gatk_variantevalall          => \&analysis_gatk_variantevalall,
-        manta                        => \&analysis_manta,
+        gatk_variantevalall         => \&analysis_gatk_variantevalall,
+        gatk_variantevalexome       => \&analysis_gatk_variantevalexome,
+        gatk_variantrecalibration => undef,           # Depends on analysis type
+        manta                     => \&analysis_manta,
         markduplicates               => \&analysis_markduplicates,
+        multiqc                      => \&analysis_multiqc,
         peddy                        => \&analysis_peddy,
         picardtools_collecthsmetrics => \&analysis_picardtools_collecthsmetrics,
         picardtools_collectmultiplemetrics =>
           \&analysis_picardtools_collectmultiplemetrics,
-        plink                     => \&analysis_plink,
         picardtools_mergesamfiles => \&analysis_picardtools_mergesamfiles,
+        plink                     => \&analysis_plink,
         prepareforvariantannotationblock =>
           \&analysis_prepareforvariantannotationblock,
-        rcovplots                 => \&analysis_rcoverageplots,
-        rhocall                   => \&analysis_rhocall_annotate,
-        rtg_vcfeval               => \&analysis_rtg_vcfeval,
+        qccollect   => \&analysis_qccollect,
+        rankvariant => undef,                       # Depends on sample features
+        rcovplots   => \&analysis_rcoverageplots,
+        rhocall     => \&analysis_rhocall_annotate,
+        rtg_vcfeval => \&analysis_rtg_vcfeval,
+        sacct       => \&analysis_sacct,
         sambamba_depth            => \&analysis_sambamba_depth,
         samtools_subsample_mt     => \&analysis_samtools_subsample_mt,
         snpeff                    => \&analysis_snpeff,
         sv_combinevariantcallsets => \&analysis_sv_combinevariantcallsets,
-        sv_varianteffectpredictor => \&analysis_vep_sv,
-        sv_vcfparser              => \&analysis_sv_vcfparser,
         sv_rankvariant => undef,                    # Depends on sample features
         sv_reformat    => \&analysis_sv_reformat,
-        tiddit         => \&analysis_tiddit,
-        varianteffectpredictor => \&analysis_vep,
-        variant_integrity      => \&analysis_variant_integrity,
-        vcfparser              => \&analysis_mip_vcfparser,
-        vcf2cytosure           => \&analysis_vcf2cytosure,
-        vt                     => \&analysis_vt,
+        sv_varianteffectpredictor => \&analysis_vep_sv,
+        sv_vcfparser              => \&analysis_sv_vcfparser,
+        tiddit                    => \&analysis_tiddit,
+        varianteffectpredictor    => \&analysis_vep,
+        variant_integrity         => \&analysis_variant_integrity,
+        vcfparser                 => \&analysis_mip_vcfparser,
+        vcf2cytosure              => \&analysis_vcf2cytosure,
+        vt                        => \&analysis_vt,
     );
 
     ## Program names for the log
     my %program_name = (
-        bwa_mem                => q{BWA mem},
-        bcftools_mpileup       => q{Bcftools mpileup},
-        bedtools_genomecov     => q{Bedtools genomecov},
-        chanjo_sexcheck        => q{Chanjo sexcheck},
-        cnvnator               => q{CNVnator},
-        delly_call             => q{Delly call},
-        delly_reformat         => q{Delly reformat},
-        expansionhunter        => q{ExpansionHunter},
-        evaluation             => q{Evaluation},
-        fastqc                 => q{FastQC},
-        freebayes              => q{Freebayes},
-        frequency_filter       => q{Frequency filter},
-        gatk_baserecalibration => q{GATK BaseRecalibrator/PrintReads},
-        gatk_genotypegvcfs     => q{GATK genotypegvcfs},
+        analysisrunstatus         => q{Analysis run status},
+        bcftools_mpileup          => q{Bcftools mpileup},
+        bedtools_genomecov        => q{Bedtools genomecov},
+        bwa_mem                   => q{BWA mem},
+        chanjo_sexcheck           => q{Chanjo sexcheck},
+        cnvnator                  => q{CNVnator},
+        delly_call                => q{Delly call},
+        delly_reformat            => q{Delly reformat},
+        endvariantannotationblock => q{Endvariantannotationblock},
+        expansionhunter           => q{ExpansionHunter},
+        evaluation                => q{Evaluation},
+        fastqc                    => q{FastQC},
+        freebayes                 => q{Freebayes},
+        frequency_filter          => q{Frequency filter},
+        gatk_baserecalibration    => q{GATK BaseRecalibrator/PrintReads},
         gatk_concatenate_genotypegvcfs =>
           q{GATK concatenate genotypegvcfs files},
         gatk_combinevariantcallsets => q{GATK combinevariantcallsets},
+        gatk_genotypegvcfs          => q{GATK genotypegvcfs},
         gatk_haplotypecaller        => q{GATK Haplotypecaller},
-        gatk_realigner => q{GATK RealignerTargetCreator/IndelRealigner},
+        gatk_realigner        => q{GATK RealignerTargetCreator/IndelRealigner},
+        gatk_variantevalall   => q{GATK variantevalall},
+        gatk_variantevalexome => q{GATK variantevalexome},
         gatk_variantrecalibration =>
           q{GATK variantrecalibrator/applyrecalibration},
-        gatk_variantevalall          => q{GATK variantevalall},
         manta                        => q{Manta},
         markduplicates               => q{Markduplicates},
+        multiqc                      => q{Multiqc},
         peddy                        => q{Peddy},
         picardtools_collecthsmetrics => q{Picardtools collecthsmetrics},
         picardtools_collectmultiplemetrics =>
@@ -352,9 +364,12 @@ sub pipeline_rare_disease {
         picardtools_mergesamfiles        => q{Picardtools MergeSamFiles},
         plink                            => q{Plink},
         prepareforvariantannotationblock => q{Prepareforvariantannotationblock},
+        qccollect                        => q{Qccollect},
+        rankvariant                      => q{Rankvariant},
         rcovplots                        => q{Rcovplots},
         rhocall                          => q{Rhocall},
         rtg_vcfeval                      => q{Rtg evaluation},
+        sacct                            => q{Sacct},
         sambamba_depth                   => q{Sambamba depth},
         samtools_subsample_mt            => q{Samtools subsample MT},
         snpeff                           => q{Snpeff},
@@ -374,14 +389,13 @@ sub pipeline_rare_disease {
     ### Special case for '--rio' capable analysis recipes
     ## Define rio blocks programs and order
     my $is_bamcalibrationblock_done;
-    my @order_bamcalibration_programs;
+    my @order_bamcal_programs;
     my %bamcal_ar;
     _define_bamcalibration_ar(
         {
-            active_parameter_href => $active_parameter_href,
-            bamcal_ar_href        => \%bamcal_ar,
-            order_bamcalibration_programs_ref =>
-              \@order_bamcalibration_programs,
+            active_parameter_href     => $active_parameter_href,
+            bamcal_ar_href            => \%bamcal_ar,
+            order_bamcal_programs_ref => \@order_bamcal_programs,
         }
     );
 
@@ -400,9 +414,10 @@ sub pipeline_rare_disease {
     _update_rankvariants_ar(
         {
             active_parameter_href => $active_parameter_href,
+            analysis_recipe_href  => \%analysis_recipe,
             log                   => $log,
             parameter_href        => $parameter_href,
-            analysis_recipe_href  => \%analysis_recipe,
+            varann_ar_href        => \%varann_ar,
         }
     );
 
@@ -410,9 +425,9 @@ sub pipeline_rare_disease {
     _update_gatk_variantrecalibration_ar(
         {
             active_parameter_href => $active_parameter_href,
+            analysis_recipe_href  => \%analysis_recipe,
             log                   => $log,
             parameter_href        => $parameter_href,
-            analysis_recipe_href  => \%analysis_recipe,
         }
     );
 
@@ -429,7 +444,7 @@ sub pipeline_rare_disease {
         ## and program is part of bamcalibration block
         next PROGRAM
           if ( $is_bamcalibrationblock_done
-            and any { $_ eq $program } @order_bamcalibration_programs );
+            and any { $_ eq $program } @order_bamcal_programs );
 
         ## Skip program if variant annotation block is done
         ## and program is part of variantannotation  block
@@ -440,7 +455,7 @@ sub pipeline_rare_disease {
         ### Analysis recipes
         ## rio enabled and bamcalibration block analysis recipe
         if ( $active_parameter_href->{reduce_io}
-            and any { $_ eq $program } @order_bamcalibration_programs )
+            and any { $_ eq $program } @order_bamcal_programs )
         {
 
             $log->info(q{[Bamcalibrationblock]});
@@ -453,7 +468,7 @@ sub pipeline_rare_disease {
                     infile_lane_prefix_href => $infile_lane_prefix_href,
                     job_id_href             => $job_id_href,
                     log                     => $log,
-                    order_programs_ref      => \@order_bamcalibration_programs,
+                    order_programs_ref      => \@order_bamcal_programs,
                     parameter_href          => $parameter_href,
                     program_name            => q{bamcalibrationblock},
                     program_name_href       => \%program_name,
@@ -479,6 +494,7 @@ sub pipeline_rare_disease {
                     infile_lane_prefix_href => $infile_lane_prefix_href,
                     job_id_href             => $job_id_href,
                     outaligner_dir => $active_parameter_href->{outaligner_dir},
+                    log            => $log,
                     order_programs_ref => \@order_varann_programs,
                     parameter_href     => $parameter_href,
                     program_name       => q{variantannotationblock},
@@ -537,199 +553,6 @@ sub pipeline_rare_disease {
 
         }
     }
-
-    if ( $active_parameter_href->{reduce_io} ) {
-
-        $active_parameter_href->{pvariantannotationblock} =
-          1;    # Enable as program
-
-        $log->info(q{[Variantannotationblock]});
-
-        analysis_variantannotationblock(
-            {
-                parameter_href          => $parameter_href,
-                active_parameter_href   => $active_parameter_href,
-                sample_info_href        => $sample_info_href,
-                file_info_href          => $file_info_href,
-                infile_lane_prefix_href => $infile_lane_prefix_href,
-                job_id_href             => $job_id_href,
-                outaligner_dir => $active_parameter_href->{outaligner_dir},
-                call_type      => q{BOTH},
-                program_name   => q{variantannotationblock},
-            }
-        );
-    }
-    else {
-
-        if ( $active_parameter_href->{rankvariant} ) {
-
-            $log->info(q{[Rankvariant]});
-
-            if ( defined $parameter_href->{dynamic_parameter}{unaffected}
-                && @{ $parameter_href->{dynamic_parameter}{unaffected} } eq
-                @{ $active_parameter_href->{sample_ids} } )
-            {
-
-                $log->warn(
-q{Only unaffected sample in pedigree - skipping genmod 'models', 'score' and 'compound'}
-                );
-
-                analysis_rankvariant_unaffected(
-                    {
-                        parameter_href          => $parameter_href,
-                        active_parameter_href   => $active_parameter_href,
-                        sample_info_href        => $sample_info_href,
-                        file_info_href          => $file_info_href,
-                        infile_lane_prefix_href => $infile_lane_prefix_href,
-                        job_id_href             => $job_id_href,
-                        call_type               => q{BOTH},
-                        program_name            => q{rankvariant},
-                    }
-                );
-            }
-            else {
-
-                analysis_rankvariant(
-                    {
-                        parameter_href          => $parameter_href,
-                        active_parameter_href   => $active_parameter_href,
-                        sample_info_href        => $sample_info_href,
-                        file_info_href          => $file_info_href,
-                        infile_lane_prefix_href => $infile_lane_prefix_href,
-                        job_id_href             => $job_id_href,
-                        call_type               => q{BOTH},
-                        program_name            => q{rankvariant},
-                    }
-                );
-            }
-        }
-        if ( $active_parameter_href->{endvariantannotationblock} ) {
-
-            $log->info(q{[Endvariantannotationblock]});
-
-            analysis_endvariantannotationblock(
-                {
-                    parameter_href          => $parameter_href,
-                    active_parameter_href   => $active_parameter_href,
-                    sample_info_href        => $sample_info_href,
-                    file_info_href          => $file_info_href,
-                    infile_lane_prefix_href => $infile_lane_prefix_href,
-                    job_id_href             => $job_id_href,
-                    call_type               => q{BOTH},
-                    program_name            => q{endvariantannotationblock},
-                }
-            );
-        }
-    }
-
-    if ( $active_parameter_href->{gatk_variantevalexome} ) {
-
-        $log->info(q{[GATK variantevalexome]});
-
-        my $variant_eval_exome_program_name = q{gatk_variantevalexome};
-
-        ## Assign directories
-        my $infamily_directory = catdir(
-            $active_parameter_href->{outdata_dir},
-            $active_parameter_href->{family_id},
-            $active_parameter_href->{outaligner_dir}
-        );
-
-      SAMPLE_ID:
-        foreach my $sample_id ( @{ $active_parameter_href->{sample_ids} } ) {
-
-            ## Assign directories
-            my $outsample_directory = catdir(
-                $active_parameter_href->{outdata_dir},
-                $sample_id,
-                $active_parameter_href->{outaligner_dir},
-                $variant_eval_exome_program_name
-            );
-
-            analysis_gatk_variantevalexome(
-                {
-                    parameter_href          => $parameter_href,
-                    active_parameter_href   => $active_parameter_href,
-                    sample_info_href        => $sample_info_href,
-                    file_info_href          => $file_info_href,
-                    infile_lane_prefix_href => $infile_lane_prefix_href,
-                    job_id_href             => $job_id_href,
-                    sample_id               => $sample_id,
-                    infamily_directory      => $infamily_directory,
-                    outsample_directory     => $outsample_directory,
-                    program_name            => $variant_eval_exome_program_name,
-                }
-            );
-        }
-    }
-    if ( $active_parameter_href->{qccollect} ) {
-
-        $log->info(q{[Qccollect]});
-
-        my $outfamily_directory = catdir(
-            $active_parameter_href->{outdata_dir},
-            $active_parameter_href->{family_id}
-        );
-
-        analysis_qccollect(
-            {
-                parameter_href          => $parameter_href,
-                active_parameter_href   => $active_parameter_href,
-                sample_info_href        => $sample_info_href,
-                infile_lane_prefix_href => $infile_lane_prefix_href,
-                job_id_href             => $job_id_href,
-                program_name            => q{qccollect},
-                outfamily_directory     => $outfamily_directory,
-            }
-        );
-    }
-
-    if ( $active_parameter_href->{multiqc} ) {
-
-        $log->info(q{[Multiqc]});
-
-        analysis_multiqc(
-            {
-                active_parameter_href   => $active_parameter_href,
-                infile_lane_prefix_href => $infile_lane_prefix_href,
-                job_id_href             => $job_id_href,
-                program_name            => q{multiqc},
-                parameter_href          => $parameter_href,
-                sample_info_href        => $sample_info_href,
-            }
-        );
-    }
-
-    if ( $active_parameter_href->{analysisrunstatus} ) {
-
-        $log->info(q{[Analysis run status]});
-
-        analysis_analysisrunstatus(
-            {
-                active_parameter_href   => $active_parameter_href,
-                infile_lane_prefix_href => $infile_lane_prefix_href,
-                job_id_href             => $job_id_href,
-                parameter_href          => $parameter_href,
-                program_name            => q{analysisrunstatus},
-                sample_info_href        => $sample_info_href,
-            }
-        );
-    }
-    if ( $active_parameter_href->{sacct} ) {
-
-        $log->info(q{[Sacct]});
-
-        analysis_sacct(
-            {
-                active_parameter_href   => $active_parameter_href,
-                infile_lane_prefix_href => $infile_lane_prefix_href,
-                job_id_href             => $job_id_href,
-                parameter_href          => $parameter_href,
-                program_name            => q{sacct},
-                sample_info_href        => $sample_info_href,
-            }
-        );
-    }
     return;
 }
 
@@ -737,15 +560,15 @@ sub _define_bamcalibration_ar {
 
 ## Function : Define bamcalibration recipes, order, coderefs and activate
 ## Returns  :
-## Arguments: $active_parameter_href             => Active parameters for this analysis hash {REF}
-##          : $order_bamcalibration_programs_ref => Order of programs in bamcalibration block {REF}
-##          : $bamcal_ar_href                    => Bamcalibration analysis recipe hash {REF}
+## Arguments: $active_parameter_href     => Active parameters for this analysis hash {REF}
+##          : $order_bamcal_programs_ref => Order of programs in bamcalibration block {REF}
+##          : $bamcal_ar_href            => Bamcalibration analysis recipe hash {REF}
 
     my ($arg_href) = @_;
 
     ## Flatten argument(s)
     my $active_parameter_href;
-    my $order_bamcalibration_programs_ref;
+    my $order_bamcal_programs_ref;
     my $bamcal_ar_href;
 
     my $tmpl = {
@@ -756,11 +579,11 @@ sub _define_bamcalibration_ar {
             store       => \$active_parameter_href,
             strict_type => 1,
         },
-        order_bamcalibration_programs_ref => {
+        order_bamcal_programs_ref => {
             default     => [],
             defined     => 1,
             required    => 1,
-            store       => \$order_bamcalibration_programs_ref,
+            store       => \$order_bamcal_programs_ref,
             strict_type => 1,
         },
         bamcal_ar_href => {
@@ -775,7 +598,7 @@ sub _define_bamcalibration_ar {
     check( $tmpl, $arg_href, 1 ) or croak q{Could not parse arguments!};
 
     ## Define rio blocks programs and order
-    @{$order_bamcalibration_programs_ref} = qw{ picardtools_mergesamfiles
+    @{$order_bamcal_programs_ref} = qw{ picardtools_mergesamfiles
       markduplicates
       gatk_realigner
       gatk_baserecalibration
@@ -842,12 +665,14 @@ sub _define_variantannotationblock_ar {
 
     ## Define rio blocks programs and order
     @{$order_varann_programs_ref} =
-      qw{ prepareforvariantannotationblock rhocall vt frequency_filter varianteffectpredictor vcfparser snpeff };
+      qw{ prepareforvariantannotationblock rhocall vt frequency_filter varianteffectpredictor vcfparser snpeff rankvariant endvariantannotationblock };
 
     %{$varann_ar_href} = (
-        frequency_filter => \&analysis_frequency_filter_rio,
+        endvariantannotationblock => \&analysis_endvariantannotationblock_rio,
+        frequency_filter          => \&analysis_frequency_filter_rio,
         prepareforvariantannotationblock =>
           \&analysis_prepareforvariantannotationblock_rio,
+        rankvariant => undef,    # Depends on sample features
         rhocall                => \&analysis_rhocall_annotate_rio,
         snpeff                 => \&analysis_snpeff_rio,
         varianteffectpredictor => \&analysis_vep_rio,
@@ -871,17 +696,19 @@ sub _update_rankvariants_ar {
 ## Function : Update which rankvariants recipe to use
 ## Returns  :
 ## Arguments: $active_parameter_href   => Active parameters for this analysis hash {REF}
+##          : $analysis_recipe_href    => Analysis recipe hash {REF}
 ##          : $log                     => Log object to write to
 ##          : $parameter_href          => Parameter hash {REF}
-##          : $analysis_recipe_href    => Analysis recipe hash {REF}
+##          : $varann_ar_href            => Variant annotation analysis recipe hash {REF}
 
     my ($arg_href) = @_;
 
     ## Flatten argument(s)
     my $active_parameter_href;
+    my $analysis_recipe_href;
     my $log;
     my $parameter_href;
-    my $analysis_recipe_href;
+    my $varann_ar_href;
 
     my $tmpl = {
         active_parameter_href => {
@@ -889,6 +716,13 @@ sub _update_rankvariants_ar {
             defined     => 1,
             required    => 1,
             store       => \$active_parameter_href,
+            strict_type => 1,
+        },
+        analysis_recipe_href => {
+            default     => {},
+            defined     => 1,
+            required    => 1,
+            store       => \$analysis_recipe_href,
             strict_type => 1,
         },
         log => {
@@ -903,11 +737,11 @@ sub _update_rankvariants_ar {
             store       => \$parameter_href,
             strict_type => 1,
         },
-        analysis_recipe_href => {
+        varann_ar_href => {
             default     => {},
             defined     => 1,
             required    => 1,
-            store       => \$analysis_recipe_href,
+            store       => \$varann_ar_href,
             strict_type => 1,
         },
     };
@@ -923,10 +757,27 @@ sub _update_rankvariants_ar {
 q{Only unaffected sample(s) in pedigree - skipping genmod 'models', 'score' and 'compound'}
         );
 
+        ## Rio recipe
+        if ( $active_parameter_href->{reduce_io} ) {
+
+            $varann_ar_href->{rankvariant} =
+              \&analysis_rankvariant_rio_unaffected;
+            return;
+        }
+        $analysis_recipe_href->{rankvariant} =
+          \&analysis_rankvariant_unaffected;
         $analysis_recipe_href->{sv_rankvariant} =
           \&analysis_sv_rankvariant_unaffected;
     }
     else {
+
+        ## Rio recipe
+        if ( $active_parameter_href->{reduce_io} ) {
+
+            $varann_ar_href->{rankvariant} = \&analysis_rankvariant_rio;
+            return;
+        }
+        $analysis_recipe_href->{rankvariant}    = \&analysis_rankvariant;
         $analysis_recipe_href->{sv_rankvariant} = \&analysis_sv_rankvariant;
     }
     return;

--- a/lib/MIP/Recipes/Pipeline/Rna.pm
+++ b/lib/MIP/Recipes/Pipeline/Rna.pm
@@ -9,7 +9,7 @@ use charnames qw{ :full :short };
 use Carp;
 use English qw{ -no_match_vars };
 use Params::Check qw{ check allow last_error };
-use File::Spec::Functions qw{ catdir };
+use File::Spec::Functions qw{ catdir catfile };
 
 ## CPANM
 use Readonly;
@@ -21,14 +21,16 @@ BEGIN {
     use base qw{ Exporter };
 
     # Set the version for version checking
-    our $VERSION = 1.08;
+    our $VERSION = 1.09;
 
     # Functions and variables which can be optionally exported
     our @EXPORT_OK = qw{ pipeline_rna };
 }
 
 ## Constants
-Readonly my $SPACE => q{ };
+Readonly my $CLOSE_BRACKET => q{]};
+Readonly my $OPEN_BRACKET  => q{[};
+Readonly my $SPACE         => q{ };
 
 sub pipeline_rna {
 
@@ -43,7 +45,7 @@ sub pipeline_rna {
 ##          : $job_id_href             => Job id hash {REF}
 ##          : $lane_href               => The lane info hash {REF}
 ##          : $log                     => Log object to write to
-##          : $outaligner_dir          => Outaligner dir used in the analysis
+##          : $order_programs_ref      => Execution order of programs {REF}
 ##          : $parameter_href          => Parameter hash {REF}
 ##          : $sample_info_href        => Info on samples and family hash {REF}
 
@@ -58,11 +60,9 @@ sub pipeline_rna {
     my $job_id_href;
     my $lane_href;
     my $log;
+    my $order_programs_ref;
     my $parameter_href;
     my $sample_info_href;
-
-    ## Default(s)
-    my $outaligner_dir;
 
     my $tmpl = {
         active_parameter_href => {
@@ -119,9 +119,11 @@ sub pipeline_rna {
             required => 1,
             store    => \$log,
         },
-        outaligner_dir => {
-            default     => $arg_href->{active_parameter_href}{outaligner_dir},
-            store       => \$outaligner_dir,
+        order_programs_ref => {
+            default     => [],
+            defined     => 1,
+            required    => 1,
+            store       => \$order_programs_ref,
             strict_type => 1,
         },
         parameter_href => {
@@ -154,6 +156,7 @@ sub pipeline_rna {
       qw{ analysis_gatk_splitncigarreads };
     use MIP::Recipes::Analysis::Gatk_variantfiltration
       qw{ analysis_gatk_variantfiltration };
+    use MIP::Recipes::Analysis::Gzip_fastq qw{ analysis_gzip_fastq };
     use MIP::Recipes::Analysis::Markduplicates qw{ analysis_markduplicates };
     use MIP::Recipes::Analysis::Picardtools_mergesamfiles
       qw{ analysis_picardtools_mergesamfiles };
@@ -161,6 +164,12 @@ sub pipeline_rna {
     use MIP::Recipes::Analysis::Star_aln qw{ analysis_star_aln };
     use MIP::Recipes::Analysis::Star_fusion qw{ analysis_star_fusion };
     use MIP::Recipes::Build::Rna qw{build_rna_meta_files};
+
+    ## Copy information about the infiles to file_info hash
+    foreach my $sample_id ( @{ $active_parameter_href->{sample_ids} } ) {
+        $file_info_href->{$sample_id}{mip_infiles} = $infile_href->{$sample_id};
+        $file_info_href->{$sample_id}{lanes}       = $lane_href->{$sample_id};
+    }
 
     ### Build recipes
     $log->info(q{[Reference check - Reference prerequisites]});
@@ -177,175 +186,82 @@ sub pipeline_rna {
         }
     );
 
-    ### Analysis recipes
-    ## Run FastQC
-    if ( $active_parameter_href->{fastqc} ) {
+    ## Dispatch table
+    my %analysis_recipe = (
+        bootstrapann              => \&analysis_bootstrapann,
+        fastqc                    => \&analysis_fastqc,
+        gatk_asereadcounter       => \&analysis_gatk_asereadcounter,
+        gatk_baserecalibration    => \&analysis_gatk_baserecalibration,
+        gatk_haplotypecaller      => \&analysis_gatk_haplotypecaller_rna,
+        gatk_splitncigarreads     => \&analysis_gatk_splitncigarreads,
+        gatk_variantfiltration    => \&analysis_gatk_variantfiltration,
+        markduplicates            => \&analysis_markduplicates,
+        picardtools_mergesamfiles => \&analysis_picardtools_mergesamfiles,
+        salmon_quant              => \&analysis_salmon_quant,
+        star_aln                  => \&analysis_star_aln,
+        star_fusion               => \&analysis_star_fusion,
+    );
 
-        $log->info(q{[Fastqc]});
+    ## Program names for the log
+    my %program_name = (
+        bootstrapann              => q{BootstrapAnn},
+        fastqc                    => q{FastQC},
+        gatk_asereadcounter       => q{GATK ASEReadCounter},
+        gatk_baserecalibration    => q{GATK BaseRecalibrator/PrintReads},
+        gatk_haplotypecaller      => q{GATK Haplotypecaller},
+        gatk_splitncigarreads     => q{GATK SplitNCigarReads},
+        gatk_variantfiltration    => q{GATK VariantFiltration},
+        markduplicates            => q{Markduplicates},
+        picardtools_mergesamfiles => q{Picardtools MergeSamFiles},
+        salmon_quant              => q{Salmon Quant},
+        star_aln                  => q{STAR},
+        star_fusion               => q{STAR-Fusion},
+    );
 
-      SAMPLE:
-        foreach my $sample_id ( @{ $active_parameter_href->{sample_ids} } ) {
+  PROGRAM:
+    foreach my $program ( @{$order_programs_ref} ) {
 
-            my $fastqc_program_name = q{fastqc};
-            my $fastq_outsample_directory =
-              catdir( $active_parameter_href->{outdata_dir},
-                $sample_id, $fastqc_program_name );
-            analysis_fastqc(
-                {
-                    active_parameter_href   => $active_parameter_href,
-                    infile_lane_prefix_href => $infile_lane_prefix_href,
-                    infiles_ref             => \@{ $infile_href->{$sample_id} },
-                    insample_directory      => $indir_path_href->{$sample_id},
-                    job_id_href             => $job_id_href,
-                    outsample_directory     => $fastq_outsample_directory,
-                    parameter_href          => $parameter_href,
-                    program_name            => $fastqc_program_name,
-                    sample_id               => $sample_id,
-                    sample_info_href        => $sample_info_href,
-                }
-            );
+        ## Skip not active programs
+        next PROGRAM if ( not $active_parameter_href->{$program} );
+
+        ## Skip program if not part of dispatch table (such as gzip fastq)
+        next PROGRAM if ( not $analysis_recipe{$program} );
+
+        $log->info( $OPEN_BRACKET . $program_name{$program} . $CLOSE_BRACKET );
+
+        ## Sample mode
+        if ( $parameter_href->{$program}{analysis_mode} eq q{sample} ) {
+
+          SAMPLE:
+            foreach my $sample_id ( @{ $active_parameter_href->{sample_ids} } )
+            {
+
+                $analysis_recipe{$program}->(
+                    {
+                        active_parameter_href   => $active_parameter_href,
+                        file_info_href          => $file_info_href,
+                        indir_path_href         => $indir_path_href,
+                        infile_lane_prefix_href => $infile_lane_prefix_href,
+                        job_id_href             => $job_id_href,
+                        parameter_href          => $parameter_href,
+                        program_name            => $program,
+                        sample_id               => $sample_id,
+                        sample_info_href        => $sample_info_href,
+                    }
+                );
+            }
         }
-    }
+        ## Family mode
+        elsif ( $parameter_href->{$program}{analysis_mode} eq q{family} ) {
 
-    ## Star aln
-    if ( $active_parameter_href->{star_aln} ) {
-
-        $log->info(q{[Star Aln]});
-
-      SAMPLE_ID:
-        foreach my $sample_id ( @{ $active_parameter_href->{sample_ids} } ) {
-
-            my $star_outsample_directory =
-              catdir( $active_parameter_href->{outdata_dir},
-                $sample_id, $active_parameter_href->{outaligner_dir} );
-
-            analysis_star_aln(
-                {
-                    active_parameter_href   => $active_parameter_href,
-                    file_info_href          => $file_info_href,
-                    infile_lane_prefix_href => $infile_lane_prefix_href,
-                    infiles_ref             => \@{ $infile_href->{$sample_id} },
-                    insample_directory      => $indir_path_href->{$sample_id},
-                    job_id_href             => $job_id_href,
-                    outsample_directory     => $star_outsample_directory,
-                    parameter_href          => $parameter_href,
-                    program_name            => q{star_aln},
-                    sample_id               => $sample_id,
-                    sample_info_href        => $sample_info_href,
-                }
+            my $outfamily_directory = catfile(
+                $active_parameter_href->{outdata_dir},
+                $active_parameter_href->{family_id},
+                $active_parameter_href->{outaligner_dir},
+                $program,
             );
-        }
-    }
 
-    ## Salmon Quant
-    if ( $active_parameter_href->{salmon_quant} ) {
-
-        $log->info(q{[Salmon Quant]});
-
-      SAMPLE_ID:
-        foreach my $sample_id ( @{ $active_parameter_href->{sample_ids} } ) {
-
-            my $salmon_outsample_directory =
-              catdir( $active_parameter_href->{outdata_dir},
-                $sample_id, $active_parameter_href->{outaligner_dir} );
-
-            analysis_salmon_quant(
-                {
-                    active_parameter_href   => $active_parameter_href,
-                    file_info_href          => $file_info_href,
-                    infiles_ref             => \@{ $infile_href->{$sample_id} },
-                    infile_lane_prefix_href => $infile_lane_prefix_href,
-                    insample_directory      => $indir_path_href->{$sample_id},
-                    job_id_href             => $job_id_href,
-                    outsample_directory     => $salmon_outsample_directory,
-                    parameter_href          => $parameter_href,
-                    program_name            => q{salmon_quant},
-                    sample_info_href        => $sample_info_href,
-                    sample_id               => $sample_id,
-                }
-            );
-        }
-    }
-
-    ## Star fusion
-    if ( $active_parameter_href->{star_fusion} ) {
-
-        $log->info(q{[Star Fusion]});
-
-      SAMPLE_ID:
-        foreach my $sample_id ( @{ $active_parameter_href->{sample_ids} } ) {
-
-            my $star_outsample_directory =
-              catdir( $active_parameter_href->{outdata_dir},
-                $sample_id, $active_parameter_href->{outaligner_dir} );
-
-            analysis_star_fusion(
-                {
-                    active_parameter_href   => $active_parameter_href,
-                    file_info_href          => $file_info_href,
-                    infiles_ref             => \@{ $infile_href->{$sample_id} },
-                    infile_lane_prefix_href => $infile_lane_prefix_href,
-                    insample_directory      => $indir_path_href->{$sample_id},
-                    job_id_href             => $job_id_href,
-                    outsample_directory     => $star_outsample_directory,
-                    parameter_href          => $parameter_href,
-                    program_name            => q{star_fusion},
-                    sample_id               => $sample_id,
-                    sample_info_href        => $sample_info_href,
-                }
-            );
-        }
-    }
-    ## Always run merge even for single samples to rename them correctly for standardised downstream processing.
-    if ( $active_parameter_href->{picardtools_mergesamfiles} ) {
-
-        $log->info(q{[Picardtools mergesamfiles]});
-
-      SAMPLE_ID:
-        foreach my $sample_id ( @{ $active_parameter_href->{sample_ids} } ) {
-
-            my $insample_directory =
-              catdir( $active_parameter_href->{outdata_dir},
-                $sample_id, $active_parameter_href->{outaligner_dir} );
-            my $outsample_directory =
-              catdir( $active_parameter_href->{outdata_dir},
-                $sample_id, $active_parameter_href->{outaligner_dir} );
-
-            analysis_picardtools_mergesamfiles(
-                {
-                    active_parameter_href   => $active_parameter_href,
-                    file_info_href          => $file_info_href,
-                    infile_lane_prefix_href => $infile_lane_prefix_href,
-                    insample_directory      => $insample_directory,
-                    job_id_href             => $job_id_href,
-                    lane_href               => $lane_href,
-                    outsample_directory     => $outsample_directory,
-                    parameter_href          => $parameter_href,
-                    program_name            => q{picardtools_mergesamfiles},
-                    sample_id               => $sample_id,
-                    sample_info_href        => $sample_info_href,
-                }
-            );
-        }
-    }
-
-    ## Picard MarkDuplicates
-    if ( $active_parameter_href->{markduplicates} ) {
-
-        $log->info(q{[Markduplicates]});
-
-      SAMPLE_ID:
-        foreach my $sample_id ( @{ $active_parameter_href->{sample_ids} } ) {
-
-            ## Assign directories
-            my $insample_directory =
-              catdir( $active_parameter_href->{outdata_dir},
-                $sample_id, $active_parameter_href->{outaligner_dir} );
-            my $outsample_directory =
-              catdir( $active_parameter_href->{outdata_dir},
-                $sample_id, $active_parameter_href->{outaligner_dir} );
-
-            analysis_markduplicates(
+            $analysis_recipe{$program}->(
                 {
                     parameter_href          => $parameter_href,
                     active_parameter_href   => $active_parameter_href,
@@ -353,212 +269,13 @@ sub pipeline_rna {
                     file_info_href          => $file_info_href,
                     infile_lane_prefix_href => $infile_lane_prefix_href,
                     job_id_href             => $job_id_href,
-                    insample_directory      => $insample_directory,
-                    outsample_directory     => $outsample_directory,
-                    sample_id               => $sample_id,
-                    program_name            => q{markduplicates},
+                    program_name            => $program,
+                    outfamily_directory     => $outfamily_directory,
                 }
             );
         }
     }
 
-    ## GATK SplitNCigarReads
-    if ( $active_parameter_href->{gatk_splitncigarreads} ) {
-
-        $log->info(q{[GATK SplitNCigarReads]});
-
-      SAMPLE_ID:
-        foreach my $sample_id ( @{ $active_parameter_href->{sample_ids} } ) {
-
-            ## Assign directories
-            my $insample_directory =
-              catdir( $active_parameter_href->{outdata_dir},
-                $sample_id, $active_parameter_href->{outaligner_dir} );
-            my $outsample_directory =
-              catdir( $active_parameter_href->{outdata_dir},
-                $sample_id, $active_parameter_href->{outaligner_dir} );
-
-            analysis_gatk_splitncigarreads(
-                {
-                    active_parameter_href   => $active_parameter_href,
-                    file_info_href          => $file_info_href,
-                    infile_lane_prefix_href => $infile_lane_prefix_href,
-                    insample_directory      => $insample_directory,
-                    job_id_href             => $job_id_href,
-                    outsample_directory     => $outsample_directory,
-                    parameter_href          => $parameter_href,
-                    program_name            => q{gatk_splitncigarreads},
-                    sample_id               => $sample_id,
-                    sample_info_href        => $sample_info_href,
-                }
-            );
-        }
-    }
-
-    ## Base recalibration
-    if ( $active_parameter_href->{gatk_baserecalibration} ) {
-
-        $log->info(q{[GATK baserecalibrator/printreads]});
-
-      SAMPLE_ID:
-        foreach my $sample_id ( @{ $active_parameter_href->{sample_ids} } ) {
-
-            ## Assign directories
-            my $insample_directory =
-              catdir( $active_parameter_href->{outdata_dir},
-                $sample_id, $active_parameter_href->{outaligner_dir} );
-            my $outsample_directory =
-              catdir( $active_parameter_href->{outdata_dir},
-                $sample_id, $active_parameter_href->{outaligner_dir} );
-
-            analysis_gatk_baserecalibration(
-                {
-                    active_parameter_href   => $active_parameter_href,
-                    file_info_href          => $file_info_href,
-                    infile_lane_prefix_href => $infile_lane_prefix_href,
-                    insample_directory      => $insample_directory,
-                    job_id_href             => $job_id_href,
-                    outsample_directory     => $outsample_directory,
-                    parameter_href          => $parameter_href,
-                    program_name            => q{gatk_baserecalibration},
-                    sample_id               => $sample_id,
-                    sample_info_href        => $sample_info_href,
-                }
-            );
-        }
-    }
-
-    ## GATK HaplotypeCaller
-    if ( $active_parameter_href->{gatk_haplotypecaller} ) {
-
-        $log->info(q{[GATK HaplotypeCaller]});
-
-      SAMPLE_ID:
-        foreach my $sample_id ( @{ $active_parameter_href->{sample_ids} } ) {
-
-            ## Assign directories
-            my $insample_directory =
-              catdir( $active_parameter_href->{outdata_dir},
-                $sample_id, $active_parameter_href->{outaligner_dir} );
-            my $outsample_directory =
-              catdir( $active_parameter_href->{outdata_dir},
-                $sample_id, $active_parameter_href->{outaligner_dir} );
-
-            analysis_gatk_haplotypecaller_rna(
-                {
-                    active_parameter_href   => $active_parameter_href,
-                    file_info_href          => $file_info_href,
-                    infile_lane_prefix_href => $infile_lane_prefix_href,
-                    insample_directory      => $insample_directory,
-                    job_id_href             => $job_id_href,
-                    outsample_directory     => $outsample_directory,
-                    parameter_href          => $parameter_href,
-                    program_name            => q{gatk_haplotypecaller},
-                    sample_id               => $sample_id,
-                    sample_info_href        => $sample_info_href,
-                }
-            );
-        }
-    }
-
-    ## GATK VariantFiltration
-    if ( $active_parameter_href->{gatk_variantfiltration} ) {
-
-        $log->info(q{[GATK VariantFiltration]});
-
-      SAMPLE_ID:
-        foreach my $sample_id ( @{ $active_parameter_href->{sample_ids} } ) {
-
-            ## Assign directories
-            my $insample_directory =
-              catdir( $active_parameter_href->{outdata_dir},
-                $sample_id, $active_parameter_href->{outaligner_dir} );
-            my $outsample_directory =
-              catdir( $active_parameter_href->{outdata_dir},
-                $sample_id, $active_parameter_href->{outaligner_dir} );
-
-            analysis_gatk_variantfiltration(
-                {
-                    active_parameter_href   => $active_parameter_href,
-                    file_info_href          => $file_info_href,
-                    infile_lane_prefix_href => $infile_lane_prefix_href,
-                    insample_directory      => $insample_directory,
-                    job_id_href             => $job_id_href,
-                    outsample_directory     => $outsample_directory,
-                    parameter_href          => $parameter_href,
-                    program_name            => q{gatk_variantfiltration},
-                    sample_id               => $sample_id,
-                    sample_info_href        => $sample_info_href,
-                }
-            );
-        }
-    }
-
-    ## GATK ASEReadCounter
-    if ( $active_parameter_href->{gatk_asereadcounter} ) {
-
-        $log->info(q{[GATK ASEReadCounter]});
-
-      SAMPLE_ID:
-        foreach my $sample_id ( @{ $active_parameter_href->{sample_ids} } ) {
-
-            ## Assign directories
-            my $insample_directory =
-              catdir( $active_parameter_href->{outdata_dir},
-                $sample_id, $active_parameter_href->{outaligner_dir} );
-            my $outsample_directory =
-              catdir( $active_parameter_href->{outdata_dir},
-                $sample_id, $active_parameter_href->{outaligner_dir} );
-
-            analysis_gatk_asereadcounter(
-                {
-                    active_parameter_href   => $active_parameter_href,
-                    file_info_href          => $file_info_href,
-                    infile_lane_prefix_href => $infile_lane_prefix_href,
-                    insample_directory      => $insample_directory,
-                    job_id_href             => $job_id_href,
-                    outsample_directory     => $outsample_directory,
-                    parameter_href          => $parameter_href,
-                    program_name            => q{gatk_asereadcounter},
-                    sample_id               => $sample_id,
-                    sample_info_href        => $sample_info_href,
-                }
-            );
-        }
-    }
-
-    ## BootstrapAnn
-    if ( $active_parameter_href->{bootstrapann} ) {
-
-        $log->info(q{[BootstrapAnn]});
-
-      SAMPLE_ID:
-        foreach my $sample_id ( @{ $active_parameter_href->{sample_ids} } ) {
-
-            ## Assign directories
-            my $insample_directory =
-              catdir( $active_parameter_href->{outdata_dir},
-                $sample_id, $active_parameter_href->{outaligner_dir} );
-            my $outsample_directory =
-              catdir( $active_parameter_href->{outdata_dir},
-                $sample_id, $active_parameter_href->{outaligner_dir} );
-
-            analysis_bootstrapann(
-                {
-                    active_parameter_href   => $active_parameter_href,
-                    file_info_href          => $file_info_href,
-                    infile_lane_prefix_href => $infile_lane_prefix_href,
-                    insample_directory      => $insample_directory,
-                    job_id_href             => $job_id_href,
-                    outsample_directory     => $outsample_directory,
-                    parameter_href          => $parameter_href,
-                    program_name            => q{bootstrapann},
-                    sample_id               => $sample_id,
-                    sample_info_href        => $sample_info_href,
-                }
-            );
-        }
-    }
     return;
 }
 

--- a/lib/MIP/Recipes/Pipeline/Rna.pm
+++ b/lib/MIP/Recipes/Pipeline/Rna.pm
@@ -169,6 +169,8 @@ sub pipeline_rna {
     foreach my $sample_id ( @{ $active_parameter_href->{sample_ids} } ) {
         $file_info_href->{$sample_id}{mip_infiles} = $infile_href->{$sample_id};
         $file_info_href->{$sample_id}{lanes}       = $lane_href->{$sample_id};
+        $file_info_href->{$sample_id}{mip_infiles_dir} =
+          $indir_path_href->{$sample_id};
     }
 
     ### Build recipes
@@ -240,7 +242,6 @@ sub pipeline_rna {
                     {
                         active_parameter_href   => $active_parameter_href,
                         file_info_href          => $file_info_href,
-                        indir_path_href         => $indir_path_href,
                         infile_lane_prefix_href => $infile_lane_prefix_href,
                         job_id_href             => $job_id_href,
                         parameter_href          => $parameter_href,

--- a/t/mip_analysis.test
+++ b/t/mip_analysis.test
@@ -61,7 +61,7 @@ Readonly my $TAB       => qq{\t};
 my ( $infile, $config_file );
 my ( %parameter, %active_parameter, %pedigree, %vcfparser_data, );
 
-our $VERSION = '2.0.0';
+our $VERSION = '2.0.1';
 
 if ( scalar @ARGV == 0 ) {
 
@@ -271,7 +271,7 @@ sub test_modules {
     use YAML;
 
     my $yaml_file =
-      catdir( dirname($Bin), qw{ definitions define_parameters.yaml } );
+      catdir( dirname($Bin), qw{ definitions mip_parameters.yaml } );
     ok( -f $yaml_file, q{YAML: File=} . $yaml_file . q{in MIP directory} );
 
     ## Create an object

--- a/t/parse_fastq_infiles.t
+++ b/t/parse_fastq_infiles.t
@@ -19,6 +19,7 @@ use warnings qw{ FATAL utf8 };
 use autodie qw { :all };
 use Modern::Perl qw{ 2014 };
 use Readonly;
+
 #use Test::Trap;
 
 ## MIPs lib/
@@ -29,7 +30,7 @@ use MIP::Script::Utils qw{ help };
 our $USAGE = build_usage( {} );
 
 my $VERBOSE = 1;
-our $VERSION = '1.0.0';
+our $VERSION = '1.0.1';
 
 ## Constants
 Readonly my $COMMA   => q{,};
@@ -127,7 +128,7 @@ my %infile_lane_prefix;
 my %lane;
 my %sample_info;
 
-my $is_file_uncompressed = parse_fastq_infiles(
+parse_fastq_infiles(
     {
         active_parameter_href           => \%active_parameter,
         file_info_href                  => \%file_info,
@@ -142,7 +143,8 @@ my $is_file_uncompressed = parse_fastq_infiles(
 );
 
 ## Then return undef
-is( $is_file_uncompressed, undef, q{No files uncompressed} );
+is( $file_info{is_file_uncompressed}{ADM1059A1},
+    undef, q{No files uncompressed} );
 
 ## Given uncompressed file
 push @{ $active_parameter{sample_ids} }, q{ADM1059A2};
@@ -151,7 +153,7 @@ push @{ $infile{ADM1059A2} },
 $indir_path{ADM1059A2} =
   catdir( $Bin, qw{ data 643594-miptest test_data bad_input } );
 
-$is_file_uncompressed = parse_fastq_infiles(
+parse_fastq_infiles(
     {
         active_parameter_href           => \%active_parameter,
         file_info_href                  => \%file_info,
@@ -166,8 +168,10 @@ $is_file_uncompressed = parse_fastq_infiles(
 );
 
 ## Then return true
-ok( $is_file_uncompressed,
-    q{Files uncompressed and got run info from headers} );
+ok(
+    $file_info{is_file_uncompressed}{ADM1059A2},
+    q{Files uncompressed and got run info from headers}
+);
 
 #### Inactivated due to strange behaviour from trap
 ## Given file, when no sample_id in file name


### PR DESCRIPTION
- Validated with an exome trio and both with and without --rio
- A plodiy error in wgs using hapmap trio 200M reads pairs. 
gatk_variantrecalibration_643594-200M_BOTH.0.stderr.txt: "MESSAGE: [ADM1059A3 C/C/C GQ 99 DP 4563 AD 4,4553 PL 165802,21638,7976,0] has 4 PL values, should be 3 since only the diploid case is supported when applying family priors."
- Will merge anyway as this is most likely not related to teh code changes in this PR.
- RNA pipe has been tested by jemten.