### PR TITLE
Feature/conda installations

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -33,7 +33,7 @@ install:
 ## Test installation script and gather coverage information
   - PERL5OPT=-MDevel::Cover=-ignore,"^t/",-coverage,statement,branch,condition,path,subroutine perl t/mip_install.test
 ## Generate rare disease installation script 
-  - PERL5OPT=-MDevel::Cover=-ignore,"^t/",-coverage,statement,branch,condition,path,subroutine perl mip install rare_disease --config definitions/install_rare_disease_parameters.yaml --quiet --bash_set_errexit --install emip epeddy epy3 --envn emip=mip_travis --snpg GRCh37.75 --skip gatk --skip freebayes
+  - PERL5OPT=-MDevel::Cover=-ignore,"^t/",-coverage,statement,branch,condition,path,subroutine perl mip install rare_disease --config definitions/install_rare_disease_parameters.yaml --quiet --bash_set_errexit --install emip epeddy epy3 --envn emip=mip_travis --snpg GRCh37.75 --skip gatk
 ## Install MIP rare disease
   - bash mip.sh
 ## Generate rna installation script

--- a/.travis.yml
+++ b/.travis.yml
@@ -33,7 +33,7 @@ install:
 ## Test installation script and gather coverage information
   - PERL5OPT=-MDevel::Cover=-ignore,"^t/",-coverage,statement,branch,condition,path,subroutine perl t/mip_install.test
 ## Generate rare disease installation script 
-  - PERL5OPT=-MDevel::Cover=-ignore,"^t/",-coverage,statement,branch,condition,path,subroutine perl mip install rare_disease --config definitions/install_rare_disease_parameters.yaml --quiet --bash_set_errexit --install emip epeddy epy3 --envn emip=mip_travis --snpg GRCh37.75 --skip gatk
+  - PERL5OPT=-MDevel::Cover=-ignore,"^t/",-coverage,statement,branch,condition,path,subroutine perl mip install rare_disease --config definitions/install_rare_disease_parameters.yaml --quiet --bash_set_errexit --install emip epeddy epy3 --envn emip=mip_travis --snpg GRCh37.75 --skip gatk --skip freebayes
 ## Install MIP rare disease
   - bash mip.sh
 ## Generate rna installation script

--- a/.travis.yml
+++ b/.travis.yml
@@ -33,11 +33,11 @@ install:
 ## Test installation script and gather coverage information
   - PERL5OPT=-MDevel::Cover=-ignore,"^t/",-coverage,statement,branch,condition,path,subroutine perl t/mip_install.test
 ## Generate rare disease installation script 
-  - PERL5OPT=-MDevel::Cover=-ignore,"^t/",-coverage,statement,branch,condition,path,subroutine perl mip install rare_disease --config definitions/install_rare_disease_parameters.yaml --quiet --bash_set_errexit --install emip esvdb epeddy epy3 --envn emip=mip_travis --snpg GRCh37.75 --skip gatk
+  - PERL5OPT=-MDevel::Cover=-ignore,"^t/",-coverage,statement,branch,condition,path,subroutine perl mip install rare_disease --config definitions/install_rare_disease_parameters.yaml --quiet --bash_set_errexit --install emip epeddy epy3 --envn emip=mip_travis --snpg GRCh37.75 --skip gatk
 ## Install MIP rare disease
   - bash mip.sh
 ## Generate rna installation script
-  - PERL5OPT=-MDevel::Cover=-ignore,"^t/",-coverage,statement,branch,condition,path,subroutine perl mip install rna --config definitions/install_rna_parameters.yaml --quiet --bash_set_errexit --install emip --skip gatk
+  - PERL5OPT=-MDevel::Cover=-ignore,"^t/",-coverage,statement,branch,condition,path,subroutine perl mip install rna --config definitions/install_rna_parameters.yaml --quiet --bash_set_errexit --install emip --skip gatk --skip freebayes
 ## Install MIP rna
   - bash mip.sh
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -33,11 +33,11 @@ install:
 ## Test installation script and gather coverage information
   - PERL5OPT=-MDevel::Cover=-ignore,"^t/",-coverage,statement,branch,condition,path,subroutine perl t/mip_install.test
 ## Generate rare disease installation script 
-  - PERL5OPT=-MDevel::Cover=-ignore,"^t/",-coverage,statement,branch,condition,path,subroutine perl mip install rare_disease --config definitions/install_rare_disease_parameters.yaml --quiet --bash_set_errexit --install emip epeddy epy3 --envn emip=mip_travis --snpg GRCh37.75 --skip gatk
+  - PERL5OPT=-MDevel::Cover=-ignore,"^t/",-coverage,statement,branch,condition,path,subroutine perl mip install rare_disease --config definitions/install_rare_disease_parameters.yaml --quiet --bash_set_errexit --install emip epeddy epy3 --envn emip=mip_travis --snpg GRCh37.75 --skip gatk --skip freebayes
 ## Install MIP rare disease
   - bash mip.sh
 ## Generate rna installation script
-  - PERL5OPT=-MDevel::Cover=-ignore,"^t/",-coverage,statement,branch,condition,path,subroutine perl mip install rna --config definitions/install_rna_parameters.yaml --quiet --bash_set_errexit --install emip --skip gatk --skip freebayes
+  - PERL5OPT=-MDevel::Cover=-ignore,"^t/",-coverage,statement,branch,condition,path,subroutine perl mip install rna --config definitions/install_rna_parameters.yaml --quiet --bash_set_errexit --install emip --skip gatk
 ## Install MIP rna
   - bash mip.sh
 

--- a/README.md
+++ b/README.md
@@ -131,7 +131,6 @@ This will generate a batch script called "mip.sh" in your working directory.
   * MIP_cnvnator
   * MIP_peddy
   * MIP_py3
-  * MIP_svdb
   * MIP_vep  
 
 It is possible to specify which environments to install using the ``--installations`` flag, as well as the names of the environments using the ``environment_name`` flag. E.g. ``--installations emip ecnvnator --environment_name emip=MIP ecnvnator=CNVNATOR``.   
@@ -159,7 +158,7 @@ $ perl t/mip_analyse_rare_disease.test
 ```
 
 ###### When setting up your analysis config file
-  In your config yaml file or on the command line you will have to supply the ``module_source_environment_command`` parameter to activate the conda environment specific for the tool. Here is an example with three Python 3 tools in their own environment and Peddy, CNVnator, SVDB and VEP in each own, with some extra initialization:
+  In your config yaml file or on the command line you will have to supply the ``module_source_environment_command`` parameter to activate the conda environment specific for the tool. Here is an example with three Python 3 tools in their own environment and Peddy, CNVnator and VEP in each own, with some extra initialization:
 
   ```Yml
   program_source_environment_command:
@@ -197,10 +196,6 @@ $ perl t/mip_analyse_rare_disease.test
      - source
      - activate
      - MIP_py3
-    sv_combinevariantcallsets:
-     - source
-     - activate
-     - MIP_svdb
     sv_varianteffectpredictor:
      - LD_LIBRARY_PATH=[CONDA_PATH]/envs/MIP_vep/lib/:$LD_LIBRARY_PATH;
      - export

--- a/definitions/install_rare_disease_parameters.yaml
+++ b/definitions/install_rare_disease_parameters.yaml
@@ -14,7 +14,7 @@ disable_env_check: 0
 
 # MIP main environment spec 
 emip:
-  bioconda:
+  conda:
     bcftools: 1.6
     bedtools: 2.26.0
     bwa: 0.7.15
@@ -33,18 +33,17 @@ emip:
     numpy: 
     peddy: 0.3.1
     picard: 2.14.1
+    pip:
     plink2: 1.90b3.35
+    python: 2.7
     rtg-tools: 3.8.4
     sambamba: 0.6.6
     samtools: 1.6
     snpeff: 4.3.1
     snpsift: 4.3.1
-    #svdb: 1.0.7
+    #svdb: 1.1.2
     vcfanno: 0.1.0
     vt: 2015.11.10
-  conda:
-    pip:
-    python: 2.7
   pip:
   shell:
     bedtools:
@@ -66,9 +65,9 @@ emip:
       snpeff_genome_versions:
         - GRCh37.75
         - GRCh38.86
-      version: v4_3s
+      version: v4_3t
     svdb:
-      version: 1.1.0
+      version: 1.1.2
     tiddit:
       version: 2.2.1
     vcf2cytosure:
@@ -78,13 +77,12 @@ emip:
 
 # CNVnator environment spec
 ecnvnator:
-  bioconda:
+  conda:
     bcftools: 1.6
     gcc: 4.8.5
-    samtools: 1.6
-  conda:
     pip:
     python: 2.7
+    samtools: 1.6
   pip:
   shell:
     cnvnator:
@@ -93,10 +91,9 @@ ecnvnator:
 
 # Peddy environment spec
 epeddy:
-  bioconda:
+  conda:
     bcftools: 1.6
     peddy: 0.3.1
-  conda:
     pip: 
     python: 2.7
   pip:
@@ -104,11 +101,10 @@ epeddy:
 
 # Python 3 environment spec
 epy3:
-  bioconda:
-    sambamba: 0.6.6 
   conda:
-    pip:
-    python: 3.6
+    pip: 
+    python: 2.7
+    sambamba: 0.6.6 
   pip:
     chanjo: 4.2.0
     genmod: 3.7.2
@@ -117,35 +113,11 @@ epy3:
   shell:
     sambamba: 0.6.1
 
-# SVDB environment spec
-esvdb:
-  bioconda:
-    bcftools: 1.6
-    cython:
-    htslib: 1.6
-    numpy:
-    picard: 2.14.1
-    #svdb: 1.0.7
-    vcfanno: 0.1.0
-    vt: 2015.11.10
-  conda:
-    pip:
-    python: 2.7
-  pip:
-  shell:
-    picard:
-      version: 2.3.0
-    svdb:
-      version: 1.1.0
-    vt:
-      version: gitRepo
-
 # VEP environment spec
 evep:
-  bioconda:
+  conda:
     bcftools: 1.6
     htslib: 1.6
-  conda:
     pip: 
     python: 2.7
   pip:
@@ -159,7 +131,7 @@ evep:
       vep_plugins:
         - LoFtool
         - MaxEntScan
-      version: 92
+      version: 93
 
 # Specify environment names
 environment_name:
@@ -168,14 +140,14 @@ environment_name:
   epeddy:
   epy3:
   esvdb:
-  evep:
+  #evep:
 
 # Environments to install
 installations:
   - emip
   - epeddy
   - epy3
-  - esvdb
+  #- esvdb
   - evep
   - ecnvnator
 

--- a/definitions/install_rare_disease_parameters.yaml
+++ b/definitions/install_rare_disease_parameters.yaml
@@ -41,7 +41,7 @@ emip:
     samtools: 1.6
     snpeff: 4.3.1
     snpsift: 4.3.1
-    #svdb: 1.1.2
+    svdb: 1.1.2
     vcfanno: 0.1.0
     vt: 2015.11.10
   pip:
@@ -139,15 +139,13 @@ environment_name:
   ecnvnator:
   epeddy:
   epy3:
-  esvdb:
-  #evep:
+  evep:
 
 # Environments to install
 installations:
   - emip
   - epeddy
   - epy3
-  #- esvdb
   - evep
   - ecnvnator
 

--- a/definitions/install_rna_parameters.yaml
+++ b/definitions/install_rna_parameters.yaml
@@ -14,8 +14,10 @@ disable_env_check: 0
 
 # MIP main environment spec
 emip: 
-  bioconda:
+  conda:
     bcftools: 1.8
+    bioconductor-deseq2:
+    bioconductor-tximport:
     cufflinks: 2.2
     fastqc: 0.11.4
     gatk: 3.8
@@ -23,18 +25,15 @@ emip:
     java-jdk:
     numpy:
     picard: 2.18
+    pip:
+    python: 2.7
+    r-optparse:
+    r-readr:
     salmon: 0.9.1
     sambamba:
     samtools: 1.8
     scipy:
     star: 2.5.4a
-    bioconductor-deseq2:
-    bioconductor-tximport:
-    r-readr:
-    r-optparse:
-  conda:
-    python: 2.7
-    pip:
   shell:
     bootstrapann:
       version: git

--- a/documentation/README.md
+++ b/documentation/README.md
@@ -130,7 +130,6 @@ This will generate a batch script called "mip.sh" in your working directory.
   * MIP_cnvnator
   * MIP_peddy
   * MIP_py3
-  * MIP_svdb
   * MIP_vep
 
 It is possible to specify which environments to install using the ``--installations`` flag, as well as the names of the environments using the ``environment_name`` flag. E.g. ``--installations emip ecnvnator --environment_name emip=MIP ecnvnator=CNVNATOR``.
@@ -158,7 +157,7 @@ $ perl t/mip_analyse_rare_disease.test
 ```
 
 ###### When setting up your analysis config file
-  In your config yaml file or on the command line you will have to supply the ``module_source_environment_command`` parameter to activate the conda environment specific for the tool. Here is an example with three Python 3 tools in their own environment and Peddy, CNVnator, SVDB and VEP in each own, with some extra initialization:
+  In your config yaml file or on the command line you will have to supply the ``module_source_environment_command`` parameter to activate the conda environment specific for the tool. Here is an example with three Python 3 tools in their own environment and Peddy, CNVnator and VEP in each own, with some extra initialization:
 
   ```Yml
   program_source_environment_command:
@@ -196,10 +195,6 @@ $ perl t/mip_analyse_rare_disease.test
      - source
      - activate
      - MIP_py3
-    sv_combinevariantcallsets:
-     - source
-     - activate
-     - MIP_svdb
     sv_varianteffectpredictor:
      - LD_LIBRARY_PATH=[CONDA_PATH]/envs/MIP_vep/lib/:$LD_LIBRARY_PATH;
      - export

--- a/lib/MIP/Cli/Mip/Install/Rare_disease.pm
+++ b/lib/MIP/Cli/Mip/Install/Rare_disease.pm
@@ -26,7 +26,7 @@ use MIP::Main::Install qw{ mip_install };
 use MIP::Script::Utils
   qw{ nest_hash print_parameter_defaults update_program_versions};
 
-our $VERSION = q{0.2.1};
+our $VERSION = q{0.2.2};
 
 extends(qw{ MIP::Cli::Mip::Install });
 
@@ -75,8 +75,7 @@ sub run {
 
     ## Add all environments to installation if full installation was selected
     if ( any { $_ eq q{full} } @{ $parameter{installations} } ) {
-        @{ $parameter{installations} } =
-          qw{ emip epeddy epy3 esvdb evep ecnvnator };
+        @{ $parameter{installations} } = qw{ emip epeddy epy3 evep ecnvnator };
     }
 
     ## Make sure that the cnvnator environment is installed last
@@ -121,7 +120,6 @@ sub _build_usage {
                 emip      => Optional [Str],
                 epeddy    => Optional [Str],
                 epy3      => Optional [Str],
-                esvdb     => Optional [Str],
                 evep      => Optional [Str],
                 ecnvnator => Optional [Str],
             ],
@@ -133,12 +131,12 @@ sub _build_usage {
         q{installations} => (
             cmd_aliases   => [qw{ install }],
             cmd_flag      => q{installations},
-            cmd_tags      => [q{Default: emip, epeddy, epy3, esvdb, evep}],
+            cmd_tags      => [q{Default: emip, epeddy, epy3, evep}],
             documentation => q{Environments to install},
             is            => q{rw},
-            isa           => ArrayRef [
-                enum( [qw{ emip epeddy epy3 esvdb evep ecnvnator full }] ),
-            ],
+            isa =>
+              ArrayRef [ enum( [qw{ emip epeddy epy3 evep ecnvnator full }] ),
+              ],
             required => 0,
         ),
     );

--- a/t/mip_analyse_rare_disease.test
+++ b/t/mip_analyse_rare_disease.test
@@ -110,7 +110,7 @@ my $cmds_ref = [
         $cluster_constant_path,
         qw{ 643594-miptest test_data ADM1059A3 fastq=ADM1059A3 }
     ),
-    qw{--rio --dra --psvv 0 },
+    qw{ --rio --dra --psvv 0 },
 ];
 
 my ( $success, $error_message, $full_buf, $stdout_buf, $stderr_buf ) =

--- a/templates/mip_config.yaml
+++ b/templates/mip_config.yaml
@@ -108,7 +108,7 @@ delly_reformat: 1
 endvariantannotationblock: 1
 evaluation: 1
 fastqc: 1
-freebayes: 1
+freebayes: 0
 frequency_filter: 1
 gatk_baserecalibration: 1
 gatk_combinevariantcallsets: 1
@@ -148,7 +148,7 @@ vt: 1
 qccollect: 1
 ## Parameters
 frequency_genmod_filter: 1
-gatk_combinevariants_prioritize_caller: gatk,bcftools,freebayes
+gatk_combinevariants_prioritize_caller: gatk,bcftools
 gatk_concatenate_genotypegvcfs_bcf_file: 1
 gatk_path: cluster_constant_path!
 gatk_baserecalibration_disable_indel_qual: 1


### PR DESCRIPTION
- Added SVDB to the main MIP environment.   
Newer versions of SVDB has no scikit-learn dependency and should be able to work together with the other programs in the MIP environment. Fixes #451 

- All conda programs are now installed together.  
Removed the separation between installation of conda and bioconda packages. All packages are now installed together via the conda-forge and bioconda channels. Fixes #450

- Dropped Freebayes from the travis installation.  
Freebayes tries to install perl and perl-threaded. Freebayes is still part of the standard installation but for now dropped from the travis test installation. The program is also removed from t/mip_analyse_rare_disease.t in order to not generate travis errrors. Issue reported #537