### PR TITLE
change base command from string to array

### DIFF
--- a/lib/MIP/Test/Writefile.pm
+++ b/lib/MIP/Test/Writefile.pm
@@ -35,7 +35,7 @@ sub test_write_to_file {
 ##Function : Test of writing to file using anonymous FILEHANDLE
 ##Returns  :
 ##Arguments: $args_ref             => Arguments to function call
-##         : $base_command         => First word in command line usually name of executable
+##         : $base_commands_ref    => Base commands {REF}
 ##         : $module_function_cref => Module method to test
 ##         : $separator            => Separator to use when writing
 
@@ -43,7 +43,7 @@ sub test_write_to_file {
 
     ## Flatten argument(s)
     my $args_ref;
-    my $base_command;
+    my $base_commands_ref;
     my $module_function_cref;
     my $separator;
 
@@ -55,10 +55,11 @@ sub test_write_to_file {
             store       => \$args_ref,
             strict_type => 1,
         },
-        base_command => {
+        base_commands_ref => {
             defined     => 1,
+			default => [],
             required    => 1,
-            store       => \$base_command,
+            store       => \$base_commands_ref,
             strict_type => 1,
         },
         module_function_cref =>
@@ -94,7 +95,9 @@ sub test_write_to_file {
 
     close $FILEHANDLE;
 
-    ## Perform test
+	my $base_command = join $separator, @{ $base_commands_ref };
+    
+	## Perform test
     my ($returned_base_command) = $file_content =~ /^($base_command)/ms;
 
     is( $returned_base_command, $base_command,

--- a/t/bcftools_annotate.t
+++ b/t/bcftools_annotate.t
@@ -99,7 +99,7 @@ diag(   q{Test bcftools_annotate from Bcftools.pm v}
       . $EXECUTABLE_NAME );
 
 ## Base arguments
-my $function_base_command = q{bcftools};
+my @function_base_commands = qw{ bcftools };
 
 my %base_argument = (
     stderrfile_path => {
@@ -112,7 +112,7 @@ my %base_argument = (
     },
     FILEHANDLE => {
         input           => undef,
-        expected_output => $function_base_command,
+        expected_output => \@function_base_commands,
     },
 );
 
@@ -161,11 +161,11 @@ ARGUMENT_HASH_REF:
 foreach my $argument_href (@arguments) {
     my @commands = test_function(
         {
-            argument_href          => $argument_href,
-            required_argument_href => \%required_argument,
-            module_function_cref   => $module_function_cref,
-            function_base_command  => $function_base_command,
-            do_test_base_command   => 1,
+            argument_href              => $argument_href,
+            required_argument_href     => \%required_argument,
+            module_function_cref       => $module_function_cref,
+            function_base_commands_ref => \@function_base_commands,
+            do_test_base_command       => 1,
         }
     );
 }

--- a/t/bcftools_base.t
+++ b/t/bcftools_base.t
@@ -99,12 +99,12 @@ diag(   q{Test bcftools_base from Base::Bcftools.pm v}
       . $EXECUTABLE_NAME );
 
 ## Base arguments
-my $function_base_command = q{bcftools};
+my @function_base_commands = qw{ bcftools };
 
 my %base_argument = (
     FILEHANDLE => {
         input           => undef,
-        expected_output => $function_base_command,
+        expected_output => \@function_base_commands,
     },
 );
 
@@ -117,7 +117,7 @@ my %required_argument = (
     },
     FILEHANDLE => {
         input           => undef,
-        expected_output => $function_base_command,
+        expected_output => \@function_base_commands,
     },
 );
 
@@ -160,11 +160,11 @@ ARGUMENT_HASH_REF:
 foreach my $argument_href (@arguments) {
     my @commands = test_function(
         {
-            argument_href          => $argument_href,
-            required_argument_href => \%required_argument,
-            module_function_cref   => $module_function_cref,
-            function_base_command  => $function_base_command,
-            do_test_base_command   => 1,
+            argument_href              => $argument_href,
+            required_argument_href     => \%required_argument,
+            module_function_cref       => $module_function_cref,
+            function_base_commands_ref => \@function_base_commands,
+            do_test_base_command       => 1,
         }
     );
 }

--- a/t/bcftools_call.t
+++ b/t/bcftools_call.t
@@ -99,7 +99,7 @@ diag(   q{Test bcftools_call from Bcftools v}
       . $EXECUTABLE_NAME );
 
 ## Base arguments
-my $function_base_command = q{bcftools};
+my @function_base_commands = qw{ bcftools };
 
 my %base_argument = (
     stdoutfile_path => {
@@ -116,7 +116,7 @@ my %base_argument = (
     },
     FILEHANDLE => {
         input           => undef,
-        expected_output => $function_base_command,
+        expected_output => \@function_base_commands,
     },
 );
 
@@ -171,11 +171,11 @@ ARGUMENT_HASH_REF:
 foreach my $argument_href (@arguments) {
     my @commands = test_function(
         {
-            argument_href          => $argument_href,
-            required_argument_href => \%required_argument,
-            module_function_cref   => $module_function_cref,
-            function_base_command  => $function_base_command,
-            do_test_base_command   => 1,
+            argument_href              => $argument_href,
+            required_argument_href     => \%required_argument,
+            module_function_cref       => $module_function_cref,
+            function_base_commands_ref => \@function_base_commands,
+            do_test_base_command       => 1,
         }
     );
 }

--- a/t/bcftools_concat.t
+++ b/t/bcftools_concat.t
@@ -101,7 +101,7 @@ diag(   q{Test bcftools_concat from Bcftools.pm v}
       . $EXECUTABLE_NAME );
 
 ## Base arguments
-my $function_base_command = q{bcftools};
+my @function_base_commands = qw{ bcftools };
 
 my %base_argument = (
     stdoutfile_path => {
@@ -118,7 +118,7 @@ my %base_argument = (
     },
     FILEHANDLE => {
         input           => undef,
-        expected_output => $function_base_command,
+        expected_output => \@function_base_commands,
     },
 );
 
@@ -161,11 +161,11 @@ ARGUMENT_HASH_REF:
 foreach my $argument_href (@arguments) {
     my @commands = test_function(
         {
-            argument_href          => $argument_href,
-            required_argument_href => \%required_argument,
-            module_function_cref   => $module_function_cref,
-            function_base_command  => $function_base_command,
-            do_test_base_command   => 1,
+            argument_href              => $argument_href,
+            required_argument_href     => \%required_argument,
+            module_function_cref       => $module_function_cref,
+            function_base_commands_ref => \@function_base_commands,
+            do_test_base_command       => 1,
         }
     );
 }

--- a/t/bcftools_filter.t
+++ b/t/bcftools_filter.t
@@ -100,7 +100,7 @@ diag(   q{Test bcftools_filter from Bcftools.pm v}
       . $EXECUTABLE_NAME );
 
 ## Base arguments
-my $function_base_command = q{bcftools};
+my @function_base_commands = qw{ bcftools };
 
 my %base_argument = (
     stdoutfile_path => {
@@ -117,7 +117,7 @@ my %base_argument = (
     },
     FILEHANDLE => {
         input           => undef,
-        expected_output => $function_base_command,
+        expected_output => \@function_base_commands,
     },
 );
 
@@ -169,11 +169,11 @@ ARGUMENT_HASH_REF:
 foreach my $argument_href (@arguments) {
     my @commands = test_function(
         {
-            argument_href          => $argument_href,
-            required_argument_href => \%required_argument,
-            module_function_cref   => $module_function_cref,
-            function_base_command  => $function_base_command,
-            do_test_base_command   => 1,
+            argument_href              => $argument_href,
+            required_argument_href     => \%required_argument,
+            module_function_cref       => $module_function_cref,
+            function_base_commands_ref => \@function_base_commands,
+            do_test_base_command       => 1,
         }
     );
 }

--- a/t/bcftools_index.t
+++ b/t/bcftools_index.t
@@ -99,7 +99,7 @@ diag(   q{Test bcftools_index from Bcftools v}
       . $EXECUTABLE_NAME );
 
 ## Base arguments
-my $function_base_command = q{bcftools};
+my @function_base_commands = qw{ bcftools };
 
 my %base_argument = (
     stdoutfile_path => {
@@ -116,7 +116,7 @@ my %base_argument = (
     },
     FILEHANDLE => {
         input           => undef,
-        expected_output => $function_base_command,
+        expected_output => \@function_base_commands,
     },
 );
 
@@ -146,11 +146,11 @@ ARGUMENT_HASH_REF:
 foreach my $argument_href (@arguments) {
     my @commands = test_function(
         {
-            argument_href          => $argument_href,
-            required_argument_href => \%required_argument,
-            module_function_cref   => $module_function_cref,
-            function_base_command  => $function_base_command,
-            do_test_base_command   => 1,
+            argument_href              => $argument_href,
+            required_argument_href     => \%required_argument,
+            module_function_cref       => $module_function_cref,
+            function_base_commands_ref => \@function_base_commands,
+            do_test_base_command       => 1,
         }
     );
 }

--- a/t/bcftools_merge.t
+++ b/t/bcftools_merge.t
@@ -99,7 +99,7 @@ diag(   q{Test bcftools_merge from Bcftools.pm v}
       . $EXECUTABLE_NAME );
 
 ## Base arguments
-my $function_base_command = q{bcftools};
+my @function_base_commands = qw{ bcftools };
 
 my %base_argument = (
     stderrfile_path => {
@@ -112,7 +112,7 @@ my %base_argument = (
     },
     FILEHANDLE => {
         input           => undef,
-        expected_output => $function_base_command,
+        expected_output => \@function_base_commands,
     },
     stdoutfile_path => {
         input           => q{stdoutfile.test},
@@ -153,11 +153,11 @@ ARGUMENT_HASH_REF:
 foreach my $argument_href (@arguments) {
     my @commands = test_function(
         {
-            argument_href          => $argument_href,
-            required_argument_href => \%required_argument,
-            module_function_cref   => $module_function_cref,
-            function_base_command  => $function_base_command,
-            do_test_base_command   => 1,
+            argument_href              => $argument_href,
+            required_argument_href     => \%required_argument,
+            module_function_cref       => $module_function_cref,
+            function_base_commands_ref => \@function_base_commands,
+            do_test_base_command       => 1,
         }
     );
 }

--- a/t/bcftools_mpileup.t
+++ b/t/bcftools_mpileup.t
@@ -102,12 +102,12 @@ diag(   q{Test bcftools_mpileup from Variantcalling::Bcftools.pm v}
 Readonly my $ADJUST_MAPPING_QUALITY => 45;
 
 ## Base arguments
-my $function_base_command = q{bcftools};
+my @function_base_commands = qw{ bcftools };
 
 my %base_argument = (
     FILEHANDLE => {
         input           => undef,
-        expected_output => $function_base_command,
+        expected_output => \@function_base_commands,
     },
 );
 
@@ -127,7 +127,7 @@ my %required_argument = (
     },
     FILEHANDLE => {
         input           => undef,
-        expected_output => $function_base_command,
+        expected_output => \@function_base_commands,
     },
     infile_paths_ref => {
         inputs_ref      => [ catfile(qw{dir file_1}), catfile(qw{dir file_2}) ],
@@ -176,10 +176,10 @@ foreach my $argument_href (@arguments) {
 
     my @commands = test_function(
         {
-            argument_href          => $argument_href,
-            required_argument_href => \%required_argument,
-            module_function_cref   => $module_function_cref,
-            function_base_command  => $function_base_command,
+            argument_href              => $argument_href,
+            required_argument_href     => \%required_argument,
+            module_function_cref       => $module_function_cref,
+            function_base_commands_ref => \@function_base_commands,
         }
     );
 }

--- a/t/bcftools_norm.t
+++ b/t/bcftools_norm.t
@@ -99,7 +99,7 @@ diag(   q{Test bcftools_norm from Bcftools.pm v}
       . $EXECUTABLE_NAME );
 
 ## Base arguments
-my $function_base_command = q{bcftools};
+my @function_base_commands = qw{ bcftools };
 
 my %base_argument = (
     stderrfile_path => {
@@ -112,7 +112,7 @@ my %base_argument = (
     },
     FILEHANDLE => {
         input           => undef,
-        expected_output => $function_base_command,
+        expected_output => \@function_base_commands,
     },
 );
 
@@ -163,11 +163,11 @@ ARGUMENT_HASH_REF:
 foreach my $argument_href (@arguments) {
     my @commands = test_function(
         {
-            argument_href          => $argument_href,
-            required_argument_href => \%required_argument,
-            module_function_cref   => $module_function_cref,
-            function_base_command  => $function_base_command,
-            do_test_base_command   => 1,
+            argument_href              => $argument_href,
+            required_argument_href     => \%required_argument,
+            module_function_cref       => $module_function_cref,
+            function_base_commands_ref => \@function_base_commands,
+            do_test_base_command       => 1,
         }
     );
 }

--- a/t/bcftools_reheader.t
+++ b/t/bcftools_reheader.t
@@ -99,12 +99,12 @@ diag(   q{Test bcftools_reheader from Bcftools.pm v}
       . $EXECUTABLE_NAME );
 
 ## Base arguments
-my $function_base_command = q{bcftools};
+my @function_base_commands = qw{ bcftools };
 
 my %base_argument = (
     FILEHANDLE => {
         input           => undef,
-        expected_output => $function_base_command,
+        expected_output => \@function_base_commands,
     },
     stderrfile_path => {
         input           => q{stderrfile.test},
@@ -149,11 +149,11 @@ ARGUMENT_HASH_REF:
 foreach my $argument_href (@arguments) {
     my @commands = test_function(
         {
-            argument_href          => $argument_href,
-            required_argument_href => \%required_argument,
-            module_function_cref   => $module_function_cref,
-            function_base_command  => $function_base_command,
-            do_test_base_command   => 1,
+            argument_href              => $argument_href,
+            required_argument_href     => \%required_argument,
+            module_function_cref       => $module_function_cref,
+            function_base_commands_ref => \@function_base_commands,
+            do_test_base_command       => 1,
         }
     );
 }

--- a/t/bcftools_roh.t
+++ b/t/bcftools_roh.t
@@ -99,12 +99,12 @@ diag(   q{Test bcftools_roh from Bcftools v}
       . $EXECUTABLE_NAME );
 
 ## Base arguments
-my $function_base_command = q{bcftools};
+my @function_base_commands = qw{ bcftools };
 
 my %base_argument = (
     FILEHANDLE => {
         input           => undef,
-        expected_output => $function_base_command,
+        expected_output => \@function_base_commands,
     },
     stderrfile_path => {
         input           => q{stderrfile.test},
@@ -158,11 +158,11 @@ ARGUMENT_HASH_REF:
 foreach my $argument_href (@arguments) {
     my @commands = test_function(
         {
-            argument_href          => $argument_href,
-            required_argument_href => \%required_argument,
-            module_function_cref   => $module_function_cref,
-            function_base_command  => $function_base_command,
-            do_test_base_command   => 1,
+            argument_href              => $argument_href,
+            required_argument_href     => \%required_argument,
+            module_function_cref       => $module_function_cref,
+            function_base_commands_ref => \@function_base_commands,
+            do_test_base_command       => 1,
         }
     );
 }

--- a/t/bcftools_stats.t
+++ b/t/bcftools_stats.t
@@ -99,12 +99,12 @@ diag(   q{Test bcftools_stats from Bcftools.pm v}
       . $EXECUTABLE_NAME );
 
 ## Base arguments
-my $function_base_command = q{bcftools};
+my @function_base_commands = qw{ bcftools };
 
 my %base_argument = (
     FILEHANDLE => {
         input           => undef,
-        expected_output => $function_base_command,
+        expected_output => \@function_base_commands,
     },
     stderrfile_path => {
         input           => q{stderrfile.test},
@@ -141,11 +141,11 @@ ARGUMENT_HASH_REF:
 foreach my $argument_href (@arguments) {
     my @commands = test_function(
         {
-            argument_href          => $argument_href,
-            required_argument_href => \%required_argument,
-            module_function_cref   => $module_function_cref,
-            function_base_command  => $function_base_command,
-            do_test_base_command   => 1,
+            argument_href              => $argument_href,
+            required_argument_href     => \%required_argument,
+            module_function_cref       => $module_function_cref,
+            function_base_commands_ref => \@function_base_commands,
+            do_test_base_command       => 1,
         }
     );
 }

--- a/t/bcftools_view.t
+++ b/t/bcftools_view.t
@@ -99,12 +99,12 @@ diag(   q{Test bcftools_view from Bcftools.pm v}
       . $EXECUTABLE_NAME );
 
 ## Base arguments
-my $function_base_command = q{bcftools};
+my @function_base_commands = qw{ bcftools };
 
 my %base_argument = (
     FILEHANDLE => {
         input           => undef,
-        expected_output => $function_base_command,
+        expected_output => \@function_base_commands,
     },
     stderrfile_path => {
         input           => q{stderrfile.test},
@@ -166,11 +166,11 @@ ARGUMENT_HASH_REF:
 foreach my $argument_href (@arguments) {
     my @commands = test_function(
         {
-            argument_href          => $argument_href,
-            required_argument_href => \%required_argument,
-            module_function_cref   => $module_function_cref,
-            function_base_command  => $function_base_command,
-            do_test_base_command   => 1,
+            argument_href              => $argument_href,
+            required_argument_href     => \%required_argument,
+            module_function_cref       => $module_function_cref,
+            function_base_commands_ref => \@function_base_commands,
+            do_test_base_command       => 1,
         }
     );
 }

--- a/t/bedtools_genomecov.t
+++ b/t/bedtools_genomecov.t
@@ -99,12 +99,12 @@ diag(   q{Test bedtools_genomecov from Bedtools.pm v}
       . $EXECUTABLE_NAME );
 
 ## Base arguments
-my $function_base_command = q{bedtools};
+my @function_base_commands = qw{ bedtools };
 
 my %base_argument = (
     FILEHANDLE => {
         input           => undef,
-        expected_output => $function_base_command,
+        expected_output => \@function_base_commands,
     },
     stderrfile_path => {
         input           => q{stderrfile.test},
@@ -124,7 +124,7 @@ my %base_argument = (
 my %required_argument = (
     FILEHANDLE => {
         input           => undef,
-        expected_output => $function_base_command,
+        expected_output => \@function_base_commands,
     },
     infile_path => {
         input           => q{infile.test},
@@ -164,10 +164,10 @@ foreach my $argument_href (@arguments) {
 
     my @commands = test_function(
         {
-            argument_href          => $argument_href,
-            required_argument_href => \%required_argument,
-            module_function_cref   => $module_function_cref,
-            function_base_command  => $function_base_command,
+            argument_href              => $argument_href,
+            required_argument_href     => \%required_argument,
+            module_function_cref       => $module_function_cref,
+            function_base_commands_ref => \@function_base_commands,
         }
     );
 }

--- a/t/bedtools_intersectbed.t
+++ b/t/bedtools_intersectbed.t
@@ -100,12 +100,12 @@ diag(   q{Test bedtools_intersectbed from Bedtools_intersectbed.pm v}
       . $EXECUTABLE_NAME );
 
 ## Base arguments
-my $function_base_command = q{intersectBed};
+my @function_base_commands = qw{ intersectBed };
 
 my %base_argument = (
     FILEHANDLE => {
         input           => undef,
-        expected_output => $function_base_command,
+        expected_output => \@function_base_commands,
     },
     stderrfile_path => {
         input           => q{stderrfile.test},
@@ -151,11 +151,11 @@ ARGUMENT_HASH_REF:
 foreach my $argument_href (@arguments) {
     my @commands = test_function(
         {
-            argument_href          => $argument_href,
-            required_argument_href => \%required_argument,
-            module_function_cref   => $module_function_cref,
-            function_base_command  => $function_base_command,
-            do_test_base_command   => 1,
+            argument_href              => $argument_href,
+            required_argument_href     => \%required_argument,
+            module_function_cref       => $module_function_cref,
+            function_base_commands_ref => \@function_base_commands,
+            do_test_base_command       => 1,
         }
     );
 }

--- a/t/bedtools_makewindows.t
+++ b/t/bedtools_makewindows.t
@@ -102,12 +102,12 @@ Readonly my $WINDOW_SIZE => 200_000;
 Readonly my $STEP_SIZE   => 199_750;
 
 ## Base arguments
-my $function_base_command = q{bedtools};
+my @function_base_commands = qw{ bedtools };
 
 my %base_argument = (
     FILEHANDLE => {
         input           => undef,
-        expected_output => $function_base_command,
+        expected_output => \@function_base_commands,
     },
     stderrfile_path => {
         input           => q{stderrfile.test},
@@ -127,7 +127,7 @@ my %base_argument = (
 my %required_argument = (
     FILEHANDLE => {
         input           => undef,
-        expected_output => $function_base_command,
+        expected_output => \@function_base_commands,
     },
     infile_bed_path => {
         input           => catfile(qw{ path to infile_bed }),
@@ -165,10 +165,10 @@ foreach my $argument_href (@arguments) {
 
     my @commands = test_function(
         {
-            argument_href          => $argument_href,
-            required_argument_href => \%required_argument,
-            module_function_cref   => $module_function_cref,
-            function_base_command  => $function_base_command,
+            argument_href              => $argument_href,
+            required_argument_href     => \%required_argument,
+            module_function_cref       => $module_function_cref,
+            function_base_commands_ref => \@function_base_commands,
         }
     );
 }

--- a/t/blobfish_all_vs_all.t
+++ b/t/blobfish_all_vs_all.t
@@ -97,7 +97,7 @@ diag(   q{Test blobfish_all_vs_all from BlobFish.pm v}
       . $SPACE
       . $EXECUTABLE_NAME );
 
-my $function_base_command = q{BlobFish.py --allvsall};
+my @function_base_commands = qw{ BlobFish.py --allvsall };
 
 my %base_argument = (
     stdoutfile_path => {
@@ -114,7 +114,7 @@ my %base_argument = (
     },
     FILEHANDLE => {
         input           => undef,
-        expected_output => $function_base_command,
+        expected_output => \@function_base_commands,
     },
 );
 
@@ -198,11 +198,11 @@ ARGUMENT_HASH_REF:
 foreach my $argument_href (@arguments) {
     my @commands = test_function(
         {
-            argument_href          => $argument_href,
-            required_argument_href => \%required_argument,
-            module_function_cref   => $module_function_cref,
-            function_base_command  => $function_base_command,
-            do_test_base_command   => 1,
+            argument_href              => $argument_href,
+            required_argument_href     => \%required_argument,
+            module_function_cref       => $module_function_cref,
+            function_base_commands_ref => \@function_base_commands,
+            do_test_base_command       => 1,
         }
     );
 }

--- a/t/bootstrapann.t
+++ b/t/bootstrapann.t
@@ -97,7 +97,7 @@ diag(   q{Test bootrstrapann from Variantcalling::BootstrapAnn.pm v}
       . $SPACE
       . $EXECUTABLE_NAME );
 
-my $function_base_command = q{BootstrapAnn.py};
+my @function_base_commands = qw{ BootstrapAnn.py };
 
 my %base_argument = (
     stdoutfile_path => {
@@ -114,7 +114,7 @@ my %base_argument = (
     },
     FILEHANDLE => {
         input           => undef,
-        expected_output => $function_base_command,
+        expected_output => \@function_base_commands,
     },
 );
 
@@ -148,11 +148,11 @@ ARGUMENT_HASH_REF:
 foreach my $argument_href (@arguments) {
     my @commands = test_function(
         {
-            argument_href          => $argument_href,
-            required_argument_href => \%required_argument,
-            module_function_cref   => $module_function_cref,
-            function_base_command  => $function_base_command,
-            do_test_base_command   => 1,
+            argument_href              => $argument_href,
+            required_argument_href     => \%required_argument,
+            module_function_cref       => $module_function_cref,
+            function_base_commands_ref => \@function_base_commands,
+            do_test_base_command       => 1,
         }
     );
 }

--- a/t/build_file_prefix_tag.t
+++ b/t/build_file_prefix_tag.t
@@ -105,8 +105,8 @@ my @order_programs = qw{ bwa_mem pmerge pmark manta };
 
 my %active_parameter = (
     family_id             => q{simpsons},
-    bwa_mem              => 1,
-    manta                => 1,
+    bwa_mem               => 1,
+    manta                 => 1,
     pmark                 => 1,
     pmerge                => 0,
     random_test_parameter => undef,
@@ -116,7 +116,7 @@ my %active_parameter = (
 my %file_info;
 my %parameter = (
     dynamic_parameter => { program => [qw{ bwa_mem pmark manta pmerge }], },
-    bwa_mem          => {
+    bwa_mem           => {
         chain    => $current_chain,
         file_tag => q{mem},
     },
@@ -147,12 +147,12 @@ build_file_prefix_tag(
 my %expected_file_tag = (
     $sample_id => {
         bwa_mem => { file_tag => q{mem}, },
-        pmark    => { file_tag => q{memmd}, },
+        pmark   => { file_tag => q{memmd}, },
         manta   => { file_tag => q{memmdmanta}, },
     },
     q{simpsons} => {
         bwa_mem => { file_tag => q{mem}, },
-        pmark    => { file_tag => q{memmd}, },
+        pmark   => { file_tag => q{memmd}, },
         manta   => { file_tag => q{memmdmanta}, },
     },
 );

--- a/t/build_human_genome_prerequisites.t
+++ b/t/build_human_genome_prerequisites.t
@@ -45,7 +45,8 @@ BEGIN {
 ### Check all internal dependency modules and imports
 ## Modules with import
     my %perl_module = (
-        q{MIP::Recipes::Build::Human_genome_prerequisites} => [qw{ build_human_genome_prerequisites }],
+        q{MIP::Recipes::Build::Human_genome_prerequisites} =>
+          [qw{ build_human_genome_prerequisites }],
         q{MIP::Test::Fixtures} =>
           [qw{ test_log test_mip_hashes test_standard_cli }],
     );
@@ -53,9 +54,11 @@ BEGIN {
     test_import( { perl_module_href => \%perl_module, } );
 }
 
-use MIP::Recipes::Build::Human_genome_prerequisites qw{ build_human_genome_prerequisites };
+use MIP::Recipes::Build::Human_genome_prerequisites
+  qw{ build_human_genome_prerequisites };
 
-diag(   q{Test build_human_genome_prerequisites from Human_genome_prerequisites.pm v}
+diag(
+q{Test build_human_genome_prerequisites from Human_genome_prerequisites.pm v}
       . $MIP::Recipes::Build::Human_genome_prerequisites::VERSION
       . $COMMA
       . $SPACE . q{Perl}
@@ -68,7 +71,7 @@ my $log = test_log();
 
 ## Given build parameters
 my $parameter_build_name = q{human_genome_reference_file_endings};
-my $program_name = q{bwa_mem};
+my $program_name         = q{bwa_mem};
 
 my %active_parameter = test_mip_hashes(
     {
@@ -98,17 +101,18 @@ trap {
             infile_lane_prefix_href => \%infile_lane_prefix,
             job_id_href             => \%job_id,
             log                     => $log,
-	 parameter_build_suffixes_ref =>
-	 \@{ $file_info{$parameter_build_name} },
-            parameter_href          => \%parameter,
-            program_name            => $program_name,
-            sample_info_href        => \%sample_info,
+            parameter_build_suffixes_ref =>
+              \@{ $file_info{$parameter_build_name} },
+            parameter_href   => \%parameter,
+            program_name     => $program_name,
+            sample_info_href => \%sample_info,
         }
       )
 };
 
 ## Then broadcast info log message
 my $log_msg = q{Will\s+try\s+to\s+create\s+.dict};
-like( $trap->stderr, qr/$log_msg/msx, q{Broadcast human genome build log message} );
+like( $trap->stderr, qr/$log_msg/msx,
+    q{Broadcast human genome build log message} );
 
 done_testing();

--- a/t/build_shebang.t
+++ b/t/build_shebang.t
@@ -153,13 +153,13 @@ my @args = (
 ## Coderef - enables generalized use of generate call
 my $module_function_cref = \&build_shebang;
 
-my $function_base_command = $batch_shebang . $bash_bin_path,;
+my @function_base_commands = ( $batch_shebang . $bash_bin_path );
 
 test_write_to_file(
     {
         args_ref             => \@args,
         module_function_cref => $module_function_cref,
-        base_command         => $function_base_command,
+        base_commands_ref    => \@function_base_commands,
         separator            => $separator,
     }
 );

--- a/t/bwa_index.t
+++ b/t/bwa_index.t
@@ -100,7 +100,7 @@ diag(   q{Test bwa_index from Bwa.pm v}
       . $EXECUTABLE_NAME );
 
 ## Base arguments
-my $function_base_command = q{bwa index};
+my @function_base_commands = qw{ bwa index };
 
 my %base_argument = (
     stdoutfile_path => {
@@ -117,7 +117,7 @@ my %base_argument = (
     },
     FILEHANDLE => {
         input           => undef,
-        expected_output => $function_base_command,
+        expected_output => \@function_base_commands,
     },
 );
 
@@ -159,11 +159,11 @@ ARGUMENT_HASH_REF:
 foreach my $argument_href (@arguments) {
     my @commands = test_function(
         {
-            argument_href          => $argument_href,
-            required_argument_href => \%required_argument,
-            module_function_cref   => $module_function_cref,
-            function_base_command  => $function_base_command,
-            do_test_base_command   => 1,
+            argument_href              => $argument_href,
+            required_argument_href     => \%required_argument,
+            module_function_cref       => $module_function_cref,
+            function_base_commands_ref => \@function_base_commands,
+            do_test_base_command       => 1,
         }
     );
 }

--- a/t/bwa_mem.t
+++ b/t/bwa_mem.t
@@ -101,7 +101,7 @@ diag(   q{Test bwa_mem from Bwa.pm v}
       . $EXECUTABLE_NAME );
 
 ## Base arguments
-my $function_base_command = q{bwa mem};
+my @function_base_commands = qw{ bwa mem };
 
 ## Read group header line
 my @read_group_headers = (
@@ -126,7 +126,7 @@ my %base_argument = (
     },
     FILEHANDLE => {
         input           => undef,
-        expected_output => $function_base_command,
+        expected_output => \@function_base_commands,
     },
 );
 
@@ -134,7 +134,7 @@ my %base_argument = (
 my %required_argument = (
     FILEHANDLE => {
         input           => undef,
-        expected_output => $function_base_command,
+        expected_output => \@function_base_commands,
     },
     infile_path => {
         input           => q{test_infile.fastq},
@@ -195,11 +195,11 @@ my @arguments = ( \%required_argument, \%specific_argument );
 foreach my $argument_href (@arguments) {
     my @commands = test_function(
         {
-            argument_href          => $argument_href,
-            required_argument_href => \%required_argument,
-            module_function_cref   => $module_function_cref,
-            function_base_command  => $function_base_command,
-            do_test_base_command   => 1,
+            argument_href              => $argument_href,
+            required_argument_href     => \%required_argument,
+            module_function_cref       => $module_function_cref,
+            function_base_commands_ref => \@function_base_commands,
+            do_test_base_command       => 1,
         }
     );
 }

--- a/t/bzip2.t
+++ b/t/bzip2.t
@@ -100,7 +100,7 @@ diag(   q{Test bzip2 from Bzip2.pm v}
       . $EXECUTABLE_NAME );
 
 ## Base arguments
-my $function_base_command = q{bzip2};
+my @function_base_commands = qw{ bzip2 };
 
 my %base_argument = (
     stderrfile_path => {
@@ -113,7 +113,7 @@ my %base_argument = (
     },
     FILEHANDLE => {
         input           => undef,
-        expected_output => $function_base_command,
+        expected_output => \@function_base_commands,
     },
 );
 
@@ -121,8 +121,8 @@ my %base_argument = (
 ## to enable testing of each individual argument
 my %required_argument = (
     infile_path => {
-        input           => catfile( qw{ path to file } ),
-        expected_output => catfile( qw{ path to file } ),
+        input           => catfile(qw{ path to file }),
+        expected_output => catfile(qw{ path to file }),
     },
 );
 
@@ -140,12 +140,12 @@ my %specific_argument = (
         expected_output => q{--decompress},
     },
     infile_path => {
-        input           => catfile( qw{ path to file } ),
-        expected_output => catfile( qw{ path to file } ),
+        input           => catfile(qw{ path to file }),
+        expected_output => catfile(qw{ path to file }),
     },
     FILEHANDLE => {
         input           => undef,
-        expected_output => $function_base_command,
+        expected_output => \@function_base_commands,
     },
     quiet => {
         input           => 1,
@@ -171,11 +171,11 @@ ARGUMENT_HASH_REF:
 foreach my $argument_href (@arguments) {
     my @commands = test_function(
         {
-            argument_href          => $argument_href,
-            required_argument_href => \%required_argument,
-            module_function_cref   => $module_function_cref,
-            function_base_command  => $function_base_command,
-            do_test_base_command   => 1,
+            argument_href              => $argument_href,
+            required_argument_href     => \%required_argument,
+            module_function_cref       => $module_function_cref,
+            function_base_commands_ref => \@function_base_commands,
+            do_test_base_command       => 1,
         }
     );
 }

--- a/t/chanjo_sex.t
+++ b/t/chanjo_sex.t
@@ -92,12 +92,12 @@ diag(
 );
 
 ## Base arguments
-my $function_base_command = q{chanjo};
+my @function_base_commands = qw{ chanjo };
 
 my %base_argument = (
     FILEHANDLE => {
         input           => undef,
-        expected_output => $function_base_command,
+        expected_output => \@function_base_commands,
     },
 );
 
@@ -105,7 +105,7 @@ my %base_argument = (
 my %required_argument = (
     FILEHANDLE => {
         input           => undef,
-        expected_output => $function_base_command,
+        expected_output => \@function_base_commands,
     },
     infile_path => {
         input           => q{infile.test},
@@ -152,10 +152,10 @@ foreach my $argument_href (@arguments) {
 
     my @commands = test_function(
         {
-            argument_href          => $argument_href,
-            required_argument_href => \%required_argument,
-            module_function_cref   => $module_function_cref,
-            function_base_command  => $function_base_command,
+            argument_href              => $argument_href,
+            required_argument_href     => \%required_argument,
+            module_function_cref       => $module_function_cref,
+            function_base_commands_ref => \@function_base_commands,
         }
     );
 }

--- a/t/check_aligner.t
+++ b/t/check_aligner.t
@@ -116,11 +116,11 @@ my $log = initiate_logger(
 my @broadcasts;
 my %active_parameter = (
     bwa_mem => 1,
-    verbose  => 1,
+    verbose => 1,
 );
 my %parameter = (
     dynamic_parameter => { aligners    => [ qw{ bwa_mem pstar }, ], },
-    bwa_mem          => { outdir_name => q{.bam}, }
+    bwa_mem           => { outdir_name => q{.bam}, }
 );
 
 check_aligner(

--- a/t/check_cmd_config_vs_definition_file.t
+++ b/t/check_cmd_config_vs_definition_file.t
@@ -108,7 +108,7 @@ my %parameter = load_yaml(
 );
 
 my %active_parameter = (
-    bwa_mem                => 1,
+    bwa_mem                 => 1,
     vcfparser_outfile_count => 1,
     family_id               => q{family_1},    #Add mandatory key default
     family_1                => 1,

--- a/t/check_command_in_path.t
+++ b/t/check_command_in_path.t
@@ -117,7 +117,7 @@ my $log = initiate_logger(
 
 my %active_parameter = (
     conda_path => catfile( $Bin, qw{ data modules miniconda } ),
-    bwa_mem   => 0,
+    bwa_mem    => 0,
 );
 my %parameter;
 
@@ -154,7 +154,7 @@ is( $return, undef,
 ## Given switched on active parameter, defined program and program_name_path parameter, when program is in path and executable
 %active_parameter = (
     conda_path => catfile( $Bin, qw{ data modules miniconda } ),
-    bwa_mem   => 1,
+    bwa_mem    => 1,
 );
 
 %parameter = (
@@ -181,7 +181,7 @@ like( $trap->stderr, qr/INFO/xms,
 ## Given switched on active parameter, defined program and program_name_path parameter, when program is in path and executable
 %active_parameter = (
     conda_path => catfile( $Bin, qw{ data modules miniconda } ),
-    bwa_mem   => 1,
+    bwa_mem    => 1,
 );
 
 %parameter = (

--- a/t/check_parameter_files.t
+++ b/t/check_parameter_files.t
@@ -129,7 +129,7 @@ my %active_parameter = (
     # To test scalar parameter
     human_genome_reference =>
       catfile( $Bin, qw{data references GRCh37_homo_sapiens_-d5-.fasta} ),
-    mip                     => 1,
+    mip                    => 1,
     gatk_baserecalibration => 1,
     gatk_genotypegvcfs     => 1,
     snpeff                 => 1,

--- a/t/check_prioritize_variant_callers.t
+++ b/t/check_prioritize_variant_callers.t
@@ -118,9 +118,9 @@ my $log = initiate_logger(
 ## Given active callers, when priority string is ok
 my %active_parameter = (
     gatk_combinevariants_prioritize_caller => q{gatk,bcftools,freebayes},
-    bcftools_mpileup                      => 1,
-    freebayes                             => 1,
-    gatk_variantrecalibration             => 1,
+    bcftools_mpileup                       => 1,
+    freebayes                              => 1,
+    gatk_variantrecalibration              => 1,
 );
 
 my %parameter = (

--- a/t/check_program_mode.t
+++ b/t/check_program_mode.t
@@ -121,7 +121,7 @@ my %parameter =
 my %active_parameter = (
     bwa_mem => 1,
     fastqc  => 0,
-    pgenmod  => 2,
+    pgenmod => 2,
 );
 
 my $is_ok = check_program_mode(

--- a/t/check_references_for_vt.t
+++ b/t/check_references_for_vt.t
@@ -116,7 +116,7 @@ my $log = initiate_logger(
 );
 
 my %active_parameter_test = (
-    gatk_baserecalibration            => 1,
+    gatk_baserecalibration             => 1,
     gatk_baserecalibration_known_sites => [
         catfile( $Bin, qw{ data references GRCh37_dbsnp_-138-.vcf } ),
         catfile( $Bin, qw{ data references GRCh37_1000g_indels_-phase1-.vcf } ),
@@ -125,7 +125,7 @@ my %active_parameter_test = (
             qw{ data references GRCh37_mills_and_1000g_indels_-gold_standard-.vcf }
         )
     ],
-    gatk_realigner                  => 1,
+    gatk_realigner                   => 1,
     gatk_realigner_indel_known_sites => [
         catfile( $Bin, qw{ data references GRCh37_1000g_indels_-phase1-.vcf } ),
         catfile(
@@ -136,8 +136,8 @@ my %active_parameter_test = (
     gatk_variantevalall => 1,
     gatk_varianteval_dbsnp =>
       catfile( $Bin, qw{ data references GRCh37_dbsnp_-138_esa_129-.vcf } ),
-    gatk_variantevalexome   => 1,
-    snpeff                  => 1,
+    gatk_variantevalexome    => 1,
+    snpeff                   => 1,
     snpsift_annotation_files => {
         catfile( $Bin,
             qw{ data references GRCh37_anon-swegen_snp_-1000samples-.vcf.gz } )
@@ -159,9 +159,8 @@ my %parameter_test = (
     gatk_realigner_indel_known_sites =>
       { associated_program => [qw{ gatk_realigner }], data_type => q{ARRAY}, },
     gatk_varianteval_dbsnp => {
-        associated_program =>
-          [qw{ gatk_variantevalall gatk_variantevalexome }],
-        data_type => q{SCALAR},
+        associated_program => [qw{ gatk_variantevalall gatk_variantevalexome }],
+        data_type          => q{SCALAR},
     },
     snpsift_annotation_files =>
       { associated_program => [qw{ snpeff }], data_type => q{HASH}, },

--- a/t/check_vcfanno_toml.t
+++ b/t/check_vcfanno_toml.t
@@ -117,7 +117,9 @@ my $log = initiate_logger(
 
 ## Given a frequency file and toml file, when matching records
 my $sv_vcfanno_config_file =
-  catfile(qw{ / home travis build Clinical-Genomics MIP t data references GRCh37_all_sv_-phase3_v2.2013-05-02-.vcf.gz });
+  catfile(
+    qw{ / home travis build Clinical-Genomics MIP t data references GRCh37_all_sv_-phase3_v2.2013-05-02-.vcf.gz }
+  );
 
 my $sv_vcfanno_config =
   catfile( $Bin, qw{ data references GRCh37_vcfanno_config_-v1.0-.toml  } );

--- a/t/cmake.t
+++ b/t/cmake.t
@@ -100,7 +100,7 @@ diag(   q{Test cmake from Cmake.pm v}
       . $EXECUTABLE_NAME );
 
 ## Base arguments
-my $function_base_command = q{cmake};
+my @function_base_commands = qw{ cmake };
 
 my %base_argument = (
     stdoutfile_path => {
@@ -117,7 +117,7 @@ my %base_argument = (
     },
     FILEHANDLE => {
         input           => undef,
-        expected_output => $function_base_command,
+        expected_output => \@function_base_commands,
     },
 );
 
@@ -138,10 +138,10 @@ ARGUMENT_HASH_REF:
 foreach my $argument_href (@arguments) {
     my @commands = test_function(
         {
-            argument_href         => $argument_href,
-            module_function_cref  => $module_function_cref,
-            function_base_command => $function_base_command,
-            do_test_base_command  => 1,
+            argument_href              => $argument_href,
+            module_function_cref       => $module_function_cref,
+            function_base_commands_ref => \@function_base_commands,
+            do_test_base_command       => 1,
         }
     );
 }

--- a/t/cnvnator_calling.t
+++ b/t/cnvnator_calling.t
@@ -97,7 +97,7 @@ diag(   q{Test cnvnator_calling from Cnvnator v}
       . $EXECUTABLE_NAME );
 
 ## Base arguments
-my $function_base_command = q{cnvnator};
+my @function_base_commands = qw{ cnvnator };
 
 my %base_argument = (
     stderrfile_path => {
@@ -106,7 +106,7 @@ my %base_argument = (
     },
     FILEHANDLE => {
         input           => undef,
-        expected_output => $function_base_command,
+        expected_output => \@function_base_commands,
     },
     stdoutfile_path => {
         input           => q{stdoutfile_path.test},
@@ -125,7 +125,7 @@ my %required_argument = (
 
 my %specific_argument = (
     regions_ref => {
-        inputs_ref => [qw{ 1 2 3 }],
+        inputs_ref      => [qw{ 1 2 3 }],
         expected_output => q{-chrom 1 2 3},
     },
     cnv_bin_size => {
@@ -144,11 +144,11 @@ ARGUMENT_HASH_REF:
 foreach my $argument_href (@arguments) {
     my @commands = test_function(
         {
-            argument_href          => $argument_href,
-            required_argument_href => \%required_argument,
-            module_function_cref   => $module_function_cref,
-            function_base_command  => $function_base_command,
-            do_test_base_command   => 1,
+            argument_href              => $argument_href,
+            required_argument_href     => \%required_argument,
+            module_function_cref       => $module_function_cref,
+            function_base_commands_ref => \@function_base_commands,
+            do_test_base_command       => 1,
         }
     );
 }

--- a/t/cnvnator_convert_to_vcf.t
+++ b/t/cnvnator_convert_to_vcf.t
@@ -97,7 +97,7 @@ diag(   q{Test cnvnator_convert_to_vcf from Cnvnator v}
       . $EXECUTABLE_NAME );
 
 ## Base arguments
-my $function_base_command = q{cnvnator2VCF.pl};
+my @function_base_commands = qw{ cnvnator2VCF.pl };
 
 my %base_argument = (
     stderrfile_path => {
@@ -106,7 +106,7 @@ my %base_argument = (
     },
     FILEHANDLE => {
         input           => undef,
-        expected_output => $function_base_command,
+        expected_output => \@function_base_commands,
     },
 );
 
@@ -123,8 +123,7 @@ my %required_argument = (
     },
 );
 
-my %specific_argument = (
-);
+my %specific_argument = ();
 
 ## Coderef - enables generalized use of generate call
 my $module_function_cref = \&cnvnator_convert_to_vcf;
@@ -136,11 +135,11 @@ ARGUMENT_HASH_REF:
 foreach my $argument_href (@arguments) {
     my @commands = test_function(
         {
-            argument_href          => $argument_href,
-            required_argument_href => \%required_argument,
-            module_function_cref   => $module_function_cref,
-            function_base_command  => $function_base_command,
-            do_test_base_command   => 1,
+            argument_href              => $argument_href,
+            required_argument_href     => \%required_argument,
+            module_function_cref       => $module_function_cref,
+            function_base_commands_ref => \@function_base_commands,
+            do_test_base_command       => 1,
         }
     );
 }

--- a/t/cnvnator_histogram.t
+++ b/t/cnvnator_histogram.t
@@ -97,7 +97,7 @@ diag(   q{Test cnvnator_histogram from Cnvnator v}
       . $EXECUTABLE_NAME );
 
 ## Base arguments
-my $function_base_command = q{cnvnator};
+my @function_base_commands = qw{ cnvnator };
 
 my %base_argument = (
     stderrfile_path => {
@@ -106,7 +106,7 @@ my %base_argument = (
     },
     FILEHANDLE => {
         input           => undef,
-        expected_output => $function_base_command,
+        expected_output => \@function_base_commands,
     },
     stdoutfile_path => {
         input           => q{stdoutfile_path.test},
@@ -129,7 +129,7 @@ my %required_argument = (
 
 my %specific_argument = (
     regions_ref => {
-        inputs_ref => [qw{ 1 2 3 }],
+        inputs_ref      => [qw{ 1 2 3 }],
         expected_output => q{-chrom 1 2 3},
     },
     cnv_bin_size => {
@@ -149,11 +149,11 @@ ARGUMENT_HASH_REF:
 foreach my $argument_href (@arguments) {
     my @commands = test_function(
         {
-            argument_href          => $argument_href,
-            required_argument_href => \%required_argument,
-            module_function_cref   => $module_function_cref,
-            function_base_command  => $function_base_command,
-            do_test_base_command   => 1,
+            argument_href              => $argument_href,
+            required_argument_href     => \%required_argument,
+            module_function_cref       => $module_function_cref,
+            function_base_commands_ref => \@function_base_commands,
+            do_test_base_command       => 1,
         }
     );
 }

--- a/t/cnvnator_partition.t
+++ b/t/cnvnator_partition.t
@@ -97,7 +97,7 @@ diag(   q{Test cnvnator_partition from Cnvnator v}
       . $EXECUTABLE_NAME );
 
 ## Base arguments
-my $function_base_command = q{cnvnator};
+my @function_base_commands = qw{ cnvnator };
 
 my %base_argument = (
     stderrfile_path => {
@@ -106,7 +106,7 @@ my %base_argument = (
     },
     FILEHANDLE => {
         input           => undef,
-        expected_output => $function_base_command,
+        expected_output => \@function_base_commands,
     },
     stdoutfile_path => {
         input           => q{stdoutfile_path.test},
@@ -125,7 +125,7 @@ my %required_argument = (
 
 my %specific_argument = (
     regions_ref => {
-        inputs_ref => [qw{ 1 2 3 }],
+        inputs_ref      => [qw{ 1 2 3 }],
         expected_output => q{-chrom 1 2 3},
     },
     cnv_bin_size => {
@@ -145,11 +145,11 @@ ARGUMENT_HASH_REF:
 foreach my $argument_href (@arguments) {
     my @commands = test_function(
         {
-            argument_href          => $argument_href,
-            required_argument_href => \%required_argument,
-            module_function_cref   => $module_function_cref,
-            function_base_command  => $function_base_command,
-            do_test_base_command   => 1,
+            argument_href              => $argument_href,
+            required_argument_href     => \%required_argument,
+            module_function_cref       => $module_function_cref,
+            function_base_commands_ref => \@function_base_commands,
+            do_test_base_command       => 1,
         }
     );
 }

--- a/t/cnvnator_read_extraction.t
+++ b/t/cnvnator_read_extraction.t
@@ -96,7 +96,7 @@ diag(   q{Test cnvnator_read_extraction from Cnvnator v}
       . $EXECUTABLE_NAME );
 
 ## Base arguments
-my $function_base_command = q{cnvnator};
+my @function_base_commands = qw{ cnvnator };
 
 my %base_argument = (
     stderrfile_path => {
@@ -105,7 +105,7 @@ my %base_argument = (
     },
     FILEHANDLE => {
         input           => undef,
-        expected_output => $function_base_command,
+        expected_output => \@function_base_commands,
     },
     stdoutfile_path => {
         input           => q{stdoutfile_path.test},
@@ -124,7 +124,7 @@ my %required_argument = (
 
 my %specific_argument = (
     regions_ref => {
-        inputs_ref => [qw{ 1 2 3 }],
+        inputs_ref      => [qw{ 1 2 3 }],
         expected_output => q{-chrom 1 2 3},
     },
     unique => {
@@ -143,11 +143,11 @@ ARGUMENT_HASH_REF:
 foreach my $argument_href (@arguments) {
     my @commands = test_function(
         {
-            argument_href          => $argument_href,
-            required_argument_href => \%required_argument,
-            module_function_cref   => $module_function_cref,
-            function_base_command  => $function_base_command,
-            do_test_base_command   => 1,
+            argument_href              => $argument_href,
+            required_argument_href     => \%required_argument,
+            module_function_cref       => $module_function_cref,
+            function_base_commands_ref => \@function_base_commands,
+            do_test_base_command       => 1,
         }
     );
 }

--- a/t/cnvnator_statistics.t
+++ b/t/cnvnator_statistics.t
@@ -97,7 +97,7 @@ diag(   q{Test cnvnator_statistics from Cnvnator v}
       . $EXECUTABLE_NAME );
 
 ## Base arguments
-my $function_base_command = q{cnvnator};
+my @function_base_commands = qw{ cnvnator };
 
 my %base_argument = (
     stderrfile_path => {
@@ -106,7 +106,7 @@ my %base_argument = (
     },
     FILEHANDLE => {
         input           => undef,
-        expected_output => $function_base_command,
+        expected_output => \@function_base_commands,
     },
     stdoutfile_path => {
         input           => q{stdoutfile_path.test},
@@ -125,7 +125,7 @@ my %required_argument = (
 
 my %specific_argument = (
     regions_ref => {
-        inputs_ref => [qw{ 1 2 3 }],
+        inputs_ref      => [qw{ 1 2 3 }],
         expected_output => q{-chrom 1 2 3},
     },
     cnv_bin_size => {
@@ -145,11 +145,11 @@ ARGUMENT_HASH_REF:
 foreach my $argument_href (@arguments) {
     my @commands = test_function(
         {
-            argument_href          => $argument_href,
-            required_argument_href => \%required_argument,
-            module_function_cref   => $module_function_cref,
-            function_base_command  => $function_base_command,
-            do_test_base_command   => 1,
+            argument_href              => $argument_href,
+            required_argument_href     => \%required_argument,
+            module_function_cref       => $module_function_cref,
+            function_base_commands_ref => \@function_base_commands,
+            do_test_base_command       => 1,
         }
     );
 }

--- a/t/conda_create.t
+++ b/t/conda_create.t
@@ -90,12 +90,12 @@ diag(   q{Test conda_create }
       . $EXECUTABLE_NAME );
 
 ## Base arguments
-my $function_base_command = q{conda create};
+my @function_base_commands = qw{ conda create };
 
 my %base_argument = (
     FILEHANDLE => {
         input           => undef,
-        expected_output => $function_base_command,
+        expected_output => \@function_base_commands,
     },
 );
 
@@ -103,7 +103,7 @@ my %base_argument = (
 my %required_argument = (
     FILEHANDLE => {
         input           => undef,
-        expected_output => $function_base_command,
+        expected_output => \@function_base_commands,
     },
 );
 
@@ -139,11 +139,11 @@ my @arguments = ( \%base_argument, \%specific_argument );
 foreach my $argument_href (@arguments) {
     my @commands = test_function(
         {
-            argument_href          => $argument_href,
-            required_argument_href => \%required_argument,
-            module_function_cref   => $module_function_cref,
-            function_base_command  => $function_base_command,
-            do_test_base_command   => 1,
+            argument_href              => $argument_href,
+            required_argument_href     => \%required_argument,
+            module_function_cref       => $module_function_cref,
+            function_base_commands_ref => \@function_base_commands,
+            do_test_base_command       => 1,
         }
     );
 }

--- a/t/conda_install.t
+++ b/t/conda_install.t
@@ -90,12 +90,12 @@ diag(   q{Test conda_install from Conda.pm v}
       . $EXECUTABLE_NAME );
 
 ## Base arguments
-my $function_base_command = q{conda install};
+my @function_base_commands = qw{ conda install };
 
 my %base_argument = (
     FILEHANDLE => {
         input           => undef,
-        expected_output => $function_base_command,
+        expected_output => \@function_base_commands,
     },
 );
 
@@ -107,7 +107,7 @@ my %required_argument = (
     },
     FILEHANDLE => {
         input           => undef,
-        expected_output => $function_base_command,
+        expected_output => \@function_base_commands,
     },
 );
 
@@ -147,11 +147,11 @@ my @arguments = ( \%base_argument, \%specific_argument );
 foreach my $argument_href (@arguments) {
     my @commands = test_function(
         {
-            argument_href          => $argument_href,
-            required_argument_href => \%required_argument,
-            module_function_cref   => $module_function_cref,
-            function_base_command  => $function_base_command,
-            do_test_base_command   => 1,
+            argument_href              => $argument_href,
+            required_argument_href     => \%required_argument,
+            module_function_cref       => $module_function_cref,
+            function_base_commands_ref => \@function_base_commands,
+            do_test_base_command       => 1,
         }
     );
 }

--- a/t/conda_source_activate.t
+++ b/t/conda_source_activate.t
@@ -91,12 +91,12 @@ diag(
 );
 
 ## Base arguments
-my $function_base_command = q{source activate};
+my @function_base_commands = qw{ source activate };
 
 my %base_argument = (
     FILEHANDLE => {
         input           => undef,
-        expected_output => $function_base_command,
+        expected_output => \@function_base_commands,
     },
 );
 
@@ -104,7 +104,7 @@ my %base_argument = (
 my %required_argument = (
     FILEHANDLE => {
         input           => undef,
-        expected_output => $function_base_command,
+        expected_output => \@function_base_commands,
     },
     env_name => {
         input           => q{test_env},
@@ -121,11 +121,11 @@ my @arguments = ( \%base_argument );
 foreach my $argument_href (@arguments) {
     my @commands = test_function(
         {
-            argument_href          => $argument_href,
-            required_argument_href => \%required_argument,
-            module_function_cref   => $module_function_cref,
-            function_base_command  => $function_base_command,
-            do_test_base_command   => 1,
+            argument_href              => $argument_href,
+            required_argument_href     => \%required_argument,
+            module_function_cref       => $module_function_cref,
+            function_base_commands_ref => \@function_base_commands,
+            do_test_base_command       => 1,
         }
     );
 }

--- a/t/conda_source_deactivate.t
+++ b/t/conda_source_deactivate.t
@@ -91,12 +91,12 @@ diag(
 );
 
 ## Base arguments
-my $function_base_command = q{source deactivate};
+my @function_base_commands = qw{ source deactivate };
 
 my %base_argument = (
     FILEHANDLE => {
         input           => undef,
-        expected_output => $function_base_command,
+        expected_output => \@function_base_commands,
     },
 );
 
@@ -104,7 +104,7 @@ my %base_argument = (
 my %required_argument = (
     FILEHANDLE => {
         input           => undef,
-        expected_output => $function_base_command,
+        expected_output => \@function_base_commands,
     },
 );
 
@@ -117,11 +117,11 @@ my @arguments = ( \%base_argument );
 foreach my $argument_href (@arguments) {
     my @commands = test_function(
         {
-            argument_href          => $argument_href,
-            required_argument_href => \%required_argument,
-            module_function_cref   => $module_function_cref,
-            function_base_command  => $function_base_command,
-            do_test_base_command   => 1,
+            argument_href              => $argument_href,
+            required_argument_href     => \%required_argument,
+            module_function_cref       => $module_function_cref,
+            function_base_commands_ref => \@function_base_commands,
+            do_test_base_command       => 1,
         }
     );
 }

--- a/t/conda_uninstall.t
+++ b/t/conda_uninstall.t
@@ -30,7 +30,7 @@ our $VERSION = 1.0.0;
 ## Constants
 Readonly my $SPACE   => q{ };
 Readonly my $NEWLINE => qq{\n};
-Readonly my $COMMA => q{,};
+Readonly my $COMMA   => q{,};
 
 ###User Options
 GetOptions(
@@ -85,18 +85,20 @@ use MIP::Test::Commands qw{ test_function };
 
 diag(   q{Test conda_uninstall from Conda.pm v}
       . $MIP::Package_manager::Conda::VERSION
-      . $COMMA . $SPACE . q{Perl} . $SPACE
+      . $COMMA
+      . $SPACE . q{Perl}
+      . $SPACE
       . $PERL_VERSION
       . $SPACE
       . $EXECUTABLE_NAME );
 
 ## Base arguments
-my $function_base_command = q{conda uninstall};
+my @function_base_commands = qw{ conda uninstall };
 
 my %base_argument = (
     FILEHANDLE => {
         input           => undef,
-        expected_output => $function_base_command,
+        expected_output => \@function_base_commands,
     },
 );
 
@@ -108,7 +110,7 @@ my %required_argument = (
     },
     FILEHANDLE => {
         input           => undef,
-        expected_output => $function_base_command,
+        expected_output => \@function_base_commands,
     },
 );
 
@@ -144,11 +146,11 @@ my @arguments = ( \%base_argument, \%specific_argument );
 foreach my $argument_href (@arguments) {
     my @commands = test_function(
         {
-            argument_href          => $argument_href,
-            required_argument_href => \%required_argument,
-            module_function_cref   => $module_function_cref,
-            function_base_command  => $function_base_command,
-            do_test_base_command   => 1,
+            argument_href              => $argument_href,
+            required_argument_href     => \%required_argument,
+            module_function_cref       => $module_function_cref,
+            function_base_commands_ref => \@function_base_commands,
+            do_test_base_command       => 1,
         }
     );
 }

--- a/t/conda_update.t
+++ b/t/conda_update.t
@@ -89,7 +89,7 @@ diag(   q{Test conda_update }
       . $EXECUTABLE_NAME );
 
 ## Base arguments
-my $function_base_command = q{conda update};
+my @function_base_commands = qw{ conda update };
 
 my %base_argument = (
     stderrfile_path => {
@@ -102,7 +102,7 @@ my %base_argument = (
     },
     FILEHANDLE => {
         input           => undef,
-        expected_output => $function_base_command,
+        expected_output => \@function_base_commands,
     },
 );
 
@@ -110,7 +110,7 @@ my %base_argument = (
 my %required_argument = (
     FILEHANDLE => {
         input           => undef,
-        expected_output => $function_base_command,
+        expected_output => \@function_base_commands,
     },
 );
 
@@ -130,11 +130,11 @@ my @arguments = ( \%required_argument, \%specific_argument );
 foreach my $argument_href (@arguments) {
     my @commands = test_function(
         {
-            argument_href          => $argument_href,
-            required_argument_href => \%required_argument,
-            module_function_cref   => $module_function_cref,
-            function_base_command  => $function_base_command,
-            do_test_base_command   => 1,
+            argument_href              => $argument_href,
+            required_argument_href     => \%required_argument,
+            module_function_cref       => $module_function_cref,
+            function_base_commands_ref => \@function_base_commands,
+            do_test_base_command       => 1,
         }
     );
 }

--- a/t/cpanm_install.t
+++ b/t/cpanm_install.t
@@ -96,12 +96,12 @@ diag(   q{Test cpanm_install from Cpanm.pm v}
       . $EXECUTABLE_NAME );
 
 ## Base arguments
-my $function_base_command = q{cpanm};
+my @function_base_commands = qw{ cpanm };
 
 my %base_argument = (
     FILEHANDLE => {
         input           => undef,
-        expected_output => $function_base_command,
+        expected_output => \@function_base_commands,
     },
 );
 
@@ -114,7 +114,7 @@ my %required_argument = (
     },
     FILEHANDLE => {
         input           => undef,
-        expected_output => $function_base_command,
+        expected_output => \@function_base_commands,
     },
 );
 
@@ -143,11 +143,11 @@ HASHES_OF_ARGUMENTS:
 foreach my $argument_href (@arguments) {
     my @commands = test_function(
         {
-            argument_href          => $argument_href,
-            required_argument_href => \%required_argument,
-            module_function_cref   => $module_function_cref,
-            function_base_command  => $function_base_command,
-            do_test_base_command   => 1,
+            argument_href              => $argument_href,
+            required_argument_href     => \%required_argument,
+            module_function_cref       => $module_function_cref,
+            function_base_commands_ref => \@function_base_commands,
+            do_test_base_command       => 1,
         }
     );
 }

--- a/t/create_fam_file.t
+++ b/t/create_fam_file.t
@@ -135,7 +135,7 @@ $active_parameter_test_hash{log_file} = $test_log_path;
 my $test_log = initiate_logger(
     {
         file_path => $active_parameter_test_hash{log_file},
-        log_name      => q{MIP},
+        log_name  => q{MIP},
     }
 );
 
@@ -199,12 +199,12 @@ for my $execution_mode (@execution_modes) {
 
     # Creating array of expected pedigree lines
     my @expected_pedigree_lines;
-    
-    SAMPLE_ID:
+
+  SAMPLE_ID:
     foreach my $sample_id ( @{ $active_parameter_test_hash{sample_ids} } ) {
         my $sample_line = $active_parameter_test_hash{family_id};
-        
-        HEADER:
+
+      HEADER:
         foreach my $header ( split $TAB, $expected_header ) {
 
             if ( defined $sample_info_test_hash{sample}{$sample_id}{$header} ) {

--- a/t/cufflinks.t
+++ b/t/cufflinks.t
@@ -97,7 +97,7 @@ diag(   q{Test cufflinks from Cufflinks.pm v}
       . $SPACE
       . $EXECUTABLE_NAME );
 
-my $function_base_command = q{cufflinks};
+my @function_base_commands = qw{ cufflinks };
 
 my %base_argument = (
     stdoutfile_path => {
@@ -114,7 +114,7 @@ my %base_argument = (
     },
     FILEHANDLE => {
         input           => undef,
-        expected_output => $function_base_command,
+        expected_output => \@function_base_commands,
     },
 );
 
@@ -168,11 +168,11 @@ ARGUMENT_HASH_REF:
 foreach my $argument_href (@arguments) {
     my @commands = test_function(
         {
-            argument_href          => $argument_href,
-            required_argument_href => \%required_argument,
-            module_function_cref   => $module_function_cref,
-            function_base_command  => $function_base_command,
-            do_test_base_command   => 1,
+            argument_href              => $argument_href,
+            required_argument_href     => \%required_argument,
+            module_function_cref       => $module_function_cref,
+            function_base_commands_ref => \@function_base_commands,
+            do_test_base_command       => 1,
         }
     );
 }

--- a/t/cutadapt.t
+++ b/t/cutadapt.t
@@ -99,12 +99,12 @@ diag(   q{Test cutadapt from Cutadapt.pm v}
       . $EXECUTABLE_NAME );
 
 ## Base arguments
-my $function_base_command = q{cutadapt};
+my @function_base_commands = qw{ cutadapt };
 
 my %base_argument = (
     FILEHANDLE => {
         input           => undef,
-        expected_output => $function_base_command,
+        expected_output => \@function_base_commands,
     },
     stderrfile_path => {
         input           => q{stderrfile.test},
@@ -194,11 +194,11 @@ ARGUMENT_HASH_REF:
 foreach my $argument_href (@arguments) {
     my @commands = test_function(
         {
-            argument_href          => $argument_href,
-            required_argument_href => \%required_argument,
-            module_function_cref   => $module_function_cref,
-            function_base_command  => $function_base_command,
-            do_test_base_command   => 1,
+            argument_href              => $argument_href,
+            required_argument_href     => \%required_argument,
+            module_function_cref       => $module_function_cref,
+            function_base_commands_ref => \@function_base_commands,
+            do_test_base_command       => 1,
         }
     );
 }

--- a/t/delly_call.t
+++ b/t/delly_call.t
@@ -100,12 +100,12 @@ diag(   q{Test delly_call from Delly.pm v}
       . $EXECUTABLE_NAME );
 
 ## Base arguments
-my $function_base_command = q{delly call};
+my @function_base_commands = qw{ delly call };
 
 my %base_argument = (
     FILEHANDLE => {
         input           => undef,
-        expected_output => $function_base_command,
+        expected_output => \@function_base_commands,
     },
     stderrfile_path => {
         input           => q{stderrfile.test},
@@ -173,11 +173,11 @@ ARGUMENT_HASH_REF:
 foreach my $argument_href (@arguments) {
     my @commands = test_function(
         {
-            argument_href          => $argument_href,
-            required_argument_href => \%required_argument,
-            module_function_cref   => $module_function_cref,
-            function_base_command  => $function_base_command,
-            do_test_base_command   => 1,
+            argument_href              => $argument_href,
+            required_argument_href     => \%required_argument,
+            module_function_cref       => $module_function_cref,
+            function_base_commands_ref => \@function_base_commands,
+            do_test_base_command       => 1,
         }
     );
 }

--- a/t/delly_filter.t
+++ b/t/delly_filter.t
@@ -102,12 +102,12 @@ diag(   q{Test delly_filter from Delly.pm v}
       . $EXECUTABLE_NAME );
 
 ## Base arguments
-my $function_base_command = q{delly filter};
+my @function_base_commands = qw{ delly filter };
 
 my %base_argument = (
     FILEHANDLE => {
         input           => undef,
-        expected_output => $function_base_command,
+        expected_output => \@function_base_commands,
     },
     stderrfile_path => {
         input           => q{stderrfile.test},
@@ -167,11 +167,11 @@ ARGUMENT_HASH_REF:
 foreach my $argument_href (@arguments) {
     my @commands = test_function(
         {
-            argument_href          => $argument_href,
-            required_argument_href => \%required_argument,
-            module_function_cref   => $module_function_cref,
-            function_base_command  => $function_base_command,
-            do_test_base_command   => 1,
+            argument_href              => $argument_href,
+            required_argument_href     => \%required_argument,
+            module_function_cref       => $module_function_cref,
+            function_base_commands_ref => \@function_base_commands,
+            do_test_base_command       => 1,
         }
     );
 }

--- a/t/delly_merge.t
+++ b/t/delly_merge.t
@@ -102,12 +102,12 @@ diag(   q{Test delly_merge from Delly.pm v}
       . $EXECUTABLE_NAME );
 
 ## Base arguments
-my $function_base_command = q{delly merge};
+my @function_base_commands = qw{ delly merge };
 
 my %base_argument = (
     FILEHANDLE => {
         input           => undef,
-        expected_output => $function_base_command,
+        expected_output => \@function_base_commands,
     },
     stderrfile_path => {
         input           => q{stderrfile.test},
@@ -163,11 +163,11 @@ ARGUMENT_HASH_REF:
 foreach my $argument_href (@arguments) {
     my @commands = test_function(
         {
-            argument_href          => $argument_href,
-            required_argument_href => \%required_argument,
-            module_function_cref   => $module_function_cref,
-            function_base_command  => $function_base_command,
-            do_test_base_command   => 1,
+            argument_href              => $argument_href,
+            required_argument_href     => \%required_argument,
+            module_function_cref       => $module_function_cref,
+            function_base_commands_ref => \@function_base_commands,
+            do_test_base_command       => 1,
         }
     );
 }

--- a/t/download_reference.t
+++ b/t/download_reference.t
@@ -100,7 +100,7 @@ diag(   q{Test download_reference from Download_reference.pm v}
       . $EXECUTABLE_NAME );
 
 ## Base arguments
-my $function_base_command = q{mip download rare_disease};
+my @function_base_commands = qw{ mip download rare_disease };
 
 my %base_argument = (
     stdoutfile_path => {
@@ -117,7 +117,7 @@ my %base_argument = (
     },
     FILEHANDLE => {
         input           => undef,
-        expected_output => $function_base_command,
+        expected_output => \@function_base_commands,
     },
 );
 
@@ -137,7 +137,7 @@ q{--reference_genome_versions test_v1 --reference_genome_versions test_v2},
     },
     FILEHANDLE => {
         input           => undef,
-        expected_output => $function_base_command,
+        expected_output => \@function_base_commands,
     },
 );
 
@@ -171,11 +171,11 @@ ARGUMENT_HASH_REF:
 foreach my $argument_href (@arguments) {
     my @commands = test_function(
         {
-            argument_href          => $argument_href,
-            required_argument_href => \%required_argument,
-            module_function_cref   => $module_function_cref,
-            function_base_command  => $function_base_command,
-            do_test_base_command   => 1,
+            argument_href              => $argument_href,
+            required_argument_href     => \%required_argument,
+            module_function_cref       => $module_function_cref,
+            function_base_commands_ref => \@function_base_commands,
+            do_test_base_command       => 1,
         }
     );
 }

--- a/t/expansionhunter.t
+++ b/t/expansionhunter.t
@@ -106,12 +106,12 @@ Readonly my $READ_DEPTH              => 30;
 Readonly my $REGION_EXTENSION_LENGTH => 1500;
 
 ## Base arguments
-my $function_base_command = q{ExpansionHunter};
+my @function_base_commands = qw{ ExpansionHunter };
 
 my %base_argument = (
     FILEHANDLE => {
         input           => undef,
-        expected_output => $function_base_command,
+        expected_output => \@function_base_commands,
     },
     stderrfile_path => {
         input           => q{stderrfile.test},
@@ -227,11 +227,11 @@ ARGUMENT_HASH_REF:
 foreach my $argument_href (@arguments) {
     my @commands = test_function(
         {
-            argument_href          => $argument_href,
-            do_test_base_command   => 1,
-            function_base_command  => $function_base_command,
-            module_function_cref   => $module_function_cref,
-            required_argument_href => \%required_argument,
+            argument_href              => $argument_href,
+            do_test_base_command       => 1,
+            function_base_commands_ref => \@function_base_commands,
+            module_function_cref       => $module_function_cref,
+            required_argument_href     => \%required_argument,
         }
     );
 }

--- a/t/fastqc.t
+++ b/t/fastqc.t
@@ -94,7 +94,7 @@ diag(   q{Test fastqc from Path.pm v}
       . $EXECUTABLE_NAME );
 
 ## Base arguments
-my $function_base_command = q{fastqc};
+my @function_base_commands = qw{ fastqc };
 
 my %base_argument = (
     stderrfile_path => {
@@ -107,7 +107,7 @@ my %base_argument = (
     },
     FILEHANDLE => {
         input           => undef,
-        expected_output => $function_base_command,
+        expected_output => \@function_base_commands,
     },
 );
 
@@ -115,7 +115,7 @@ my %base_argument = (
 my %required_argument = (
     FILEHANDLE => {
         input           => undef,
-        expected_output => $function_base_command,
+        expected_output => \@function_base_commands,
     },
     infile_path => {
         input           => q{test_infile.fastq},
@@ -151,11 +151,11 @@ my @arguments = ( \%required_argument, \%specific_argument );
 foreach my $argument_href (@arguments) {
     my @commands = test_function(
         {
-            argument_href          => $argument_href,
-            required_argument_href => \%required_argument,
-            module_function_cref   => $module_function_cref,
-            function_base_command  => $function_base_command,
-            do_test_base_command   => 1,
+            argument_href              => $argument_href,
+            required_argument_href     => \%required_argument,
+            module_function_cref       => $module_function_cref,
+            function_base_commands_ref => \@function_base_commands,
+            do_test_base_command       => 1,
         }
     );
 }

--- a/t/findutils_xargs.t
+++ b/t/findutils_xargs.t
@@ -101,12 +101,12 @@ Readonly my $MAX_PROCESSES => 16;
 Readonly my $MAX_ARGUMENTS => 1;
 
 ## Base arguments
-my $function_base_command = q{xargs};
+my @function_base_commands = qw{ xargs };
 
 my %base_argument = (
     FILEHANDLE => {
         input           => undef,
-        expected_output => $function_base_command,
+        expected_output => \@function_base_commands,
     },
 );
 
@@ -119,7 +119,7 @@ my %required_argument = (
     },
     FILEHANDLE => {
         input           => undef,
-        expected_output => $function_base_command,
+        expected_output => \@function_base_commands,
     },
 );
 
@@ -160,11 +160,11 @@ HASHES_OF_ARGUMENTS:
 foreach my $argument_href (@arguments) {
     my @commands = test_function(
         {
-            argument_href          => $argument_href,
-            required_argument_href => \%required_argument,
-            module_function_cref   => $module_function_cref,
-            function_base_command  => $function_base_command,
-            do_test_base_command   => 1,
+            argument_href              => $argument_href,
+            required_argument_href     => \%required_argument,
+            module_function_cref       => $module_function_cref,
+            function_base_commands_ref => \@function_base_commands,
+            do_test_base_command       => 1,
         }
     );
 }

--- a/t/freebayes_calling.t
+++ b/t/freebayes_calling.t
@@ -100,7 +100,7 @@ diag(   q{Test freebayes_calling from Freebayes v}
       . $EXECUTABLE_NAME );
 
 ## Base arguments
-my $function_base_command = q{freebayes};
+my @function_base_commands = qw{ freebayes };
 
 my %base_argument = (
     stderrfile_path => {
@@ -109,7 +109,7 @@ my %base_argument = (
     },
     FILEHANDLE => {
         input           => undef,
-        expected_output => $function_base_command,
+        expected_output => \@function_base_commands,
     },
     stdoutfile_path => {
         input           => q{stdoutfile_path.test},
@@ -153,11 +153,11 @@ ARGUMENT_HASH_REF:
 foreach my $argument_href (@arguments) {
     my @commands = test_function(
         {
-            argument_href          => $argument_href,
-            required_argument_href => \%required_argument,
-            module_function_cref   => $module_function_cref,
-            function_base_command  => $function_base_command,
-            do_test_base_command   => 1,
+            argument_href              => $argument_href,
+            required_argument_href     => \%required_argument,
+            module_function_cref       => $module_function_cref,
+            function_base_commands_ref => \@function_base_commands,
+            do_test_base_command       => 1,
         }
     );
 }

--- a/t/gatk_applyrecalibration.t
+++ b/t/gatk_applyrecalibration.t
@@ -105,12 +105,12 @@ diag(   q{Test gatk_applyrecalibration from Gatk v}
       . $EXECUTABLE_NAME );
 
 ## Base arguments
-my $function_base_command = q{--analysis_type ApplyRecalibration};
+my @function_base_commands = qw{ --analysis_type ApplyRecalibration };
 
 my %base_argument = (
     FILEHANDLE => {
         input           => undef,
-        expected_output => $function_base_command,
+        expected_output => \@function_base_commands,
     },
 );
 
@@ -119,17 +119,20 @@ my %base_argument = (
 my %required_argument = (
     infile_path => {
         input           => catfile(qw{ path_to_analysis_dir infile.vcf }),
-        expected_output => q{--input} . $SPACE
+        expected_output => q{--input}
+          . $SPACE
           . catfile(qw{ path_to_analysis_dir infile.vcf }),
     },
     outfile_path => {
         input           => catfile(qw{ path_to_analysis_dir outfile.vcf }),
-        expected_output => q{--out} . $SPACE
+        expected_output => q{--out}
+          . $SPACE
           . catfile(qw{ path_to_analysis_dir outfile.vcf }),
     },
     referencefile_path => {
         input           => catfile(qw{reference_dir human_genome_build.fasta }),
-        expected_output => q{--reference_sequence} . $SPACE
+        expected_output => q{--reference_sequence}
+          . $SPACE
           . catfile(qw{reference_dir human_genome_build.fasta }),
     },
     mode => {
@@ -159,7 +162,9 @@ my %specific_argument = (
     },
     pedigree => {
         input           => catfile(qw{ dir pedigree.fam }),
-        expected_output => q{--pedigree} . $SPACE . catfile(qw{ dir pedigree.fam }),
+        expected_output => q{--pedigree}
+          . $SPACE
+          . catfile(qw{ dir pedigree.fam }),
     },
     pedigree_validation_type => {
         input           => q{SILENT},
@@ -171,23 +176,31 @@ my %specific_argument = (
           q{--read_filter MaxReadLength --read_filter MappingQuality},
     },
     static_quantized_quals_ref => {
-        inputs_ref => [ $QUALSCORE_1, $QUALSCORE_2 ],
-        expected_output =>
-          q{--static_quantized_quals} . $SPACE . $QUALSCORE_1 . $SPACE . q{--static_quantized_quals} . $SPACE . $QUALSCORE_2,
+        inputs_ref      => [ $QUALSCORE_1, $QUALSCORE_2 ],
+        expected_output => q{--static_quantized_quals}
+          . $SPACE
+          . $QUALSCORE_1
+          . $SPACE
+          . q{--static_quantized_quals}
+          . $SPACE
+          . $QUALSCORE_2,
     },
     base_quality_score_recalibration_file => {
         input           => catfile(qw{ dir recalibration_report.grp }),
-        expected_output => q{--BQSR} . $SPACE
+        expected_output => q{--BQSR}
+          . $SPACE
           . catfile(qw{ dir recalibration_report.grp }),
     },
     recal_file_path => {
         input           => catfile(qw{ dir recal_file.intervals }),
-        expected_output => q{--recal_file} . $SPACE
+        expected_output => q{--recal_file}
+          . $SPACE
           . catfile(qw{ dir recal_file.intervals }),
     },
     tranches_file_path => {
         input           => catfile(qw{ dir tranchesfile.tranches }),
-        expected_output => q{--tranches_file} . $SPACE
+        expected_output => q{--tranches_file}
+          . $SPACE
           . catfile(qw{ dir tranchesfile.tranches }),
     },
     num_cpu_threads_per_data_thread => {
@@ -215,11 +228,11 @@ ARGUMENT_HASH_REF:
 foreach my $argument_href (@arguments) {
     my @commands = test_function(
         {
-            argument_href          => $argument_href,
-            required_argument_href => \%required_argument,
-            module_function_cref   => $module_function_cref,
-            function_base_command  => $function_base_command,
-            do_test_base_command   => 1,
+            argument_href              => $argument_href,
+            required_argument_href     => \%required_argument,
+            module_function_cref       => $module_function_cref,
+            function_base_commands_ref => \@function_base_commands,
+            do_test_base_command       => 1,
         }
     );
 }

--- a/t/gatk_asereadcounter.t
+++ b/t/gatk_asereadcounter.t
@@ -102,12 +102,12 @@ diag(   q{Test gatk_asereadcounter from Gatk v}
       . $EXECUTABLE_NAME );
 
 ## Base arguments
-my $function_base_command = q{--analysis_type ASEReadCounter};
+my @function_base_commands = qw{ --analysis_type ASEReadCounter };
 
 my %base_argument = (
     FILEHANDLE => {
         input           => undef,
-        expected_output => $function_base_command,
+        expected_output => \@function_base_commands,
     },
 );
 
@@ -187,11 +187,11 @@ ARGUMENT_HASH_REF:
 foreach my $argument_href (@arguments) {
     my @commands = test_function(
         {
-            argument_href          => $argument_href,
-            required_argument_href => \%required_argument,
-            module_function_cref   => $module_function_cref,
-            function_base_command  => $function_base_command,
-            do_test_base_command   => 1,
+            argument_href              => $argument_href,
+            required_argument_href     => \%required_argument,
+            module_function_cref       => $module_function_cref,
+            function_base_commands_ref => \@function_base_commands,
+            do_test_base_command       => 1,
         }
     );
 }

--- a/t/gatk_base.t
+++ b/t/gatk_base.t
@@ -105,12 +105,12 @@ Readonly my $STATIC_QUANTIZED_QUALS_MINIMUM_LEVEL => 10;
 Readonly my $STATIC_QUANTIZED_QUALS_MAX_LEVEL     => 20;
 
 ## Base arguments
-my $function_base_command = q{--analysis_type HaplotypeCaller};
+my @function_base_commands = qw{ --analysis_type HaplotypeCaller };
 
 my %base_argument = (
     FILEHANDLE => {
         input           => undef,
-        expected_output => $function_base_command,
+        expected_output => \@function_base_commands,
     },
 );
 
@@ -203,11 +203,11 @@ ARGUMENT_HASH_REF:
 foreach my $argument_href (@arguments) {
     my @commands = test_function(
         {
-            argument_href          => $argument_href,
-            required_argument_href => \%required_argument,
-            module_function_cref   => $module_function_cref,
-            function_base_command  => $function_base_command,
-            do_test_base_command   => 1,
+            argument_href              => $argument_href,
+            required_argument_href     => \%required_argument,
+            module_function_cref       => $module_function_cref,
+            function_base_commands_ref => \@function_base_commands,
+            do_test_base_command       => 1,
         }
     );
 }

--- a/t/gatk_baserecalibrator.t
+++ b/t/gatk_baserecalibrator.t
@@ -25,7 +25,7 @@ use MIP::Script::Utils qw{ help };
 our $USAGE = build_usage( {} );
 
 my $VERBOSE = 1;
-our $VERSION = 1.0.1;
+our $VERSION = 1.02;
 
 ## Constants
 Readonly my $SPACE   => q{ };
@@ -100,7 +100,7 @@ diag(   q{Test gatk_baserecalibrator from Alignment::Gatk.pm v}
       . $EXECUTABLE_NAME );
 
 ## Base arguments
-my $function_base_command = q{--analysis_type BaseRecalibrator};
+my @function_base_commands = qw {--analysis_type BaseRecalibrator };
 
 my %base_argument = (
     stderrfile_path => {
@@ -109,7 +109,7 @@ my %base_argument = (
     },
     FILEHANDLE => {
         input           => undef,
-        expected_output => $function_base_command,
+        expected_output => \@function_base_commands,
     },
 );
 
@@ -185,11 +185,11 @@ ARGUMENT_HASH_REF:
 foreach my $argument_href (@arguments) {
     my @commands = test_function(
         {
-            argument_href          => $argument_href,
-            required_argument_href => \%required_argument,
-            module_function_cref   => $module_function_cref,
-            function_base_command  => $function_base_command,
-            do_test_base_command   => 1,
+            argument_href              => $argument_href,
+            do_test_base_command       => 1,
+            function_base_commands_ref => \@function_base_commands,
+            module_function_cref       => $module_function_cref,
+            required_argument_href     => \%required_argument,
         }
     );
 }

--- a/t/gatk_calculategenotypeposteriors.t
+++ b/t/gatk_calculategenotypeposteriors.t
@@ -101,12 +101,12 @@ diag(   q{Test gatk_calculategenotypeposteriors from Gatk v}
       . $EXECUTABLE_NAME );
 
 ## Base arguments
-my $function_base_command = q{--analysis_type CalculateGenotypePosteriors};
+my @function_base_commands = qw{ --analysis_type CalculateGenotypePosteriors };
 
 my %base_argument = (
     FILEHANDLE => {
         input           => undef,
-        expected_output => $function_base_command,
+        expected_output => \@function_base_commands,
     },
 );
 
@@ -115,17 +115,20 @@ my %base_argument = (
 my %required_argument = (
     infile_path => {
         input           => catfile(qw{ path_to_analysis_dir infile.bam }),
-        expected_output => q{--input} . $SPACE
+        expected_output => q{--input}
+          . $SPACE
           . catfile(qw{ path_to_analysis_dir infile.bam }),
     },
     outfile_path => {
         input           => catfile(qw{ path_to_analysis_dir outfile.bam }),
-        expected_output => q{--out} . $SPACE
+        expected_output => q{--out}
+          . $SPACE
           . catfile(qw{ path_to_analysis_dir outfile.bam }),
     },
     referencefile_path => {
         input           => catfile(qw{reference_dir human_genome_build.fasta }),
-        expected_output => q{--reference_sequence} . $SPACE
+        expected_output => q{--reference_sequence}
+          . $SPACE
           . catfile(qw{reference_dir human_genome_build.fasta }),
     },
 );
@@ -151,7 +154,9 @@ my %specific_argument = (
     },
     pedigree => {
         input           => catfile(qw{ dir pedigree.fam }),
-        expected_output => q{--pedigree} . $SPACE . catfile(qw{ dir pedigree.fam }),
+        expected_output => q{--pedigree}
+          . $SPACE
+          . catfile(qw{ dir pedigree.fam }),
     },
     pedigree_validation_type => {
         input           => q{SILENT},
@@ -159,7 +164,8 @@ my %specific_argument = (
     },
     supporting_callset_file_path => {
         input           => catfile(qw{ dir supporting_callset.vcf }),
-        expected_output => q{--supporting} . $SPACE
+        expected_output => q{--supporting}
+          . $SPACE
           . catfile(qw{ dir supporting_callset.vcf }),
     },
 );
@@ -174,11 +180,11 @@ ARGUMENT_HASH_REF:
 foreach my $argument_href (@arguments) {
     my @commands = test_function(
         {
-            argument_href          => $argument_href,
-            required_argument_href => \%required_argument,
-            module_function_cref   => $module_function_cref,
-            function_base_command  => $function_base_command,
-            do_test_base_command   => 1,
+            argument_href              => $argument_href,
+            required_argument_href     => \%required_argument,
+            module_function_cref       => $module_function_cref,
+            function_base_commands_ref => \@function_base_commands,
+            do_test_base_command       => 1,
         }
     );
 }

--- a/t/gatk_catvariants.t
+++ b/t/gatk_catvariants.t
@@ -101,12 +101,12 @@ diag(   q{Test gatk_catvariants from Gatk v}
       . $EXECUTABLE_NAME );
 
 ## Base arguments
-my $function_base_command = q{-cp};
+my @function_base_commands = qw{ -cp };
 
 my %base_argument = (
     FILEHANDLE => {
         input           => undef,
-        expected_output => $function_base_command,
+        expected_output => \@function_base_commands,
     },
 );
 
@@ -175,11 +175,11 @@ ARGUMENT_HASH_REF:
 foreach my $argument_href (@arguments) {
     my @commands = test_function(
         {
-            argument_href          => $argument_href,
-            required_argument_href => \%required_argument,
-            module_function_cref   => $module_function_cref,
-            function_base_command  => $function_base_command,
-            do_test_base_command   => 1,
+            argument_href              => $argument_href,
+            required_argument_href     => \%required_argument,
+            module_function_cref       => $module_function_cref,
+            function_base_commands_ref => \@function_base_commands,
+            do_test_base_command       => 1,
         }
     );
 }

--- a/t/gatk_combinevariants.t
+++ b/t/gatk_combinevariants.t
@@ -101,12 +101,12 @@ diag(   q{Test gatk_combinevariants from Gatk v}
       . $EXECUTABLE_NAME );
 
 ## Base arguments
-my $function_base_command = q{--analysis_type CombineVariants};
+my @function_base_commands = qw{ --analysis_type CombineVariants };
 
 my %base_argument = (
     FILEHANDLE => {
         input           => undef,
-        expected_output => $function_base_command,
+        expected_output => \@function_base_commands,
     },
 );
 
@@ -120,11 +120,14 @@ my %required_argument = (
     },
     outfile_path => {
         input           => catfile(qw{ dir outfile.vcf }),
-        expected_output => q{--outputFile} . $SPACE . catfile(qw{ dir outfile.vcf }),
+        expected_output => q{--outputFile}
+          . $SPACE
+          . catfile(qw{ dir outfile.vcf }),
     },
     referencefile_path => {
         input           => catfile(qw{reference_dir human_genome_build.fasta }),
-        expected_output => q{--reference_sequence} . $SPACE
+        expected_output => q{--reference_sequence}
+          . $SPACE
           . catfile(qw{reference_dir human_genome_build.fasta }),
     },
 );
@@ -150,7 +153,9 @@ my %specific_argument = (
     },
     pedigree => {
         input           => catfile(qw{ dir pedigree.fam }),
-        expected_output => q{--pedigree} . $SPACE . catfile(qw{ dir pedigree.fam }),
+        expected_output => q{--pedigree}
+          . $SPACE
+          . catfile(qw{ dir pedigree.fam }),
     },
     pedigree_validation_type => {
         input           => q{SILENT},
@@ -181,11 +186,11 @@ ARGUMENT_HASH_REF:
 foreach my $argument_href (@arguments) {
     my @commands = test_function(
         {
-            argument_href          => $argument_href,
-            required_argument_href => \%required_argument,
-            module_function_cref   => $module_function_cref,
-            function_base_command  => $function_base_command,
-            do_test_base_command   => 1,
+            argument_href              => $argument_href,
+            required_argument_href     => \%required_argument,
+            module_function_cref       => $module_function_cref,
+            function_base_commands_ref => \@function_base_commands,
+            do_test_base_command       => 1,
         }
     );
 }

--- a/t/gatk_contest.t
+++ b/t/gatk_contest.t
@@ -99,12 +99,12 @@ diag(   q{Test gatk_contest from Contest.pm v}
       . $EXECUTABLE_NAME );
 
 ## Base arguments
-my $function_base_command = q{--analysis_type ContEst};
+my @function_base_commands = qw{ --analysis_type ContEst };
 
 my %base_argument = (
     FILEHANDLE => {
         input           => undef,
-        expected_output => $function_base_command,
+        expected_output => \@function_base_commands,
     },
 );
 
@@ -176,11 +176,11 @@ ARGUMENT_HASH_REF:
 foreach my $argument_href (@arguments) {
     my @commands = test_function(
         {
-            argument_href          => $argument_href,
-            do_test_base_command   => 1,
-            function_base_command  => $function_base_command,
-            module_function_cref   => $module_function_cref,
-            required_argument_href => \%required_argument,
+            argument_href              => $argument_href,
+            do_test_base_command       => 1,
+            function_base_commands_ref => \@function_base_commands,
+            module_function_cref       => $module_function_cref,
+            required_argument_href     => \%required_argument,
         }
     );
 }

--- a/t/gatk_genotypegvcfs.t
+++ b/t/gatk_genotypegvcfs.t
@@ -101,12 +101,12 @@ diag(   q{Test gatk_genotypegvcfs from Gatk v}
       . $EXECUTABLE_NAME );
 
 ## Base arguments
-my $function_base_command = q{--analysis_type GenotypeGVCFs};
+my @function_base_commands = qw{ --analysis_type GenotypeGVCFs };
 
 my %base_argument = (
     FILEHANDLE => {
         input           => undef,
-        expected_output => $function_base_command,
+        expected_output => \@function_base_commands,
     },
 );
 
@@ -120,12 +120,14 @@ my %required_argument = (
     },
     outfile_path => {
         input           => catfile(qw{ path_to_analysis_dir outfile.vcf }),
-        expected_output => q{--out} . $SPACE
+        expected_output => q{--out}
+          . $SPACE
           . catfile(qw{ path_to_analysis_dir outfile.vcf }),
     },
     referencefile_path => {
         input           => catfile(qw{reference_dir human_genome_build.fasta }),
-        expected_output => q{--reference_sequence} . $SPACE
+        expected_output => q{--reference_sequence}
+          . $SPACE
           . catfile(qw{reference_dir human_genome_build.fasta }),
     },
 );
@@ -151,7 +153,9 @@ my %specific_argument = (
     },
     pedigree => {
         input           => catfile(qw{ dir pedigree.fam }),
-        expected_output => q{--pedigree} . $SPACE . catfile(qw{ dir pedigree.fam }),
+        expected_output => q{--pedigree}
+          . $SPACE
+          . catfile(qw{ dir pedigree.fam }),
     },
     pedigree_validation_type => {
         input           => q{SILENT},
@@ -159,7 +163,8 @@ my %specific_argument = (
     },
     dbsnp_file_path => {
         input           => catfile(qw{ dir GRCh37_dbsnp_-138-.vcf}),
-        expected_output => q{--dbsnp} . $SPACE
+        expected_output => q{--dbsnp}
+          . $SPACE
           . catfile(qw{ dir GRCh37_dbsnp_-138-.vcf}),
     },
     include_nonvariant_sites => {
@@ -179,11 +184,11 @@ ARGUMENT_HASH_REF:
 foreach my $argument_href (@arguments) {
     my @commands = test_function(
         {
-            argument_href          => $argument_href,
-            required_argument_href => \%required_argument,
-            module_function_cref   => $module_function_cref,
-            function_base_command  => $function_base_command,
-            do_test_base_command   => 1,
+            argument_href              => $argument_href,
+            required_argument_href     => \%required_argument,
+            module_function_cref       => $module_function_cref,
+            function_base_commands_ref => \@function_base_commands,
+            do_test_base_command       => 1,
         }
     );
 }

--- a/t/gatk_haplotypecaller.t
+++ b/t/gatk_haplotypecaller.t
@@ -106,7 +106,7 @@ Readonly my $STANDARD_MIN_CONFIDENCE_THRESHOLD_FOR_CALLING => 10;
 Readonly my $VARIANT_INDEX_PARAMETER                       => 128_000;
 
 ## Base arguments
-my $function_base_command = q{--analysis_type HaplotypeCaller};
+my @function_base_commands = qw{ --analysis_type HaplotypeCaller };
 
 my %base_argument = (
     stderrfile_path => {
@@ -115,7 +115,7 @@ my %base_argument = (
     },
     FILEHANDLE => {
         input           => undef,
-        expected_output => $function_base_command,
+        expected_output => \@function_base_commands,
     },
 );
 
@@ -220,11 +220,11 @@ ARGUMENT_HASH_REF:
 foreach my $argument_href (@arguments) {
     my @commands = test_function(
         {
-            argument_href          => $argument_href,
-            required_argument_href => \%required_argument,
-            module_function_cref   => $module_function_cref,
-            function_base_command  => $function_base_command,
-            do_test_base_command   => 1,
+            argument_href              => $argument_href,
+            required_argument_href     => \%required_argument,
+            module_function_cref       => $module_function_cref,
+            function_base_commands_ref => \@function_base_commands,
+            do_test_base_command       => 1,
         }
     );
 }

--- a/t/gatk_indelrealigner.t
+++ b/t/gatk_indelrealigner.t
@@ -100,7 +100,7 @@ diag(   q{Test gatk_indelrealigner from Alignment::Gatk.pm v}
       . $EXECUTABLE_NAME );
 
 ## Base arguments
-my $function_base_command = q{--analysis_type IndelRealigner};
+my @function_base_commands = qw{ --analysis_type IndelRealigner };
 
 my %base_argument = (
     stderrfile_path => {
@@ -109,7 +109,7 @@ my %base_argument = (
     },
     FILEHANDLE => {
         input           => undef,
-        expected_output => $function_base_command,
+        expected_output => \@function_base_commands,
     },
 );
 
@@ -193,11 +193,11 @@ ARGUMENT_HASH_REF:
 foreach my $argument_href (@arguments) {
     my @commands = test_function(
         {
-            argument_href          => $argument_href,
-            required_argument_href => \%required_argument,
-            module_function_cref   => $module_function_cref,
-            function_base_command  => $function_base_command,
-            do_test_base_command   => 1,
+            argument_href              => $argument_href,
+            required_argument_href     => \%required_argument,
+            module_function_cref       => $module_function_cref,
+            function_base_commands_ref => \@function_base_commands,
+            do_test_base_command       => 1,
         }
     );
 }

--- a/t/gatk_leftalignandtrimvariants.t
+++ b/t/gatk_leftalignandtrimvariants.t
@@ -101,12 +101,12 @@ diag(   q{Test gatk_leftalignandtrimvariants from Gatk v}
       . $EXECUTABLE_NAME );
 
 ## Base arguments
-my $function_base_command = q{--analysis_type LeftAlignAndTrimVariants};
+my @function_base_commands = qw{ --analysis_type LeftAlignAndTrimVariants };
 
 my %base_argument = (
     FILEHANDLE => {
         input           => undef,
-        expected_output => $function_base_command,
+        expected_output => \@function_base_commands,
     },
 );
 
@@ -115,17 +115,20 @@ my %base_argument = (
 my %required_argument = (
     infile_path => {
         input           => catfile(qw{ path_to_analysis_dir infile.vcf }),
-        expected_output => q{--variant} . $SPACE
+        expected_output => q{--variant}
+          . $SPACE
           . catfile(qw{ path_to_analysis_dir infile.vcf }),
     },
     outfile_path => {
         input           => catfile(qw{ path_to_analysis_dir outfile.vcf }),
-        expected_output => q{--out} . $SPACE
+        expected_output => q{--out}
+          . $SPACE
           . catfile(qw{ path_to_analysis_dir outfile.vcf }),
     },
     referencefile_path => {
         input           => catfile(qw{reference_dir human_genome_build.fasta }),
-        expected_output => q{--reference_sequence} . $SPACE
+        expected_output => q{--reference_sequence}
+          . $SPACE
           . catfile(qw{reference_dir human_genome_build.fasta }),
     },
 );
@@ -151,7 +154,9 @@ my %specific_argument = (
     },
     pedigree => {
         input           => catfile(qw{ dir pedigree.fam }),
-        expected_output => q{--pedigree} . $SPACE . catfile(qw{ dir pedigree.fam }),
+        expected_output => q{--pedigree}
+          . $SPACE
+          . catfile(qw{ dir pedigree.fam }),
     },
     pedigree_validation_type => {
         input           => q{SILENT},
@@ -174,11 +179,11 @@ ARGUMENT_HASH_REF:
 foreach my $argument_href (@arguments) {
     my @commands = test_function(
         {
-            argument_href          => $argument_href,
-            required_argument_href => \%required_argument,
-            module_function_cref   => $module_function_cref,
-            function_base_command  => $function_base_command,
-            do_test_base_command   => 1,
+            argument_href              => $argument_href,
+            required_argument_href     => \%required_argument,
+            module_function_cref       => $module_function_cref,
+            function_base_commands_ref => \@function_base_commands,
+            do_test_base_command       => 1,
         }
     );
 }

--- a/t/gatk_printreads.t
+++ b/t/gatk_printreads.t
@@ -100,7 +100,7 @@ diag(   q{Test gatk_printreads from Alignment::Gatk.pm v}
       . $EXECUTABLE_NAME );
 
 ## Base arguments
-my $function_base_command = q{--analysis_type PrintReads};
+my @function_base_commands = qw{ --analysis_type PrintReads };
 
 my %base_argument = (
     stderrfile_path => {
@@ -109,7 +109,7 @@ my %base_argument = (
     },
     FILEHANDLE => {
         input           => undef,
-        expected_output => $function_base_command,
+        expected_output => \@function_base_commands,
     },
 );
 
@@ -161,11 +161,11 @@ ARGUMENT_HASH_REF:
 foreach my $argument_href (@arguments) {
     my @commands = test_function(
         {
-            argument_href          => $argument_href,
-            required_argument_href => \%required_argument,
-            module_function_cref   => $module_function_cref,
-            function_base_command  => $function_base_command,
-            do_test_base_command   => 1,
+            argument_href              => $argument_href,
+            required_argument_href     => \%required_argument,
+            module_function_cref       => $module_function_cref,
+            function_base_commands_ref => \@function_base_commands,
+            do_test_base_command       => 1,
         }
     );
 }

--- a/t/gatk_realignertargetcreator.t
+++ b/t/gatk_realignertargetcreator.t
@@ -100,7 +100,7 @@ diag(   q{Test gatk_realignertargetcreator from Alignment::Gatk.pm v}
       . $EXECUTABLE_NAME );
 
 ## Base arguments
-my $function_base_command = q{--analysis_type RealignerTargetCreator};
+my @function_base_commands = qw{ --analysis_type RealignerTargetCreator };
 
 my %base_argument = (
     stderrfile_path => {
@@ -109,7 +109,7 @@ my %base_argument = (
     },
     FILEHANDLE => {
         input           => undef,
-        expected_output => $function_base_command,
+        expected_output => \@function_base_commands,
     },
 );
 
@@ -179,11 +179,11 @@ ARGUMENT_HASH_REF:
 foreach my $argument_href (@arguments) {
     my @commands = test_function(
         {
-            argument_href          => $argument_href,
-            required_argument_href => \%required_argument,
-            module_function_cref   => $module_function_cref,
-            function_base_command  => $function_base_command,
-            do_test_base_command   => 1,
+            argument_href              => $argument_href,
+            required_argument_href     => \%required_argument,
+            module_function_cref       => $module_function_cref,
+            function_base_commands_ref => \@function_base_commands,
+            do_test_base_command       => 1,
         }
     );
 }

--- a/t/gatk_selectvariants.t
+++ b/t/gatk_selectvariants.t
@@ -101,12 +101,12 @@ diag(   q{Test gatk_selectvariants from Gatk v}
       . $EXECUTABLE_NAME );
 
 ## Base arguments
-my $function_base_command = q{--analysis_type SelectVariants};
+my @function_base_commands = qw{ --analysis_type SelectVariants };
 
 my %base_argument = (
     FILEHANDLE => {
         input           => undef,
-        expected_output => $function_base_command,
+        expected_output => \@function_base_commands,
     },
 );
 
@@ -120,17 +120,20 @@ q{--sample_name sample_1 --sample_name sample_2 --sample_name sample_3},
     },
     infile_path => {
         input           => catfile(qw{ path_to_analysis_dir infile.vcf }),
-        expected_output => q{--variant} . $SPACE
+        expected_output => q{--variant}
+          . $SPACE
           . catfile(qw{ path_to_analysis_dir infile.vcf }),
     },
     outfile_path => {
         input           => catfile(qw{ path_to_analysis_dir outfile.vcf }),
-        expected_output => q{--out} . $SPACE
+        expected_output => q{--out}
+          . $SPACE
           . catfile(qw{ path_to_analysis_dir outfile.vcf }),
     },
     referencefile_path => {
         input           => catfile(qw{reference_dir human_genome_build.fasta }),
-        expected_output => q{--reference_sequence} . $SPACE
+        expected_output => q{--reference_sequence}
+          . $SPACE
           . catfile(qw{reference_dir human_genome_build.fasta }),
     },
 );
@@ -156,7 +159,9 @@ my %specific_argument = (
     },
     pedigree => {
         input           => catfile(qw{ dir pedigree.fam }),
-        expected_output => q{--pedigree} . $SPACE . catfile(qw{ dir pedigree.fam }),
+        expected_output => q{--pedigree}
+          . $SPACE
+          . catfile(qw{ dir pedigree.fam }),
     },
     pedigree_validation_type => {
         input           => q{SILENT},
@@ -179,11 +184,11 @@ ARGUMENT_HASH_REF:
 foreach my $argument_href (@arguments) {
     my @commands = test_function(
         {
-            argument_href          => $argument_href,
-            required_argument_href => \%required_argument,
-            module_function_cref   => $module_function_cref,
-            function_base_command  => $function_base_command,
-            do_test_base_command   => 1,
+            argument_href              => $argument_href,
+            required_argument_href     => \%required_argument,
+            module_function_cref       => $module_function_cref,
+            function_base_commands_ref => \@function_base_commands,
+            do_test_base_command       => 1,
         }
     );
 }

--- a/t/gatk_splitncigarreads.t
+++ b/t/gatk_splitncigarreads.t
@@ -102,7 +102,7 @@ diag(   q{Test gatk_splitncigarreads from Alignment::Gatk.pm v}
       . $EXECUTABLE_NAME );
 
 ## Base arguments
-my $function_base_command = q{--analysis_type SplitNCigarReads};
+my @function_base_commands = qw{ --analysis_type SplitNCigarReads };
 
 my %base_argument = (
     stderrfile_path => {
@@ -111,7 +111,7 @@ my %base_argument = (
     },
     FILEHANDLE => {
         input           => undef,
-        expected_output => $function_base_command,
+        expected_output => \@function_base_commands,
     },
 );
 
@@ -179,11 +179,11 @@ ARGUMENT_HASH_REF:
 foreach my $argument_href (@arguments) {
     my @commands = test_function(
         {
-            argument_href          => $argument_href,
-            required_argument_href => \%required_argument,
-            module_function_cref   => $module_function_cref,
-            function_base_command  => $function_base_command,
-            do_test_base_command   => 1,
+            argument_href              => $argument_href,
+            required_argument_href     => \%required_argument,
+            module_function_cref       => $module_function_cref,
+            function_base_commands_ref => \@function_base_commands,
+            do_test_base_command       => 1,
         }
     );
 }

--- a/t/gatk_varianteval.t
+++ b/t/gatk_varianteval.t
@@ -101,12 +101,12 @@ diag(   q{Test gatk_varianteval from Gatk v}
       . $EXECUTABLE_NAME );
 
 ## Base arguments
-my $function_base_command = q{--analysis_type VariantEval};
+my @function_base_commands = qw{ --analysis_type VariantEval };
 
 my %base_argument = (
     FILEHANDLE => {
         input           => undef,
-        expected_output => $function_base_command,
+        expected_output => \@function_base_commands,
     },
 );
 
@@ -120,12 +120,14 @@ my %required_argument = (
     },
     outfile_path => {
         input           => catfile(qw{ path_to_analysis_dir outfile.vcf }),
-        expected_output => q{--out} . $SPACE
+        expected_output => q{--out}
+          . $SPACE
           . catfile(qw{ path_to_analysis_dir outfile.vcf }),
     },
     referencefile_path => {
         input           => catfile(qw{reference_dir human_genome_build.fasta }),
-        expected_output => q{--reference_sequence} . $SPACE
+        expected_output => q{--reference_sequence}
+          . $SPACE
           . catfile(qw{reference_dir human_genome_build.fasta }),
     },
 );
@@ -151,7 +153,9 @@ my %specific_argument = (
     },
     pedigree => {
         input           => catfile(qw{ dir pedigree.fam }),
-        expected_output => q{--pedigree} . $SPACE . catfile(qw{ dir pedigree.fam }),
+        expected_output => q{--pedigree}
+          . $SPACE
+          . catfile(qw{ dir pedigree.fam }),
     },
     pedigree_validation_type => {
         input           => q{SILENT},
@@ -159,13 +163,15 @@ my %specific_argument = (
     },
     dbsnp_file_path => {
         input           => catfile(qw{ dir GRCh37_dbsnp_-138_esa_129-.vcf}),
-        expected_output => q{--dbsnp} . $SPACE
+        expected_output => q{--dbsnp}
+          . $SPACE
           . catfile(qw{ dir GRCh37_dbsnp_-138_esa_129-.vcf}),
     },
     indel_gold_standard_file_path => {
         input =>
           catfile(qw{ dir GRCh37_mills_and_1000g_indels_-gold_standard-.vcf}),
-        expected_output => q{--goldStandard} . $SPACE
+        expected_output => q{--goldStandard}
+          . $SPACE
           . catfile(qw{ dir GRCh37_mills_and_1000g_indels_-gold_standard-.vcf}),
     },
 );
@@ -180,11 +186,11 @@ ARGUMENT_HASH_REF:
 foreach my $argument_href (@arguments) {
     my @commands = test_function(
         {
-            argument_href          => $argument_href,
-            required_argument_href => \%required_argument,
-            module_function_cref   => $module_function_cref,
-            function_base_command  => $function_base_command,
-            do_test_base_command   => 1,
+            argument_href              => $argument_href,
+            required_argument_href     => \%required_argument,
+            module_function_cref       => $module_function_cref,
+            function_base_commands_ref => \@function_base_commands,
+            do_test_base_command       => 1,
         }
     );
 }

--- a/t/gatk_variantfiltration.t
+++ b/t/gatk_variantfiltration.t
@@ -106,7 +106,7 @@ Readonly my $CLUSTER_SIZE        => 3;
 Readonly my $CLUSTER_WINDOW_SIZE => 35;
 
 ## Base arguments
-my $function_base_command = q{--analysis_type VariantFiltration};
+my @function_base_commands = qw{ --analysis_type VariantFiltration };
 
 my %base_argument = (
     stderrfile_path => {
@@ -115,7 +115,7 @@ my %base_argument = (
     },
     FILEHANDLE => {
         input           => undef,
-        expected_output => $function_base_command,
+        expected_output => \@function_base_commands,
     },
 );
 
@@ -173,11 +173,11 @@ ARGUMENT_HASH_REF:
 foreach my $argument_href (@arguments) {
     my @commands = test_function(
         {
-            argument_href          => $argument_href,
-            required_argument_href => \%required_argument,
-            module_function_cref   => $module_function_cref,
-            function_base_command  => $function_base_command,
-            do_test_base_command   => 1,
+            argument_href              => $argument_href,
+            required_argument_href     => \%required_argument,
+            module_function_cref       => $module_function_cref,
+            function_base_commands_ref => \@function_base_commands,
+            do_test_base_command       => 1,
         }
     );
 }

--- a/t/gatk_variantrecalibrator.t
+++ b/t/gatk_variantrecalibrator.t
@@ -105,12 +105,12 @@ diag(   q{Test gatk_variantrecalibrator from Gatk v}
       . $EXECUTABLE_NAME );
 
 ## Base arguments
-my $function_base_command = q{--analysis_type VariantRecalibrator};
+my @function_base_commands = qw{ --analysis_type VariantRecalibrator };
 
 my %base_argument = (
     FILEHANDLE => {
         input           => undef,
-        expected_output => $function_base_command,
+        expected_output => \@function_base_commands,
     },
 );
 
@@ -132,7 +132,8 @@ my %required_argument = (
     },
     referencefile_path => {
         input           => catfile(qw{reference_dir human_genome_build.fasta }),
-        expected_output => q{--reference_sequence} . $SPACE
+        expected_output => q{--reference_sequence}
+          . $SPACE
           . catfile(qw{reference_dir human_genome_build.fasta }),
     },
     mode => {
@@ -162,7 +163,9 @@ my %specific_argument = (
     },
     pedigree => {
         input           => catfile(qw{ dir pedigree.fam }),
-        expected_output => q{--pedigree} . $SPACE . catfile(qw{ dir pedigree.fam }),
+        expected_output => q{--pedigree}
+          . $SPACE
+          . catfile(qw{ dir pedigree.fam }),
     },
     pedigree_validation_type => {
         input           => q{SILENT},
@@ -174,27 +177,37 @@ my %specific_argument = (
           q{--read_filter MalformedRead --read_filter BadCigar},
     },
     static_quantized_quals_ref => {
-        inputs_ref => [ $QUALSCORE_1, $QUALSCORE_2 ],
-        expected_output =>
-          q{--static_quantized_quals} . $SPACE . $QUALSCORE_1 . $SPACE . q{--static_quantized_quals} . $SPACE . $QUALSCORE_2,
+        inputs_ref      => [ $QUALSCORE_1, $QUALSCORE_2 ],
+        expected_output => q{--static_quantized_quals}
+          . $SPACE
+          . $QUALSCORE_1
+          . $SPACE
+          . q{--static_quantized_quals}
+          . $SPACE
+          . $QUALSCORE_2,
     },
     base_quality_score_recalibration_file => {
         input           => catfile(qw{ dir recalibration_report.grp }),
-        expected_output => q{--BQSR} . $SPACE
+        expected_output => q{--BQSR}
+          . $SPACE
           . catfile(qw{ dir recalibration_report.grp }),
     },
     rscript_file_path => {
         input           => catfile(qw{ dir rscript.r }),
-        expected_output => q{--rscript_file} . $SPACE . catfile(qw{ dir rscript.r }),
+        expected_output => q{--rscript_file}
+          . $SPACE
+          . catfile(qw{ dir rscript.r }),
     },
     recal_file_path => {
         input           => catfile(qw{ dir recal_file.intervals }),
-        expected_output => q{--recal_file} . $SPACE
+        expected_output => q{--recal_file}
+          . $SPACE
           . catfile(qw{ dir recal_file.intervals }),
     },
     tranches_file_path => {
         input           => catfile(qw{ dir tranchesfile.tranches }),
-        expected_output => q{--tranches_file} . $SPACE
+        expected_output => q{--tranches_file}
+          . $SPACE
           . catfile(qw{ dir tranchesfile.tranches }),
     },
     num_cpu_threads_per_data_thread => {
@@ -221,11 +234,11 @@ ARGUMENT_HASH_REF:
 foreach my $argument_href (@arguments) {
     my @commands = test_function(
         {
-            argument_href          => $argument_href,
-            required_argument_href => \%required_argument,
-            module_function_cref   => $module_function_cref,
-            function_base_command  => $function_base_command,
-            do_test_base_command   => 1,
+            argument_href              => $argument_href,
+            required_argument_href     => \%required_argument,
+            module_function_cref       => $module_function_cref,
+            function_base_commands_ref => \@function_base_commands,
+            do_test_base_command       => 1,
         }
     );
 }

--- a/t/genmod_annotate.t
+++ b/t/genmod_annotate.t
@@ -99,12 +99,12 @@ diag(   q{Test genmod_annotate from Genmod.pm v}
       . $EXECUTABLE_NAME );
 
 ## Base arguments
-my $function_base_command = q{genmod};
+my @function_base_commands = qw{ genmod };
 
 my %base_argument = (
     FILEHANDLE => {
         input           => undef,
-        expected_output => $function_base_command,
+        expected_output => \@function_base_commands,
     },
     stderrfile_path => {
         input           => q{stderrfile.test},
@@ -195,11 +195,11 @@ ARGUMENT_HASH_REF:
 foreach my $argument_href (@arguments) {
     my @commands = test_function(
         {
-            argument_href          => $argument_href,
-            required_argument_href => \%required_argument,
-            module_function_cref   => $module_function_cref,
-            function_base_command  => $function_base_command,
-            do_test_base_command   => 1,
+            argument_href              => $argument_href,
+            required_argument_href     => \%required_argument,
+            module_function_cref       => $module_function_cref,
+            function_base_commands_ref => \@function_base_commands,
+            do_test_base_command       => 1,
         }
     );
 }

--- a/t/genmod_compound.t
+++ b/t/genmod_compound.t
@@ -99,12 +99,12 @@ diag(   q{Test genmod_compound from Genmod.pm v}
       . $EXECUTABLE_NAME );
 
 ## Base arguments
-my $function_base_command = q{genmod};
+my @function_base_commands = qw{ genmod };
 
 my %base_argument = (
     FILEHANDLE => {
         input           => undef,
-        expected_output => $function_base_command,
+        expected_output => \@function_base_commands,
     },
     stderrfile_path => {
         input           => q{stderrfile.test},
@@ -170,11 +170,11 @@ ARGUMENT_HASH_REF:
 foreach my $argument_href (@arguments) {
     my @commands = test_function(
         {
-            argument_href          => $argument_href,
-            required_argument_href => \%required_argument,
-            module_function_cref   => $module_function_cref,
-            function_base_command  => $function_base_command,
-            do_test_base_command   => 1,
+            argument_href              => $argument_href,
+            required_argument_href     => \%required_argument,
+            module_function_cref       => $module_function_cref,
+            function_base_commands_ref => \@function_base_commands,
+            do_test_base_command       => 1,
         }
     );
 }

--- a/t/genmod_filter.t
+++ b/t/genmod_filter.t
@@ -99,12 +99,12 @@ diag(   q{Test genmod_filter from Genmod.pm v}
       . $EXECUTABLE_NAME );
 
 ## Base arguments
-my $function_base_command = q{genmod};
+my @function_base_commands = qw{ genmod };
 
 my %base_argument = (
     FILEHANDLE => {
         input           => undef,
-        expected_output => $function_base_command,
+        expected_output => \@function_base_commands,
     },
     stderrfile_path => {
         input           => q{stderrfile.test},
@@ -160,11 +160,11 @@ ARGUMENT_HASH_REF:
 foreach my $argument_href (@arguments) {
     my @commands = test_function(
         {
-            argument_href          => $argument_href,
-            required_argument_href => \%required_argument,
-            module_function_cref   => $module_function_cref,
-            function_base_command  => $function_base_command,
-            do_test_base_command   => 1,
+            argument_href              => $argument_href,
+            required_argument_href     => \%required_argument,
+            module_function_cref       => $module_function_cref,
+            function_base_commands_ref => \@function_base_commands,
+            do_test_base_command       => 1,
         }
     );
 }

--- a/t/genmod_models.t
+++ b/t/genmod_models.t
@@ -99,12 +99,12 @@ diag(   q{Test genmod_models from Genmod.pm v}
       . $EXECUTABLE_NAME );
 
 ## Base arguments
-my $function_base_command = q{genmod};
+my @function_base_commands = qw{ genmod };
 
 my %base_argument = (
     FILEHANDLE => {
         input           => undef,
-        expected_output => $function_base_command,
+        expected_output => \@function_base_commands,
     },
     stderrfile_path => {
         input           => q{stderrfile.test},
@@ -196,11 +196,11 @@ ARGUMENT_HASH_REF:
 foreach my $argument_href (@arguments) {
     my @commands = test_function(
         {
-            argument_href          => $argument_href,
-            required_argument_href => \%required_argument,
-            module_function_cref   => $module_function_cref,
-            function_base_command  => $function_base_command,
-            do_test_base_command   => 1,
+            argument_href              => $argument_href,
+            required_argument_href     => \%required_argument,
+            module_function_cref       => $module_function_cref,
+            function_base_commands_ref => \@function_base_commands,
+            do_test_base_command       => 1,
         }
     );
 }

--- a/t/genmod_score.t
+++ b/t/genmod_score.t
@@ -99,12 +99,12 @@ diag(   q{Test genmod_score from Genmod.pm v}
       . $EXECUTABLE_NAME );
 
 ## Base arguments
-my $function_base_command = q{genmod};
+my @function_base_commands = qw{ genmod };
 
 my %base_argument = (
     FILEHANDLE => {
         input           => undef,
-        expected_output => $function_base_command,
+        expected_output => \@function_base_commands,
     },
     stderrfile_path => {
         input           => q{stderrfile.test},
@@ -194,11 +194,11 @@ ARGUMENT_HASH_REF:
 foreach my $argument_href (@arguments) {
     my @commands = test_function(
         {
-            argument_href          => $argument_href,
-            required_argument_href => \%required_argument,
-            module_function_cref   => $module_function_cref,
-            function_base_command  => $function_base_command,
-            do_test_base_command   => 1,
+            argument_href              => $argument_href,
+            required_argument_href     => \%required_argument,
+            module_function_cref       => $module_function_cref,
+            function_base_commands_ref => \@function_base_commands,
+            do_test_base_command       => 1,
         }
     );
 }

--- a/t/get_capture_kit.t
+++ b/t/get_capture_kit.t
@@ -102,10 +102,11 @@ my $capture_kit = q{latest};
 
 my %parameter = (
     supported_capture_kit => {
-            q{agilent_sureselect.v5} =>
+        q{agilent_sureselect.v5} =>
 q{genome_reference_source_version_agilent_sureselect_targets_-v5-.bed},
-		    latest => q{genome_reference_source_version_agilent_sureselect_targets_cre_-v1-.bed},
-        },
+        latest =>
+q{genome_reference_source_version_agilent_sureselect_targets_cre_-v1-.bed},
+    },
 );
 
 my %user_supply_switch = ( exome_target_bed => 0, );

--- a/t/get_core_number.t
+++ b/t/get_core_number.t
@@ -60,7 +60,7 @@ BEGIN {
 ### Check all internal dependency modules and imports
     ## Modules with import
     my %perl_module = (
-        'MIP::Script::Utils'       => [qw{help}],
+        'MIP::Script::Utils'  => [qw{help}],
         'MIP::Check::Cluster' => [qw{check_max_core_number}],
     );
 
@@ -81,8 +81,7 @@ BEGIN {
 
 use MIP::Cluster qw(get_core_number);
 
-diag(
-    "Test get_core_number $MIP::Cluster::VERSION, Perl $^V, $EXECUTABLE_NAME" );
+diag("Test get_core_number $MIP::Cluster::VERSION, Perl $^V, $EXECUTABLE_NAME");
 
 # Core number to test
 Readonly my $MODULE_CORE_NUMBER   => 1;

--- a/t/get_module_parameters.t
+++ b/t/get_module_parameters.t
@@ -108,7 +108,7 @@ my %active_parameter = (
 my ( $core_number, $time, @source_environment_cmds ) = get_module_parameters(
     {
         active_parameter_href => \%active_parameter,
-        program_name      => $program_name,
+        program_name          => $program_name,
     }
 );
 
@@ -130,7 +130,7 @@ is_deeply( \@source_environment_cmds, [qw{source activate mip}],
 ( $core_number, $time, @source_environment_cmds ) = get_module_parameters(
     {
         active_parameter_href => \%active_parameter,
-        program_name      => $program_name,
+        program_name          => $program_name,
     }
 );
 

--- a/t/get_program_parameters.t
+++ b/t/get_program_parameters.t
@@ -108,7 +108,7 @@ my %active_parameter = (
 my @program_source_environment_cmds = get_program_parameters(
     {
         active_parameter_href => \%active_parameter,
-        program_name      => $program_name,
+        program_name          => $program_name,
     }
 );
 

--- a/t/get_program_version.t
+++ b/t/get_program_version.t
@@ -176,7 +176,7 @@ my $sambamba_cmd =
 ## Set in program features hash
 $program_feature{gatk_path}{cmd}        = $gatk_cmd;
 $program_feature{picardtools_path}{cmd} = $picard_cmd;
-$program_feature{sambamba_depth}{cmd}  = $sambamba_cmd;
+$program_feature{sambamba_depth}{cmd}   = $sambamba_cmd;
 
 ## Scramble the regexps, that need scrambling
 $program_feature{gatk_path}{regexp}        = q{Not valid};

--- a/t/get_user_supplied_info.t
+++ b/t/get_user_supplied_info.t
@@ -29,10 +29,10 @@ my $VERBOSE = 1;
 our $VERSION = '1.0.0';
 
 ## Constants
-Readonly my $COMMA   => q{,};
+Readonly my $COMMA             => q{,};
 Readonly my $EXPECTED_COVERAGE => 30;
-Readonly my $NEWLINE => qq{\n};
-Readonly my $SPACE   => q{ };
+Readonly my $NEWLINE           => qq{\n};
+Readonly my $SPACE             => q{ };
 
 ### User Options
 GetOptions(
@@ -99,8 +99,8 @@ diag(   q{Test get_user_supplied_info from Parameter.pm v}
       . $EXECUTABLE_NAME );
 
 my %active_parameter = (
-    analysis_type => { sample_id => q{wgs}, },
-    sample_ids    => [qw{ sample_1 sample_2 }],
+    analysis_type     => { sample_id => q{wgs}, },
+    sample_ids        => [qw{ sample_1 sample_2 }],
     expected_coverage => $EXPECTED_COVERAGE,
 );
 

--- a/t/git_checkout.t
+++ b/t/git_checkout.t
@@ -100,7 +100,7 @@ diag(   q{Test git_checkout from Git.pm v}
       . $EXECUTABLE_NAME );
 
 ## Base arguments
-my $function_base_command = q{git};
+my @function_base_commands = qw{ git };
 
 my %base_argument = (
     stdoutfile_path => {
@@ -117,7 +117,7 @@ my %base_argument = (
     },
     FILEHANDLE => {
         input           => undef,
-        expected_output => $function_base_command,
+        expected_output => \@function_base_commands,
     },
 );
 
@@ -130,14 +130,14 @@ my %required_argument = (
     },
     FILEHANDLE => {
         input           => undef,
-        expected_output => $function_base_command,
+        expected_output => \@function_base_commands,
     },
 );
 
 my %specific_argument = (
     FILEHANDLE => {
         input           => undef,
-        expected_output => $function_base_command,
+        expected_output => \@function_base_commands,
     },
 );
 
@@ -151,11 +151,11 @@ ARGUMENT_HASH_REF:
 foreach my $argument_href (@arguments) {
     my @commands = test_function(
         {
-            argument_href          => $argument_href,
-            required_argument_href => \%required_argument,
-            module_function_cref   => $module_function_cref,
-            function_base_command  => $function_base_command,
-            do_test_base_command   => 1,
+            argument_href              => $argument_href,
+            required_argument_href     => \%required_argument,
+            module_function_cref       => $module_function_cref,
+            function_base_commands_ref => \@function_base_commands,
+            do_test_base_command       => 1,
         }
     );
 }

--- a/t/git_clone.t
+++ b/t/git_clone.t
@@ -100,7 +100,7 @@ diag(   q{Test git_clone from Git.pm v}
       . $EXECUTABLE_NAME );
 
 ## Base arguments
-my $function_base_command = q{git};
+my @function_base_commands = qw{ git };
 
 my %base_argument = (
     stdoutfile_path => {
@@ -117,7 +117,7 @@ my %base_argument = (
     },
     FILEHANDLE => {
         input           => undef,
-        expected_output => $function_base_command,
+        expected_output => \@function_base_commands,
     },
 );
 
@@ -130,18 +130,18 @@ my %required_argument = (
     },
     FILEHANDLE => {
         input           => undef,
-        expected_output => $function_base_command,
+        expected_output => \@function_base_commands,
     },
 );
 
 my %specific_argument = (
     FILEHANDLE => {
         input           => undef,
-        expected_output => $function_base_command,
+        expected_output => \@function_base_commands,
     },
     outdir_path => {
-        input           => catdir( qw{ a test path } ),
-        expected_output => catdir( qw{ a test path } ),
+        input           => catdir(qw{ a test path }),
+        expected_output => catdir(qw{ a test path }),
     },
     verbose => {
         input           => 1,
@@ -163,11 +163,11 @@ ARGUMENT_HASH_REF:
 foreach my $argument_href (@arguments) {
     my @commands = test_function(
         {
-            argument_href          => $argument_href,
-            required_argument_href => \%required_argument,
-            module_function_cref   => $module_function_cref,
-            function_base_command  => $function_base_command,
-            do_test_base_command   => 1,
+            argument_href              => $argument_href,
+            required_argument_href     => \%required_argument,
+            module_function_cref       => $module_function_cref,
+            function_base_commands_ref => \@function_base_commands,
+            do_test_base_command       => 1,
         }
     );
 }

--- a/t/gnu_cat.t
+++ b/t/gnu_cat.t
@@ -78,7 +78,7 @@ use MIP::Test::Commands qw(test_function);
 diag("Test gnu_cat $MIP::Gnu::Coreutils::VERSION, Perl $^V, $EXECUTABLE_NAME");
 
 ## Base arguments
-my $function_base_command = 'cat';
+my @function_base_commands = 'cat';
 
 my %base_argument = (
     stderrfile_path => {
@@ -91,7 +91,7 @@ my %base_argument = (
     },
     FILEHANDLE => {
         input           => undef,
-        expected_output => $function_base_command,
+        expected_output => \@function_base_commands,
     },
 );
 
@@ -124,10 +124,10 @@ my @arguments = ( \%base_argument, \%specific_argument );
 foreach my $argument_href (@arguments) {
     my @commands = test_function(
         {
-            argument_href          => $argument_href,
-            required_argument_href => \%required_argument,
-            module_function_cref   => $module_function_cref,
-            function_base_command  => $function_base_command,
+            argument_href              => $argument_href,
+            required_argument_href     => \%required_argument,
+            module_function_cref       => $module_function_cref,
+            function_base_commands_ref => \@function_base_commands,
         }
     );
 }

--- a/t/gnu_cd.t
+++ b/t/gnu_cd.t
@@ -82,7 +82,7 @@ use MIP::Test::Commands qw(test_function);
 diag("Test gnu_cd $MIP::Gnu::Bash::VERSION, Perl $^V, $EXECUTABLE_NAME");
 
 ## Base arguments
-my $function_base_command = 'cd';
+my @function_base_commands = 'cd';
 
 my %base_argument = (
     stderrfile_path => {
@@ -95,7 +95,7 @@ my %base_argument = (
     },
     FILEHANDLE => {
         input           => undef,
-        expected_output => $function_base_command,
+        expected_output => \@function_base_commands,
     },
 );
 
@@ -117,9 +117,9 @@ foreach my $argument_href (@arguments) {
 
     my @commands = test_function(
         {
-            argument_href         => $argument_href,
-            module_function_cref  => $module_function_cref,
-            function_base_command => $function_base_command,
+            argument_href              => $argument_href,
+            module_function_cref       => $module_function_cref,
+            function_base_commands_ref => \@function_base_commands,
         }
     );
 }

--- a/t/gnu_chmod.t
+++ b/t/gnu_chmod.t
@@ -90,7 +90,7 @@ diag(   q{Test gnu_chmod in Coreutils.pm v}
       . $EXECUTABLE_NAME );
 
 ## Base arguments
-my $function_base_command = q{chmod};
+my @function_base_commands = qw{ chmod };
 
 my %base_argument = (
     stderrfile_path => {
@@ -107,7 +107,7 @@ my %base_argument = (
     },
     FILEHANDLE => {
         input           => undef,
-        expected_output => $function_base_command,
+        expected_output => \@function_base_commands,
     },
 );
 
@@ -132,11 +132,11 @@ my @arguments = ( \%base_argument, \%required_argument );
 foreach my $argument_href (@arguments) {
     my @commands = test_function(
         {
-            argument_href          => $argument_href,
-            required_argument_href => \%required_argument,
-            module_function_cref   => $module_function_cref,
-            function_base_command  => $function_base_command,
-            do_test_base_command   => 1,
+            argument_href              => $argument_href,
+            required_argument_href     => \%required_argument,
+            module_function_cref       => $module_function_cref,
+            function_base_commands_ref => \@function_base_commands,
+            do_test_base_command       => 1,
         }
     );
 }

--- a/t/gnu_cp.t
+++ b/t/gnu_cp.t
@@ -75,10 +75,10 @@ BEGIN {
 use MIP::Gnu::Coreutils qw(gnu_cp);
 use MIP::Test::Commands qw(test_function);
 
-diag( "Test gnu_cp $MIP::Gnu::Coreutils::VERSION, Perl $^V, $EXECUTABLE_NAME" );
+diag("Test gnu_cp $MIP::Gnu::Coreutils::VERSION, Perl $^V, $EXECUTABLE_NAME");
 
 ## Base arguments
-my $function_base_command = 'cp';
+my @function_base_commands = 'cp';
 
 my %base_argument = (
     stderrfile_path => {
@@ -91,7 +91,7 @@ my %base_argument = (
     },
     FILEHANDLE => {
         input           => undef,
-        expected_output => $function_base_command,
+        expected_output => \@function_base_commands,
     },
 );
 
@@ -148,10 +148,10 @@ my @arguments = ( \%base_argument, \%specific_argument );
 foreach my $argument_href (@arguments) {
     my @commands = test_function(
         {
-            argument_href          => $argument_href,
-            required_argument_href => \%required_argument,
-            module_function_cref   => $module_function_cref,
-            function_base_command  => $function_base_command,
+            argument_href              => $argument_href,
+            required_argument_href     => \%required_argument,
+            module_function_cref       => $module_function_cref,
+            function_base_commands_ref => \@function_base_commands,
         }
     );
 }

--- a/t/gnu_echo.t
+++ b/t/gnu_echo.t
@@ -78,11 +78,11 @@ use MIP::Test::Commands qw(test_function);
 
 diag("Test gnu_echo $MIP::Gnu::Coreutils::VERSION, Perl $^V, $EXECUTABLE_NAME");
 
-## Constants 
+## Constants
 Readonly my $DOUBLE_QUOTE => q{"};
 
 ## Base arguments
-my $function_base_command = 'echo';
+my @function_base_commands = 'echo';
 
 my %base_argument = (
     stderrfile_path => {
@@ -95,7 +95,7 @@ my %base_argument = (
     },
     FILEHANDLE => {
         input           => undef,
-        expected_output => $function_base_command,
+        expected_output => \@function_base_commands,
     },
 );
 
@@ -103,7 +103,9 @@ my %base_argument = (
 my %required_argument = (
     strings_ref => {
         inputs_ref      => [q{This is my test string}],
-        expected_output => $DOUBLE_QUOTE . q{This is my test string} . $DOUBLE_QUOTE,
+        expected_output => $DOUBLE_QUOTE
+          . q{This is my test string}
+          . $DOUBLE_QUOTE,
     },
 );
 
@@ -111,7 +113,9 @@ my %required_argument = (
 my %specific_argument = (
     strings_ref => {
         inputs_ref      => [q{This is my test string}],
-        expected_output => $DOUBLE_QUOTE . q{This is my test string} . $DOUBLE_QUOTE,
+        expected_output => $DOUBLE_QUOTE
+          . q{This is my test string}
+          . $DOUBLE_QUOTE,
     },
     outfile_path => {
         input           => 'outfile.test',
@@ -136,10 +140,10 @@ my @arguments = ( \%base_argument, \%specific_argument );
 foreach my $argument_href (@arguments) {
     my @commands = test_function(
         {
-            argument_href          => $argument_href,
-            required_argument_href => \%required_argument,
-            module_function_cref   => $module_function_cref,
-            function_base_command  => $function_base_command,
+            argument_href              => $argument_href,
+            required_argument_href     => \%required_argument,
+            module_function_cref       => $module_function_cref,
+            function_base_commands_ref => \@function_base_commands,
         }
     );
 }

--- a/t/gnu_find.t
+++ b/t/gnu_find.t
@@ -100,12 +100,12 @@ diag(   q{Test gnu_find from Findutils.pm v}
       . $EXECUTABLE_NAME );
 
 ## Base arguments
-my $function_base_command = q{find};
+my @function_base_commands = qw{ find };
 
 my %base_argument = (
     FILEHANDLE => {
         input           => undef,
-        expected_output => $function_base_command,
+        expected_output => \@function_base_commands,
     },
 );
 
@@ -147,11 +147,11 @@ ARGUMENT_HASH_REF:
 foreach my $argument_href (@arguments) {
     my @commands = test_function(
         {
-            argument_href          => $argument_href,
-            required_argument_href => \%required_argument,
-            module_function_cref   => $module_function_cref,
-            function_base_command  => $function_base_command,
-            do_test_base_command   => 1,
+            argument_href              => $argument_href,
+            required_argument_href     => \%required_argument,
+            module_function_cref       => $module_function_cref,
+            function_base_commands_ref => \@function_base_commands,
+            do_test_base_command       => 1,
         }
     );
 }

--- a/t/gnu_grep.t
+++ b/t/gnu_grep.t
@@ -84,7 +84,7 @@ diag(
 );
 
 ## Base arguments
-my $function_base_command = 'grep';
+my @function_base_commands = 'grep';
 
 my %base_argument = (
     stderrfile_path => {
@@ -97,7 +97,7 @@ my %base_argument = (
     },
     FILEHANDLE => {
         input           => undef,
-        expected_output => $function_base_command,
+        expected_output => \@function_base_commands,
     },
 );
 
@@ -139,10 +139,10 @@ foreach my $argument_href (@arguments) {
 
     my @commands = test_function(
         {
-            argument_href          => $argument_href,
-            required_argument_href => \%required_argument,
-            module_function_cref   => $module_function_cref,
-            function_base_command  => $function_base_command,
+            argument_href              => $argument_href,
+            required_argument_href     => \%required_argument,
+            module_function_cref       => $module_function_cref,
+            function_base_commands_ref => \@function_base_commands,
         }
     );
 }

--- a/t/gnu_less.t
+++ b/t/gnu_less.t
@@ -84,7 +84,7 @@ diag(
 );
 
 ## Base arguments
-my $function_base_command = 'less';
+my @function_base_commands = 'less';
 
 my %base_argument = (
     stderrfile_path => {
@@ -97,7 +97,7 @@ my %base_argument = (
     },
     FILEHANDLE => {
         input           => undef,
-        expected_output => $function_base_command,
+        expected_output => \@function_base_commands,
     },
 );
 
@@ -122,9 +122,9 @@ my @arguments = ( \%base_argument, \%specific_argument );
 foreach my $argument_href (@arguments) {
     my @commands = test_function(
         {
-            argument_href          => $argument_href,
-            module_function_cref   => $module_function_cref,
-            function_base_command  => $function_base_command,
+            argument_href              => $argument_href,
+            module_function_cref       => $module_function_cref,
+            function_base_commands_ref => \@function_base_commands,
         }
     );
 }

--- a/t/gnu_ln.t
+++ b/t/gnu_ln.t
@@ -90,7 +90,7 @@ diag(   q{Test gnu_ln }
       . $EXECUTABLE_NAME );
 
 ## Base arguments
-my $function_base_command = q{ln};
+my @function_base_commands = qw{ ln };
 
 my %base_argument = (
     stderrfile_path => {
@@ -107,7 +107,7 @@ my %base_argument = (
     },
     FILEHANDLE => {
         input           => undef,
-        expected_output => $function_base_command,
+        expected_output => \@function_base_commands,
     },
 );
 
@@ -143,11 +143,11 @@ my @arguments = ( \%required_argument, \%specific_argument );
 foreach my $argument_href (@arguments) {
     my @commands = test_function(
         {
-            argument_href          => $argument_href,
-            required_argument_href => \%required_argument,
-            module_function_cref   => $module_function_cref,
-            function_base_command  => $function_base_command,
-            do_test_base_command   => 1,
+            argument_href              => $argument_href,
+            required_argument_href     => \%required_argument,
+            module_function_cref       => $module_function_cref,
+            function_base_commands_ref => \@function_base_commands,
+            do_test_base_command       => 1,
         }
     );
 }

--- a/t/gnu_make.t
+++ b/t/gnu_make.t
@@ -100,7 +100,7 @@ diag(   q{Test gnu_make from Software.pm v}
       . $EXECUTABLE_NAME );
 
 ## Base arguments
-my $function_base_command = q{make};
+my @function_base_commands = qw{ make };
 
 my %base_argument = (
     stdoutfile_path => {
@@ -117,7 +117,7 @@ my %base_argument = (
     },
     FILEHANDLE => {
         input           => undef,
-        expected_output => $function_base_command,
+        expected_output => \@function_base_commands,
     },
 );
 
@@ -142,10 +142,10 @@ ARGUMENT_HASH_REF:
 foreach my $argument_href (@arguments) {
     my @commands = test_function(
         {
-            argument_href         => $argument_href,
-            module_function_cref  => $module_function_cref,
-            function_base_command => $function_base_command,
-            do_test_base_command  => 1,
+            argument_href              => $argument_href,
+            module_function_cref       => $module_function_cref,
+            function_base_commands_ref => \@function_base_commands,
+            do_test_base_command       => 1,
         }
     );
 }

--- a/t/gnu_md5sum.t
+++ b/t/gnu_md5sum.t
@@ -101,7 +101,7 @@ diag(   q{Test gnu_md5sum from Coreutils.pm v}
       . $EXECUTABLE_NAME );
 
 ## Base arguments
-my $function_base_command = q{md5sum};
+my @function_base_commands = qw{ md5sum };
 
 my %base_argument = (
     stdoutfile_path => {
@@ -118,7 +118,7 @@ my %base_argument = (
     },
     FILEHANDLE => {
         input           => undef,
-        expected_output => $function_base_command,
+        expected_output => \@function_base_commands,
     },
 );
 
@@ -147,11 +147,11 @@ ARGUMENT_HASH_REF:
 foreach my $argument_href (@arguments) {
     my @commands = test_function(
         {
-            argument_href          => $argument_href,
-            required_argument_href => \%required_argument,
-            module_function_cref   => $module_function_cref,
-            function_base_command  => $function_base_command,
-            do_test_base_command   => 1,
+            argument_href              => $argument_href,
+            required_argument_href     => \%required_argument,
+            module_function_cref       => $module_function_cref,
+            function_base_commands_ref => \@function_base_commands,
+            do_test_base_command       => 1,
         }
     );
 }

--- a/t/gnu_mkdir.t
+++ b/t/gnu_mkdir.t
@@ -79,7 +79,7 @@ diag(
     "Test gnu_mkdir $MIP::Gnu::Coreutils::VERSION, Perl $^V, $EXECUTABLE_NAME");
 
 ## Base arguments
-my $function_base_command = 'mkdir';
+my @function_base_commands = 'mkdir';
 
 my %base_argument = (
     stderrfile_path => {
@@ -92,7 +92,7 @@ my %base_argument = (
     },
     FILEHANDLE => {
         input           => undef,
-        expected_output => $function_base_command,
+        expected_output => \@function_base_commands,
     },
 );
 
@@ -129,10 +129,10 @@ my @arguments = ( \%base_argument, \%specific_argument );
 foreach my $argument_href (@arguments) {
     my @commands = test_function(
         {
-            argument_href          => $argument_href,
-            required_argument_href => \%required_argument,
-            module_function_cref   => $module_function_cref,
-            function_base_command  => $function_base_command,
+            argument_href              => $argument_href,
+            required_argument_href     => \%required_argument,
+            module_function_cref       => $module_function_cref,
+            function_base_commands_ref => \@function_base_commands,
         }
     );
 }

--- a/t/gnu_mv.t
+++ b/t/gnu_mv.t
@@ -78,7 +78,7 @@ use MIP::Test::Commands qw(test_function);
 diag("Test gnu_mv $MIP::Gnu::Coreutils::VERSION, Perl $^V, $EXECUTABLE_NAME");
 
 ## Base arguments
-my $function_base_command = 'mv';
+my @function_base_commands = 'mv';
 
 my %base_argument = (
     stderrfile_path => {
@@ -91,7 +91,7 @@ my %base_argument = (
     },
     FILEHANDLE => {
         input           => undef,
-        expected_output => $function_base_command,
+        expected_output => \@function_base_commands,
     },
 );
 
@@ -136,10 +136,10 @@ my @arguments = ( \%base_argument, \%specific_argument );
 foreach my $argument_href (@arguments) {
     my @commands = test_function(
         {
-            argument_href          => $argument_href,
-            required_argument_href => \%required_argument,
-            module_function_cref   => $module_function_cref,
-            function_base_command  => $function_base_command,
+            argument_href              => $argument_href,
+            required_argument_href     => \%required_argument,
+            module_function_cref       => $module_function_cref,
+            function_base_commands_ref => \@function_base_commands,
         }
     );
 }

--- a/t/gnu_printf.t
+++ b/t/gnu_printf.t
@@ -75,11 +75,12 @@ BEGIN {
 use MIP::Gnu::Coreutils qw(gnu_printf);
 use MIP::Test::Commands qw(test_function);
 
-diag("Test gnu_printf $MIP::Gnu::Coreutils::VERSION, Perl $^V, $EXECUTABLE_NAME"
+diag(
+    "Test gnu_printf $MIP::Gnu::Coreutils::VERSION, Perl $^V, $EXECUTABLE_NAME"
 );
 
 ## Base arguments
-my $function_base_command = 'printf';
+my @function_base_commands = 'printf';
 
 my %base_argument = (
     stdoutfile_path => {
@@ -96,7 +97,7 @@ my %base_argument = (
     },
     FILEHANDLE => {
         input           => undef,
-        expected_output => $function_base_command,
+        expected_output => \@function_base_commands,
     },
 );
 
@@ -119,9 +120,9 @@ my @arguments = ( \%base_argument, \%specific_argument );
 foreach my $argument_href (@arguments) {
     my @commands = test_function(
         {
-            argument_href         => $argument_href,
-            module_function_cref  => $module_function_cref,
-            function_base_command => $function_base_command,
+            argument_href              => $argument_href,
+            module_function_cref       => $module_function_cref,
+            function_base_commands_ref => \@function_base_commands,
         }
     );
 }

--- a/t/gnu_rm.t
+++ b/t/gnu_rm.t
@@ -78,7 +78,7 @@ use MIP::Test::Commands qw(test_function);
 diag("Test gnu_rm $MIP::Gnu::Coreutils::VERSION, Perl $^V, $EXECUTABLE_NAME");
 
 ## Base arguments
-my $function_base_command = 'rm';
+my @function_base_commands = 'rm';
 
 my %base_argument = (
     stderrfile_path => {
@@ -91,7 +91,7 @@ my %base_argument = (
     },
     FILEHANDLE => {
         input           => undef,
-        expected_output => $function_base_command,
+        expected_output => \@function_base_commands,
     },
 );
 
@@ -132,10 +132,10 @@ my @arguments = ( \%base_argument, \%specific_argument );
 foreach my $argument_href (@arguments) {
     my @commands = test_function(
         {
-            argument_href          => $argument_href,
-            required_argument_href => \%required_argument,
-            module_function_cref   => $module_function_cref,
-            function_base_command  => $function_base_command,
+            argument_href              => $argument_href,
+            required_argument_href     => \%required_argument,
+            module_function_cref       => $module_function_cref,
+            function_base_commands_ref => \@function_base_commands,
         }
     );
 }

--- a/t/gnu_sed.t
+++ b/t/gnu_sed.t
@@ -101,12 +101,12 @@ diag(   q{Test gnu_sed from Gnu_sed.pm v}
       . $EXECUTABLE_NAME );
 
 ## Base arguments
-my $function_base_command = q{sed};
+my @function_base_commands = qw{ sed };
 
 my %base_argument = (
     FILEHANDLE => {
         input           => undef,
-        expected_output => $function_base_command,
+        expected_output => \@function_base_commands,
     },
     stderrfile_path => {
         input           => q{stderrfile.test},
@@ -155,10 +155,10 @@ my @arguments = ( \%base_argument, \%specific_argument );
 foreach my $argument_href (@arguments) {
     my @commands = test_function(
         {
-            argument_href          => $argument_href,
-            required_argument_href => \%required_argument,
-            module_function_cref   => $module_function_cref,
-            function_base_command  => $function_base_command,
+            argument_href              => $argument_href,
+            required_argument_href     => \%required_argument,
+            module_function_cref       => $module_function_cref,
+            function_base_commands_ref => \@function_base_commands,
         }
     );
 }

--- a/t/gnu_set.t
+++ b/t/gnu_set.t
@@ -143,13 +143,13 @@ my @args = (
 ## Coderef - enables generalized use of generate call
 my $module_function_cref = \&gnu_set;
 
-my $function_base_command = q{set};
+my @function_base_commands = qw{ set };
 
 test_write_to_file(
     {
         args_ref             => \@args,
         module_function_cref => $module_function_cref,
-        base_command         => $function_base_command,
+        base_commands_ref    => \@function_base_commands,
         separator            => $NEWLINE,
     }
 );

--- a/t/gnu_sleep.t
+++ b/t/gnu_sleep.t
@@ -102,7 +102,7 @@ diag(   q{Test gnu_sleep from Coreutils.pm v}
       . $EXECUTABLE_NAME );
 
 ## Base arguments
-my $function_base_command = q{sleep};
+my @function_base_commands = qw{ sleep };
 
 my %base_argument = (
     stdoutfile_path => {
@@ -119,7 +119,7 @@ my %base_argument = (
     },
     FILEHANDLE => {
         input           => undef,
-        expected_output => $function_base_command,
+        expected_output => \@function_base_commands,
     },
 );
 
@@ -142,9 +142,9 @@ my @arguments = ( \%base_argument, \%specific_argument );
 foreach my $argument_href (@arguments) {
     my @commands = test_function(
         {
-            argument_href         => $argument_href,
-            module_function_cref  => $module_function_cref,
-            function_base_command => $function_base_command,
+            argument_href              => $argument_href,
+            module_function_cref       => $module_function_cref,
+            function_base_commands_ref => \@function_base_commands,
         }
     );
 }

--- a/t/gnu_sort.t
+++ b/t/gnu_sort.t
@@ -91,7 +91,7 @@ diag(   q{Test gnu_sort from Coreutils.pm v}
       . $EXECUTABLE_NAME );
 
 ## Base arguments
-my $function_base_command = q{sort};
+my @function_base_commands = qw{ sort };
 
 my %base_argument = (
     stdoutfile_path => {
@@ -108,7 +108,7 @@ my %base_argument = (
     },
     FILEHANDLE => {
         input           => undef,
-        expected_output => $function_base_command,
+        expected_output => \@function_base_commands,
     },
 );
 
@@ -145,10 +145,10 @@ my @arguments = ( \%base_argument, \%specific_argument );
 foreach my $argument_href (@arguments) {
     my @commands = test_function(
         {
-            argument_href          => $argument_href,
-            required_argument_href => \%required_argument,
-            module_function_cref   => $module_function_cref,
-            function_base_command  => $function_base_command,
+            argument_href              => $argument_href,
+            required_argument_href     => \%required_argument,
+            module_function_cref       => $module_function_cref,
+            function_base_commands_ref => \@function_base_commands,
         }
     );
 }

--- a/t/gnu_split.t
+++ b/t/gnu_split.t
@@ -79,7 +79,7 @@ diag(
     "Test gnu_split $MIP::Gnu::Coreutils::VERSION, Perl $^V, $EXECUTABLE_NAME");
 
 ## Base arguments
-my $function_base_command = 'split';
+my @function_base_commands = 'split';
 
 my %base_argument = (
     stderrfile_path => {
@@ -92,7 +92,7 @@ my %base_argument = (
     },
     FILEHANDLE => {
         input           => undef,
-        expected_output => $function_base_command,
+        expected_output => \@function_base_commands,
     },
 );
 
@@ -145,10 +145,10 @@ my @arguments = ( \%base_argument, \%specific_argument );
 foreach my $argument_href (@arguments) {
     my @commands = test_function(
         {
-            argument_href          => $argument_href,
-            required_argument_href => \%required_argument,
-            module_function_cref   => $module_function_cref,
-            function_base_command  => $function_base_command,
+            argument_href              => $argument_href,
+            required_argument_href     => \%required_argument,
+            module_function_cref       => $module_function_cref,
+            function_base_commands_ref => \@function_base_commands,
         }
     );
 }

--- a/t/gnu_tail.t
+++ b/t/gnu_tail.t
@@ -99,12 +99,12 @@ diag(   q{Test gnu_tail from Coreutils.pm v}
       . $EXECUTABLE_NAME );
 
 ## Base arguments
-my $function_base_command = q{tail};
+my @function_base_commands = qw{ tail };
 
 my %base_argument = (
     FILEHANDLE => {
         input           => undef,
-        expected_output => $function_base_command,
+        expected_output => \@function_base_commands,
     },
     stderrfile_path => {
         input           => q{stderrfile.test},
@@ -137,10 +137,10 @@ ARGUMENT_HASH_REF:
 foreach my $argument_href (@arguments) {
     my @commands = test_function(
         {
-            argument_href         => $argument_href,
-            module_function_cref  => $module_function_cref,
-            function_base_command => $function_base_command,
-            do_test_base_command  => 1,
+            argument_href              => $argument_href,
+            module_function_cref       => $module_function_cref,
+            function_base_commands_ref => \@function_base_commands,
+            do_test_base_command       => 1,
         }
     );
 }

--- a/t/gnu_trap.t
+++ b/t/gnu_trap.t
@@ -86,7 +86,7 @@ use MIP::Test::Commands qw(test_function);
 diag("Test gnu_trap $MIP::Gnu::Bash::VERSION, Perl $^V, $EXECUTABLE_NAME");
 
 ## Base arguments
-my $function_base_command = 'trap';
+my @function_base_commands = 'trap';
 
 my %base_argument = (
     stderrfile_path => {
@@ -99,7 +99,7 @@ my %base_argument = (
     },
     FILEHANDLE => {
         input           => undef,
-        expected_output => $function_base_command,
+        expected_output => \@function_base_commands,
     },
 );
 
@@ -125,9 +125,9 @@ foreach my $argument_href (@arguments) {
 
     my @commands = test_function(
         {
-            argument_href         => $argument_href,
-            module_function_cref  => $module_function_cref,
-            function_base_command => $function_base_command,
+            argument_href              => $argument_href,
+            module_function_cref       => $module_function_cref,
+            function_base_commands_ref => \@function_base_commands,
         }
     );
 }

--- a/t/gnu_unset.t
+++ b/t/gnu_unset.t
@@ -99,12 +99,12 @@ diag(   q{Test gnu_unset from Bash.pm v}
       . $EXECUTABLE_NAME );
 
 ## Base arguments
-my $function_base_command = q{unset};
+my @function_base_commands = qw{ unset };
 
 my %base_argument = (
     FILEHANDLE => {
         input           => undef,
-        expected_output => $function_base_command,
+        expected_output => \@function_base_commands,
     },
     stderrfile_path => {
         input           => q{stderrfile.test},
@@ -145,11 +145,11 @@ ARGUMENT_HASH_REF:
 foreach my $argument_href (@arguments) {
     my @commands = test_function(
         {
-            argument_href          => $argument_href,
-            required_argument_href => \%required_argument,
-            module_function_cref   => $module_function_cref,
-            function_base_command  => $function_base_command,
-            do_test_base_command   => 1,
+            argument_href              => $argument_href,
+            required_argument_href     => \%required_argument,
+            module_function_cref       => $module_function_cref,
+            function_base_commands_ref => \@function_base_commands,
+            do_test_base_command       => 1,
         }
     );
 }

--- a/t/gnu_wait.t
+++ b/t/gnu_wait.t
@@ -86,7 +86,7 @@ use MIP::Test::Commands qw(test_function);
 diag("Test gnu_wait $MIP::Gnu::Bash::VERSION, Perl $^V, $EXECUTABLE_NAME");
 
 ## Base arguments
-my $function_base_command = 'wait';
+my @function_base_commands = 'wait';
 
 my %base_argument = (
     stderrfile_path => {
@@ -121,9 +121,9 @@ foreach my $argument_href (@arguments) {
 
     my @commands = test_function(
         {
-            argument_href         => $argument_href,
-            module_function_cref  => $module_function_cref,
-            function_base_command => $function_base_command,
+            argument_href              => $argument_href,
+            module_function_cref       => $module_function_cref,
+            function_base_commands_ref => \@function_base_commands,
         }
     );
 }

--- a/t/gzip.t
+++ b/t/gzip.t
@@ -99,7 +99,7 @@ diag(   q{Test gzip from Gzip.pm v}
       . $EXECUTABLE_NAME );
 
 ## Base arguments
-my $function_base_command = q{gzip};
+my @function_base_commands = qw{ gzip };
 
 my %base_argument = (
     stderrfile_path => {
@@ -112,7 +112,7 @@ my %base_argument = (
     },
     FILEHANDLE => {
         input           => undef,
-        expected_output => $function_base_command,
+        expected_output => \@function_base_commands,
     },
 );
 
@@ -125,7 +125,7 @@ my %required_argument = (
     },
     FILEHANDLE => {
         input           => undef,
-        expected_output => $function_base_command,
+        expected_output => \@function_base_commands,
     },
 );
 
@@ -166,11 +166,11 @@ HASHES_OF_ARGUMENTS:
 foreach my $argument_href (@arguments) {
     my @commands = test_function(
         {
-            argument_href          => $argument_href,
-            required_argument_href => \%required_argument,
-            module_function_cref   => $module_function_cref,
-            function_base_command  => $function_base_command,
-            do_test_base_command   => 1,
+            argument_href              => $argument_href,
+            required_argument_href     => \%required_argument,
+            module_function_cref       => $module_function_cref,
+            function_base_commands_ref => \@function_base_commands,
+            do_test_base_command       => 1,
         }
     );
 }

--- a/t/htslib_bgzip.t
+++ b/t/htslib_bgzip.t
@@ -99,12 +99,12 @@ diag(   q{Test htslib_bgzip from Htslib.pm v}
       . $EXECUTABLE_NAME );
 
 ## Base arguments
-my $function_base_command = q{bgzip};
+my @function_base_commands = qw{ bgzip };
 
 my %base_argument = (
     FILEHANDLE => {
         input           => undef,
-        expected_output => $function_base_command,
+        expected_output => \@function_base_commands,
     },
     stderrfile_path => {
         input           => q{stderrfile.test},
@@ -156,11 +156,11 @@ ARGUMENT_HASH_REF:
 foreach my $argument_href (@arguments) {
     my @commands = test_function(
         {
-            argument_href          => $argument_href,
-            required_argument_href => \%required_argument,
-            module_function_cref   => $module_function_cref,
-            function_base_command  => $function_base_command,
-            do_test_base_command   => 1,
+            argument_href              => $argument_href,
+            required_argument_href     => \%required_argument,
+            module_function_cref       => $module_function_cref,
+            function_base_commands_ref => \@function_base_commands,
+            do_test_base_command       => 1,
         }
     );
 }

--- a/t/htslib_tabix.t
+++ b/t/htslib_tabix.t
@@ -99,12 +99,12 @@ diag(   q{Test htslib_tabix from Htslib.pm v}
       . $EXECUTABLE_NAME );
 
 ## Base arguments
-my $function_base_command = q{tabix};
+my @function_base_commands = qw{ tabix };
 
 my %base_argument = (
     FILEHANDLE => {
         input           => undef,
-        expected_output => $function_base_command,
+        expected_output => \@function_base_commands,
     },
     stderrfile_path => {
         input           => q{stderrfile.test},
@@ -163,11 +163,11 @@ ARGUMENT_HASH_REF:
 foreach my $argument_href (@arguments) {
     my @commands = test_function(
         {
-            argument_href          => $argument_href,
-            required_argument_href => \%required_argument,
-            module_function_cref   => $module_function_cref,
-            function_base_command  => $function_base_command,
-            do_test_base_command   => 1,
+            argument_href              => $argument_href,
+            required_argument_href     => \%required_argument,
+            module_function_cref       => $module_function_cref,
+            function_base_commands_ref => \@function_base_commands,
+            do_test_base_command       => 1,
         }
     );
 }

--- a/t/java_core.t
+++ b/t/java_core.t
@@ -102,12 +102,12 @@ diag(   q{Test java_core from Java.pm v}
       . $EXECUTABLE_NAME );
 
 ## Base arguments
-my $function_base_command = q{java};
+my @function_base_commands = qw{ java };
 
 my %base_argument = (
     FILEHANDLE => {
         input           => undef,
-        expected_output => $function_base_command,
+        expected_output => \@function_base_commands,
     },
 );
 
@@ -131,7 +131,7 @@ my %specific_argument = (
     },
     FILEHANDLE => {
         input           => undef,
-        expected_output => $function_base_command,
+        expected_output => \@function_base_commands,
     },
 );
 
@@ -145,10 +145,10 @@ HASHES_OF_ARGUMENTS:
 foreach my $argument_href (@arguments) {
     my @commands = test_function(
         {
-            argument_href         => $argument_href,
-            module_function_cref  => $module_function_cref,
-            function_base_command => $function_base_command,
-            do_test_base_command  => 1,
+            argument_href              => $argument_href,
+            module_function_cref       => $module_function_cref,
+            function_base_commands_ref => \@function_base_commands,
+            do_test_base_command       => 1,
         }
     );
 }

--- a/t/manta_config.t
+++ b/t/manta_config.t
@@ -96,7 +96,7 @@ diag(   q{Test manta_config from Manta v}
       . $EXECUTABLE_NAME );
 
 ## Base arguments
-my $function_base_command = q{configManta.py};
+my @function_base_commands = qw{ configManta.py };
 
 my %base_argument = (
     stderrfile_path => {
@@ -109,7 +109,7 @@ my %base_argument = (
     },
     FILEHANDLE => {
         input           => undef,
-        expected_output => $function_base_command,
+        expected_output => \@function_base_commands,
     },
 );
 
@@ -149,11 +149,11 @@ ARGUMENT_HASH_REF:
 foreach my $argument_href (@arguments) {
     my @commands = test_function(
         {
-            argument_href          => $argument_href,
-            required_argument_href => \%required_argument,
-            module_function_cref   => $module_function_cref,
-            function_base_command  => $function_base_command,
-            do_test_base_command   => 1,
+            argument_href              => $argument_href,
+            required_argument_href     => \%required_argument,
+            module_function_cref       => $module_function_cref,
+            function_base_commands_ref => \@function_base_commands,
+            do_test_base_command       => 1,
         }
     );
 }

--- a/t/manta_workflow.t
+++ b/t/manta_workflow.t
@@ -140,12 +140,16 @@ ARGUMENT_HASH_REF:
 foreach my $argument_href (@arguments) {
     my @commands = test_function(
         {
-            argument_href          => $argument_href,
-            required_argument_href => \%required_argument,
-            module_function_cref   => $module_function_cref,
-            function_base_command  => catfile( $required_argument{outdirectory_path}{expected_output},
-              $function_base_command ),
-            do_test_base_command   => 1,
+            argument_href              => $argument_href,
+            required_argument_href     => \%required_argument,
+            module_function_cref       => $module_function_cref,
+            function_base_commands_ref => [
+                catfile(
+                    $required_argument{outdirectory_path}{expected_output},
+                    $function_base_command
+                )
+            ],
+            do_test_base_command => 1,
         }
     );
 }

--- a/t/mip_vcfparser.t
+++ b/t/mip_vcfparser.t
@@ -100,12 +100,12 @@ diag(   q{Test mip_vcfparser from Mip_vcfparser.pm v}
       . $EXECUTABLE_NAME );
 
 ## Base arguments
-my $function_base_command = q{vcfparser};
+my @function_base_commands = qw{ vcfparser };
 
 my %base_argument = (
     FILEHANDLE => {
         input           => undef,
-        expected_output => $function_base_command,
+        expected_output => \@function_base_commands,
     },
     stderrfile_path => {
         input           => q{stderrfile.test},
@@ -125,8 +125,12 @@ my %base_argument = (
 ## to enable testing of each individual argument
 my %required_argument = (
     infile_path => {
-        input           => catfile( qw{ file_path_prefix_contig_analysis-type_suffix.annotation_infile_number} ),
-        expected_output => catfile( qw{ file_path_prefix_contig_analysis-type_suffix.annotation_infile_number} ),
+        input => catfile(
+            qw{ file_path_prefix_contig_analysis-type_suffix.annotation_infile_number}
+        ),
+        expected_output => catfile(
+            qw{ file_path_prefix_contig_analysis-type_suffix.annotation_infile_number}
+        ),
     },
 );
 
@@ -144,28 +148,35 @@ my %specific_argument = (
         expected_output => q{--per_gene},
     },
     range_feature_annotation_columns_ref => {
-        inputs_ref      => [qw{ feature_anno1 feature_anno2 }],
-        expected_output => q{--range_feature_annotation_columns feature_anno1,feature_anno2},
+        inputs_ref => [qw{ feature_anno1 feature_anno2 }],
+        expected_output =>
+          q{--range_feature_annotation_columns feature_anno1,feature_anno2},
     },
     range_feature_file_path => {
-        input           => q{sv_vcfparser_range_feature_file},
-        expected_output => q{--range_feature_file sv_vcfparser_range_feature_file},
+        input => q{sv_vcfparser_range_feature_file},
+        expected_output =>
+          q{--range_feature_file sv_vcfparser_range_feature_file},
     },
     select_feature_annotation_columns_ref => {
-        inputs_ref      => [qw{ feature_anno1 feature_anno2 }],
-        expected_output => q{--select_feature_annotation_columns feature_anno1,feature_anno2},
+        inputs_ref => [qw{ feature_anno1 feature_anno2 }],
+        expected_output =>
+          q{--select_feature_annotation_columns feature_anno1,feature_anno2},
     },
     select_feature_file_path => {
-        input           => catfile( qw{ active_parameter_href vcfparser_select_file } ),
-        expected_output => q{--select_feature_file} . $SPACE . catfile( qw{ active_parameter_href vcfparser_select_file } ),
+        input => catfile(qw{ active_parameter_href vcfparser_select_file }),
+        expected_output => q{--select_feature_file}
+          . $SPACE
+          . catfile(qw{ active_parameter_href vcfparser_select_file }),
     },
     select_feature_matching_column => {
         input           => 2,
         expected_output => q{--select_feature_matching_column 2},
     },
     select_outfile => {
-        input           => catdir( qw{ outfile_path prefix_contig.selectedsuffix } ),
-        expected_output => q{--select_outfile} . $SPACE . catdir( qw{ outfile_path prefix_contig.selectedsuffix } ),
+        input => catdir(qw{ outfile_path prefix_contig.selectedsuffix }),
+        expected_output => q{--select_outfile}
+          . $SPACE
+          . catdir(qw{ outfile_path prefix_contig.selectedsuffix }),
     },
 );
 
@@ -179,11 +190,11 @@ ARGUMENT_HASH_REF:
 foreach my $argument_href (@arguments) {
     my @commands = test_function(
         {
-            argument_href          => $argument_href,
-            required_argument_href => \%required_argument,
-            module_function_cref   => $module_function_cref,
-            function_base_command  => $function_base_command,
-            do_test_base_command   => 1,
+            argument_href              => $argument_href,
+            required_argument_href     => \%required_argument,
+            module_function_cref       => $module_function_cref,
+            function_base_commands_ref => \@function_base_commands,
+            do_test_base_command       => 1,
         }
     );
 }

--- a/t/multiqc.t
+++ b/t/multiqc.t
@@ -100,7 +100,7 @@ diag(   q{Test multiqc from Multiqc v}
       . $EXECUTABLE_NAME );
 
 ## Base arguments
-my $function_base_command = q{multiqc};
+my @function_base_commands = qw{ multiqc };
 
 my %base_argument = (
     stdoutfile_path => {
@@ -117,7 +117,7 @@ my %base_argument = (
     },
     FILEHANDLE => {
         input           => undef,
-        expected_output => $function_base_command,
+        expected_output => \@function_base_commands,
     },
 );
 
@@ -147,11 +147,11 @@ ARGUMENT_HASH_REF:
 foreach my $argument_href (@arguments) {
     my @commands = test_function(
         {
-            argument_href          => $argument_href,
-            required_argument_href => \%required_argument,
-            module_function_cref   => $module_function_cref,
-            function_base_command  => $function_base_command,
-            do_test_base_command   => 1,
+            argument_href              => $argument_href,
+            required_argument_href     => \%required_argument,
+            module_function_cref       => $module_function_cref,
+            function_base_commands_ref => \@function_base_commands,
+            do_test_base_command       => 1,
         }
     );
 }

--- a/t/parse_prioritize_variant_callers.t
+++ b/t/parse_prioritize_variant_callers.t
@@ -117,9 +117,9 @@ my $log = initiate_logger(
 ## Given no structural active callers, when priority string is ok
 my %active_parameter = (
     gatk_combinevariants_prioritize_caller => q{gatk,bcftools,freebayes},
-    bcftools_mpileup                      => 1,
-    freebayes                             => 1,
-    gatk_variantrecalibration             => 1,
+    bcftools_mpileup                       => 1,
+    freebayes                              => 1,
+    gatk_variantrecalibration              => 1,
 );
 
 my %parameter = (

--- a/t/peddy.t
+++ b/t/peddy.t
@@ -23,16 +23,15 @@ use Readonly;
 use lib catdir( dirname($Bin), q{lib} );
 use MIP::Script::Utils qw{ help };
 
-
 our $USAGE = build_usage( {} );
 
 my $VERBOSE = 1;
 our $VERSION = '1.0.0';
 
 ## Constants
-Readonly my $SPACE   => q{ };
-Readonly my $NEWLINE => qq{\n};
-Readonly my $COMMA   => q{,};
+Readonly my $SPACE        => q{ };
+Readonly my $NEWLINE      => qq{\n};
+Readonly my $COMMA        => q{,};
 Readonly my $N_PROCESSORS => 4;
 
 ### User Options
@@ -101,7 +100,7 @@ diag(   q{Test peddy from Peddy.pm v}
       . $EXECUTABLE_NAME );
 
 ## Base arguments
-my $function_base_command = q{python -m peddy};
+my @function_base_commands = qw{ python -m peddy };
 
 my %base_argument = (
     stderrfile_path => {
@@ -110,7 +109,7 @@ my %base_argument = (
     },
     FILEHANDLE => {
         input           => undef,
-        expected_output => $function_base_command,
+        expected_output => \@function_base_commands,
     },
     stderrfile_path_append => {
         input           => q{stderrfile.test},
@@ -146,7 +145,7 @@ my %required_argument = (
 my %specific_argument = (
     processor_number => {
         input           => $N_PROCESSORS,
-        expected_output => q{--procs} .$SPACE . $N_PROCESSORS,
+        expected_output => q{--procs} . $SPACE . $N_PROCESSORS,
     },
     plot => {
         input           => 1,
@@ -164,11 +163,11 @@ ARGUMENT_HASH_REF:
 foreach my $argument_href (@arguments) {
     my @commands = test_function(
         {
-            argument_href          => $argument_href,
-            required_argument_href => \%required_argument,
-            module_function_cref   => $module_function_cref,
-            function_base_command  => $function_base_command,
-            do_test_base_command   => 1,
+            argument_href              => $argument_href,
+            required_argument_href     => \%required_argument,
+            module_function_cref       => $module_function_cref,
+            function_base_commands_ref => \@function_base_commands,
+            do_test_base_command       => 1,
         }
     );
 }

--- a/t/picardtools_addorreplacereadgroups.t
+++ b/t/picardtools_addorreplacereadgroups.t
@@ -101,12 +101,12 @@ diag(   q{Test picardtools_addorreplacereadgroups from Picardtools.pm v}
       . $EXECUTABLE_NAME );
 
 ## Base arguments
-my $function_base_command = q{AddOrReplaceReadGroups};
+my @function_base_commands = qw{ AddOrReplaceReadGroups };
 
 my %base_argument = (
     FILEHANDLE => {
         input           => undef,
-        expected_output => $function_base_command,
+        expected_output => \@function_base_commands,
     },
 );
 
@@ -186,11 +186,11 @@ ARGUMENT_HASH_REF:
 foreach my $argument_href (@arguments) {
     my @commands = test_function(
         {
-            argument_href          => $argument_href,
-            required_argument_href => \%required_argument,
-            module_function_cref   => $module_function_cref,
-            function_base_command  => $function_base_command,
-            do_test_base_command   => 1,
+            argument_href              => $argument_href,
+            required_argument_href     => \%required_argument,
+            module_function_cref       => $module_function_cref,
+            function_base_commands_ref => \@function_base_commands,
+            do_test_base_command       => 1,
         }
     );
 }

--- a/t/picardtools_base.t
+++ b/t/picardtools_base.t
@@ -100,12 +100,12 @@ diag(   q{Test picardtools_base from Picardtools.pm v}
       . $EXECUTABLE_NAME );
 
 ## Base arguments
-my $function_base_command = q{R=};
+my @function_base_commands = qw{ R= };
 
 my %base_argument = (
     FILEHANDLE => {
         input           => undef,
-        expected_output => $function_base_command,
+        expected_output => \@function_base_commands,
     },
 );
 
@@ -141,11 +141,11 @@ ARGUMENT_HASH_REF:
 foreach my $argument_href (@arguments) {
     my @commands = test_function(
         {
-            argument_href          => $argument_href,
-            required_argument_href => \%required_argument,
-            module_function_cref   => $module_function_cref,
-            function_base_command  => $function_base_command,
-            do_test_base_command   => 0,
+            argument_href              => $argument_href,
+            required_argument_href     => \%required_argument,
+            module_function_cref       => $module_function_cref,
+            function_base_commands_ref => \@function_base_commands,
+            do_test_base_command       => 0,
         }
     );
 }

--- a/t/picardtools_collecthsmetrics.t
+++ b/t/picardtools_collecthsmetrics.t
@@ -100,12 +100,12 @@ diag(   q{Test picardtools_collecthsmetrics from Picardtools.pm v}
       . $EXECUTABLE_NAME );
 
 ## Base arguments
-my $function_base_command = q{CollectHsMetrics};
+my @function_base_commands = qw{ CollectHsMetrics };
 
 my %base_argument = (
     FILEHANDLE => {
         input           => undef,
-        expected_output => $function_base_command,
+        expected_output => \@function_base_commands,
     },
 );
 
@@ -172,11 +172,11 @@ ARGUMENT_HASH_REF:
 foreach my $argument_href (@arguments) {
     my @commands = test_function(
         {
-            argument_href          => $argument_href,
-            required_argument_href => \%required_argument,
-            module_function_cref   => $module_function_cref,
-            function_base_command  => $function_base_command,
-            do_test_base_command   => 1,
+            argument_href              => $argument_href,
+            required_argument_href     => \%required_argument,
+            module_function_cref       => $module_function_cref,
+            function_base_commands_ref => \@function_base_commands,
+            do_test_base_command       => 1,
         }
     );
 }

--- a/t/picardtools_collectmultiplemetrics.t
+++ b/t/picardtools_collectmultiplemetrics.t
@@ -101,12 +101,12 @@ diag(   q{Test picardtools_collectmultiplemetrics from Picardtools.pm v}
       . $EXECUTABLE_NAME );
 
 ## Base arguments
-my $function_base_command = q{CollectMultipleMetrics};
+my @function_base_commands = qw{ CollectMultipleMetrics };
 
 my %base_argument = (
     FILEHANDLE => {
         input           => undef,
-        expected_output => $function_base_command,
+        expected_output => \@function_base_commands,
     },
 );
 
@@ -153,11 +153,11 @@ ARGUMENT_HASH_REF:
 foreach my $argument_href (@arguments) {
     my @commands = test_function(
         {
-            argument_href          => $argument_href,
-            required_argument_href => \%required_argument,
-            module_function_cref   => $module_function_cref,
-            function_base_command  => $function_base_command,
-            do_test_base_command   => 1,
+            argument_href              => $argument_href,
+            required_argument_href     => \%required_argument,
+            module_function_cref       => $module_function_cref,
+            function_base_commands_ref => \@function_base_commands,
+            do_test_base_command       => 1,
         }
     );
 }

--- a/t/picardtools_createsequencedictionary.t
+++ b/t/picardtools_createsequencedictionary.t
@@ -101,7 +101,7 @@ diag(
       . $EXECUTABLE_NAME );
 
 ## Base arguments
-my $function_base_command = q{CreateSequenceDictionary};
+my @function_base_commands = qw{ CreateSequenceDictionary };
 
 my %base_argument = (
     stdoutfile_path => {
@@ -118,7 +118,7 @@ my %base_argument = (
     },
     FILEHANDLE => {
         input           => undef,
-        expected_output => $function_base_command,
+        expected_output => \@function_base_commands,
     },
 );
 
@@ -158,11 +158,11 @@ ARGUMENT_HASH_REF:
 foreach my $argument_href (@arguments) {
     my @commands = test_function(
         {
-            argument_href          => $argument_href,
-            required_argument_href => \%required_argument,
-            module_function_cref   => $module_function_cref,
-            function_base_command  => $function_base_command,
-            do_test_base_command   => 1,
+            argument_href              => $argument_href,
+            required_argument_href     => \%required_argument,
+            module_function_cref       => $module_function_cref,
+            function_base_commands_ref => \@function_base_commands,
+            do_test_base_command       => 1,
         }
     );
 }

--- a/t/picardtools_gatherbamfiles.t
+++ b/t/picardtools_gatherbamfiles.t
@@ -100,12 +100,12 @@ diag(   q{Test picardtools_gatherbamfiles from Picardtools.pm v}
       . $EXECUTABLE_NAME );
 
 ## Base arguments
-my $function_base_command = q{GatherBamFiles};
+my @function_base_commands = qw{ GatherBamFiles };
 
 my %base_argument = (
     FILEHANDLE => {
         input           => undef,
-        expected_output => $function_base_command,
+        expected_output => \@function_base_commands,
     },
 );
 
@@ -152,11 +152,11 @@ ARGUMENT_HASH_REF:
 foreach my $argument_href (@arguments) {
     my @commands = test_function(
         {
-            argument_href          => $argument_href,
-            required_argument_href => \%required_argument,
-            module_function_cref   => $module_function_cref,
-            function_base_command  => $function_base_command,
-            do_test_base_command   => 1,
+            argument_href              => $argument_href,
+            required_argument_href     => \%required_argument,
+            module_function_cref       => $module_function_cref,
+            function_base_commands_ref => \@function_base_commands,
+            do_test_base_command       => 1,
         }
     );
 }

--- a/t/picardtools_genotypeconcordance.t
+++ b/t/picardtools_genotypeconcordance.t
@@ -106,7 +106,7 @@ Readonly my $MIN_GQ    => 20;
 Readonly my $MIN_DEPTH => 10;
 
 ## Base arguments
-my $function_base_command = q{GenotypeConcordance};
+my @function_base_commands = qw{ GenotypeConcordance };
 
 my %base_argument = (
     stderrfile_path => {
@@ -115,7 +115,7 @@ my %base_argument = (
     },
     FILEHANDLE => {
         input           => undef,
-        expected_output => $function_base_command,
+        expected_output => \@function_base_commands,
     },
 );
 
@@ -196,11 +196,11 @@ ARGUMENT_HASH_REF:
 foreach my $argument_href (@arguments) {
     my @commands = test_function(
         {
-            argument_href          => $argument_href,
-            required_argument_href => \%required_argument,
-            module_function_cref   => $module_function_cref,
-            function_base_command  => $function_base_command,
-            do_test_base_command   => 1,
+            argument_href              => $argument_href,
+            required_argument_href     => \%required_argument,
+            module_function_cref       => $module_function_cref,
+            function_base_commands_ref => \@function_base_commands,
+            do_test_base_command       => 1,
         }
     );
 }

--- a/t/picardtools_intervallisttools.t
+++ b/t/picardtools_intervallisttools.t
@@ -102,7 +102,7 @@ diag(   q{Test picardtools_intervallisttools from Interval::Picardtools.pm v}
 ## Constants
 Readonly my $PADDING => 100;
 ## Base arguments
-my $function_base_command = q{IntervalListTools};
+my @function_base_commands = qw{ IntervalListTools };
 
 my %base_argument = (
     stderrfile_path => {
@@ -111,7 +111,7 @@ my %base_argument = (
     },
     FILEHANDLE => {
         input           => undef,
-        expected_output => $function_base_command,
+        expected_output => \@function_base_commands,
     },
 );
 
@@ -168,11 +168,11 @@ ARGUMENT_HASH_REF:
 foreach my $argument_href (@arguments) {
     my @commands = test_function(
         {
-            argument_href          => $argument_href,
-            required_argument_href => \%required_argument,
-            module_function_cref   => $module_function_cref,
-            function_base_command  => $function_base_command,
-            do_test_base_command   => 1,
+            argument_href              => $argument_href,
+            required_argument_href     => \%required_argument,
+            module_function_cref       => $module_function_cref,
+            function_base_commands_ref => \@function_base_commands,
+            do_test_base_command       => 1,
         }
     );
 }

--- a/t/picardtools_markduplicates.t
+++ b/t/picardtools_markduplicates.t
@@ -100,12 +100,12 @@ diag(   q{Test picardtools_markduplicates from Picardtools.pm v}
       . $EXECUTABLE_NAME );
 
 ## Base arguments
-my $function_base_command = q{MarkDuplicates};
+my @function_base_commands = qw{ MarkDuplicates };
 
 my %base_argument = (
     FILEHANDLE => {
         input           => undef,
-        expected_output => $function_base_command,
+        expected_output => \@function_base_commands,
     },
 );
 
@@ -160,11 +160,11 @@ ARGUMENT_HASH_REF:
 foreach my $argument_href (@arguments) {
     my @commands = test_function(
         {
-            argument_href          => $argument_href,
-            required_argument_href => \%required_argument,
-            module_function_cref   => $module_function_cref,
-            function_base_command  => $function_base_command,
-            do_test_base_command   => 1,
+            argument_href              => $argument_href,
+            required_argument_href     => \%required_argument,
+            module_function_cref       => $module_function_cref,
+            function_base_commands_ref => \@function_base_commands,
+            do_test_base_command       => 1,
         }
     );
 }

--- a/t/picardtools_mergesamfiles.t
+++ b/t/picardtools_mergesamfiles.t
@@ -100,12 +100,12 @@ diag(   q{Test picardtools_mergesamfiles from Picardtools.pm v}
       . $EXECUTABLE_NAME );
 
 ## Base arguments
-my $function_base_command = q{MergeSamFiles};
+my @function_base_commands = qw{ MergeSamFiles };
 
 my %base_argument = (
     FILEHANDLE => {
         input           => undef,
-        expected_output => $function_base_command,
+        expected_output => \@function_base_commands,
     },
 );
 
@@ -161,11 +161,11 @@ ARGUMENT_HASH_REF:
 foreach my $argument_href (@arguments) {
     my @commands = test_function(
         {
-            argument_href          => $argument_href,
-            required_argument_href => \%required_argument,
-            module_function_cref   => $module_function_cref,
-            function_base_command  => $function_base_command,
-            do_test_base_command   => 1,
+            argument_href              => $argument_href,
+            required_argument_href     => \%required_argument,
+            module_function_cref       => $module_function_cref,
+            function_base_commands_ref => \@function_base_commands,
+            do_test_base_command       => 1,
         }
     );
 }

--- a/t/picardtools_sortvcf.t
+++ b/t/picardtools_sortvcf.t
@@ -104,7 +104,7 @@ Readonly my $MIN_GQ    => 20;
 Readonly my $MIN_DEPTH => 10;
 
 ## Base arguments
-my $function_base_command = q{SortVcf};
+my @function_base_commands = qw{ SortVcf };
 
 my %base_argument = (
     stderrfile_path => {
@@ -113,7 +113,7 @@ my %base_argument = (
     },
     FILEHANDLE => {
         input           => undef,
-        expected_output => $function_base_command,
+        expected_output => \@function_base_commands,
     },
 );
 
@@ -176,11 +176,11 @@ ARGUMENT_HASH_REF:
 foreach my $argument_href (@arguments) {
     my @commands = test_function(
         {
-            argument_href          => $argument_href,
-            required_argument_href => \%required_argument,
-            module_function_cref   => $module_function_cref,
-            function_base_command  => $function_base_command,
-            do_test_base_command   => 1,
+            argument_href              => $argument_href,
+            required_argument_href     => \%required_argument,
+            module_function_cref       => $module_function_cref,
+            function_base_commands_ref => \@function_base_commands,
+            do_test_base_command       => 1,
         }
     );
 }

--- a/t/pigz.t
+++ b/t/pigz.t
@@ -96,12 +96,12 @@ diag(   q{Test pigz from Pigz v}
       . $EXECUTABLE_NAME );
 
 ## Base arguments
-my $function_base_command = q{pigz};
+my @function_base_commands = qw{ pigz };
 
 my %base_argument = (
     FILEHANDLE => {
         input           => undef,
-        expected_output => $function_base_command,
+        expected_output => \@function_base_commands,
     },
 );
 
@@ -114,7 +114,7 @@ my %required_argument = (
     },
     FILEHANDLE => {
         input           => undef,
-        expected_output => $function_base_command,
+        expected_output => \@function_base_commands,
     },
 );
 
@@ -164,11 +164,11 @@ HASHES_OF_ARGUMENTS:
 foreach my $argument_href (@arguments) {
     my @commands = test_function(
         {
-            argument_href          => $argument_href,
-            required_argument_href => \%required_argument,
-            module_function_cref   => $module_function_cref,
-            function_base_command  => $function_base_command,
-            do_test_base_command   => 1,
+            argument_href              => $argument_href,
+            required_argument_href     => \%required_argument,
+            module_function_cref       => $module_function_cref,
+            function_base_commands_ref => \@function_base_commands,
+            do_test_base_command       => 1,
         }
     );
 }

--- a/t/pip_install.t
+++ b/t/pip_install.t
@@ -100,7 +100,7 @@ diag(   q{Test pip_install from Pip.pm v}
       . $EXECUTABLE_NAME );
 
 ## Base arguments
-my $function_base_command = q{pip install};
+my @function_base_commands = qw{ pip install };
 
 my %base_argument = (
     stdoutfile_path => {
@@ -117,7 +117,7 @@ my %base_argument = (
     },
     FILEHANDLE => {
         input           => undef,
-        expected_output => $function_base_command,
+        expected_output => \@function_base_commands,
     },
 );
 
@@ -140,7 +140,7 @@ my %specific_argument = (
     },
     FILEHANDLE => {
         input           => undef,
-        expected_output => $function_base_command,
+        expected_output => \@function_base_commands,
     },
 );
 
@@ -154,10 +154,10 @@ ARGUMENT_HASH_REF:
 foreach my $argument_href (@arguments) {
     my @commands = test_function(
         {
-            argument_href         => $argument_href,
-            module_function_cref  => $module_function_cref,
-            function_base_command => $function_base_command,
-            do_test_base_command  => 1,
+            argument_href              => $argument_href,
+            module_function_cref       => $module_function_cref,
+            function_base_commands_ref => \@function_base_commands,
+            do_test_base_command       => 1,
         }
     );
 }

--- a/t/plink_calculate_inbreeding.t
+++ b/t/plink_calculate_inbreeding.t
@@ -89,8 +89,7 @@ BEGIN {
 use MIP::Program::Variantcalling::Plink qw{ plink_calculate_inbreeding };
 use MIP::Test::Commands qw{ test_function };
 
-diag(
-q{Test plink_calculate_inbreeding from Plink.pm v}
+diag(   q{Test plink_calculate_inbreeding from Plink.pm v}
       . $MIP::Program::Variantcalling::Plink::VERSION
       . $COMMA
       . $SPACE . q{Perl}
@@ -100,7 +99,7 @@ q{Test plink_calculate_inbreeding from Plink.pm v}
       . $EXECUTABLE_NAME );
 
 ## Base arguments
-my $function_base_command = q{plink2};
+my @function_base_commands = qw{ plink2 };
 
 my %base_argument = (
     stderrfile_path => {
@@ -109,7 +108,7 @@ my %base_argument = (
     },
     FILEHANDLE => {
         input           => undef,
-        expected_output => $function_base_command,
+        expected_output => \@function_base_commands,
     },
 );
 
@@ -161,11 +160,11 @@ ARGUMENT_HASH_REF:
 foreach my $argument_href (@arguments) {
     my @commands = test_function(
         {
-            argument_href          => $argument_href,
-            required_argument_href => \%required_argument,
-            module_function_cref   => $module_function_cref,
-            function_base_command  => $function_base_command,
-            do_test_base_command   => 1,
+            argument_href              => $argument_href,
+            required_argument_href     => \%required_argument,
+            module_function_cref       => $module_function_cref,
+            function_base_commands_ref => \@function_base_commands,
+            do_test_base_command       => 1,
         }
     );
 }

--- a/t/plink_check_sex_chroms.t
+++ b/t/plink_check_sex_chroms.t
@@ -99,7 +99,7 @@ diag( q{Test plink_check_sex_chroms from MIP::Program::Variantcalling::Plink v}
       . $EXECUTABLE_NAME );
 
 ## Base arguments
-my $function_base_command = q{plink2};
+my @function_base_commands = qw{ plink2 };
 
 my %base_argument = (
     stderrfile_path => {
@@ -108,7 +108,7 @@ my %base_argument = (
     },
     FILEHANDLE => {
         input           => undef,
-        expected_output => $function_base_command,
+        expected_output => \@function_base_commands,
     },
 );
 
@@ -158,11 +158,11 @@ ARGUMENT_HASH_REF:
 foreach my $argument_href (@arguments) {
     my @commands = test_function(
         {
-            argument_href          => $argument_href,
-            required_argument_href => \%required_argument,
-            module_function_cref   => $module_function_cref,
-            function_base_command  => $function_base_command,
-            do_test_base_command   => 1,
+            argument_href              => $argument_href,
+            required_argument_href     => \%required_argument,
+            module_function_cref       => $module_function_cref,
+            function_base_commands_ref => \@function_base_commands,
+            do_test_base_command       => 1,
         }
     );
 }

--- a/t/plink_create_mibs.t
+++ b/t/plink_create_mibs.t
@@ -99,7 +99,7 @@ diag(   q{Test plink_create_mibs from Plink v}
       . $EXECUTABLE_NAME );
 
 ## Base arguments
-my $function_base_command = q{plink2};
+my @function_base_commands = qw{ plink2 };
 
 my %base_argument = (
     stderrfile_path => {
@@ -108,7 +108,7 @@ my %base_argument = (
     },
     FILEHANDLE => {
         input           => undef,
-        expected_output => $function_base_command,
+        expected_output => \@function_base_commands,
     },
 );
 
@@ -156,11 +156,11 @@ ARGUMENT_HASH_REF:
 foreach my $argument_href (@arguments) {
     my @commands = test_function(
         {
-            argument_href          => $argument_href,
-            required_argument_href => \%required_argument,
-            module_function_cref   => $module_function_cref,
-            function_base_command  => $function_base_command,
-            do_test_base_command   => 1,
+            argument_href              => $argument_href,
+            required_argument_href     => \%required_argument,
+            module_function_cref       => $module_function_cref,
+            function_base_commands_ref => \@function_base_commands,
+            do_test_base_command       => 1,
         }
     );
 }

--- a/t/plink_fix_fam_ped_map_freq.t
+++ b/t/plink_fix_fam_ped_map_freq.t
@@ -99,12 +99,12 @@ diag(   q{Test plink_fix_fam_ped_map_freq from Plink.pm v}
       . $EXECUTABLE_NAME );
 
 ## Base arguments
-my $function_base_command = q{plink2};
+my @function_base_commands = qw{ plink2 };
 
 my %base_argument = (
     FILEHANDLE => {
         input           => undef,
-        expected_output => $function_base_command,
+        expected_output => \@function_base_commands,
     },
     stderrfile_path => {
         input           => q{stderrfile.test},
@@ -182,11 +182,11 @@ ARGUMENT_HASH_REF:
 foreach my $argument_href (@arguments) {
     my @commands = test_function(
         {
-            argument_href          => $argument_href,
-            required_argument_href => \%required_argument,
-            module_function_cref   => $module_function_cref,
-            function_base_command  => $function_base_command,
-            do_test_base_command   => 1,
+            argument_href              => $argument_href,
+            required_argument_href     => \%required_argument,
+            module_function_cref       => $module_function_cref,
+            function_base_commands_ref => \@function_base_commands,
+            do_test_base_command       => 1,
         }
     );
 }

--- a/t/plink_sex_check.t
+++ b/t/plink_sex_check.t
@@ -99,7 +99,7 @@ diag(   q{Test plink_sex_check from MIP::Program::Variantcalling::Plink v}
       . $EXECUTABLE_NAME );
 
 ## Base arguments
-my $function_base_command = q{plink2};
+my @function_base_commands = qw{ plink2 };
 
 my %base_argument = (
     stderrfile_path => {
@@ -108,7 +108,7 @@ my %base_argument = (
     },
     FILEHANDLE => {
         input           => undef,
-        expected_output => $function_base_command,
+        expected_output => \@function_base_commands,
     },
 );
 
@@ -182,11 +182,11 @@ ARGUMENT_HASH_REF:
 foreach my $argument_href (@arguments) {
     my @commands = test_function(
         {
-            argument_href          => $argument_href,
-            required_argument_href => \%required_argument,
-            module_function_cref   => $module_function_cref,
-            function_base_command  => $function_base_command,
-            do_test_base_command   => 1,
+            argument_href              => $argument_href,
+            required_argument_href     => \%required_argument,
+            module_function_cref       => $module_function_cref,
+            function_base_commands_ref => \@function_base_commands,
+            do_test_base_command       => 1,
         }
     );
 }

--- a/t/plink_variant_pruning.t
+++ b/t/plink_variant_pruning.t
@@ -102,7 +102,7 @@ diag(   q{Test plink_variant_pruning from MIP::Program::Variantcalling::Plink v}
       . $EXECUTABLE_NAME );
 
 ## Base arguments
-my $function_base_command = q{plink2};
+my @function_base_commands = qw{ plink2 };
 
 my %base_argument = (
     stderrfile_path => {
@@ -111,7 +111,7 @@ my %base_argument = (
     },
     FILEHANDLE => {
         input           => undef,
-        expected_output => $function_base_command,
+        expected_output => \@function_base_commands,
     },
 );
 
@@ -183,11 +183,11 @@ ARGUMENT_HASH_REF:
 foreach my $argument_href (@arguments) {
     my @commands = test_function(
         {
-            argument_href          => $argument_href,
-            required_argument_href => \%required_argument,
-            module_function_cref   => $module_function_cref,
-            function_base_command  => $function_base_command,
-            do_test_base_command   => 1,
+            argument_href              => $argument_href,
+            required_argument_href     => \%required_argument,
+            module_function_cref       => $module_function_cref,
+            function_base_commands_ref => \@function_base_commands,
+            do_test_base_command       => 1,
         }
     );
 }

--- a/t/processes_add_pan_job_id_to_sample_id_dependency_tree.t
+++ b/t/processes_add_pan_job_id_to_sample_id_dependency_tree.t
@@ -83,7 +83,8 @@ BEGIN {
     }
 }
 
-use MIP::Processmanagement::Processes qw{add_pan_job_id_to_sample_id_dependency_tree};
+use MIP::Processmanagement::Processes
+  qw{add_pan_job_id_to_sample_id_dependency_tree};
 
 diag(
 "Test add_pan_job_id_to_sample_id_dependency_tree $MIP::Processmanagement::Processes::VERSION, Perl $^V, $EXECUTABLE_NAME"
@@ -106,8 +107,7 @@ my %job_id = (
 
 ### Pan jobs
 
-my $pan_chain_key =
-  $family_id_chain_key . $UNDERSCORE . $sample_id_chain_key;
+my $pan_chain_key = $family_id_chain_key . $UNDERSCORE . $sample_id_chain_key;
 
 add_pan_job_id_to_sample_id_dependency_tree(
     {
@@ -134,11 +134,7 @@ add_pan_job_id_to_sample_id_dependency_tree(
 
 my $pan_push_result = join $SPACE,
   @{ $job_id{$family_id_chain_key}{$sample_id_chain_key} };
-is(
-    $pan_push_result,
-    q{job_id_3 job_id_0 job_id_1},
-    q{Pushed pan job_id}
-);
+is( $pan_push_result, q{job_id_3 job_id_0 job_id_1}, q{Pushed pan job_id} );
 
 done_testing();
 

--- a/t/processes_add_parallel_job_id_to_parallel_dependency_tree.t
+++ b/t/processes_add_parallel_job_id_to_parallel_dependency_tree.t
@@ -121,31 +121,39 @@ add_parallel_job_id_to_parallel_dependency_tree(
     {
         job_id_href           => \%job_id,
         family_id_chain_key   => $family_id_chain_key . q{no_parallel},
-     id => $family_id,
-     path => $path,
-     sbatch_script_tracker => $sbatch_script_tracker,
-     job_id_returned => q{job_id_12},
+        id                    => $family_id,
+        path                  => $path,
+        sbatch_script_tracker => $sbatch_script_tracker,
+        job_id_returned       => q{job_id_12},
     }
 );
 
 my $no_push_result = join $SPACE,
   @{ $job_id{$family_id_chain_key}{$family_id_parallel_chain_key} };
-is( $no_push_result, q{job_id_10 job_id_11}, q{No pushed parallel job_ids to parallel id} );
+is(
+    $no_push_result,
+    q{job_id_10 job_id_11},
+    q{No pushed parallel job_ids to parallel id}
+);
 
 add_parallel_job_id_to_parallel_dependency_tree(
     {
         job_id_href           => \%job_id,
         family_id_chain_key   => $family_id_chain_key,
-     id => $family_id,
-     path => $path,
-     sbatch_script_tracker => $sbatch_script_tracker,
-     job_id_returned => q{job_id_12},
+        id                    => $family_id,
+        path                  => $path,
+        sbatch_script_tracker => $sbatch_script_tracker,
+        job_id_returned       => q{job_id_12},
     }
 );
 
 my $push_result = join $SPACE,
   @{ $job_id{$family_id_chain_key}{$family_id_parallel_chain_key} };
-is( $push_result, q{job_id_10 job_id_11 job_id_12}, q{Pushed parallel job_ids to parallel id} );
+is(
+    $push_result,
+    q{job_id_10 job_id_11 job_id_12},
+    q{Pushed parallel job_ids to parallel id}
+);
 
 done_testing();
 

--- a/t/processes_add_parallel_job_ids_to_job_id_dependency_string.t
+++ b/t/processes_add_parallel_job_ids_to_job_id_dependency_string.t
@@ -117,13 +117,12 @@ my %job_id = (
 
 ### Parallel jobs
 
-my $no_job_id_string =
-  add_parallel_job_ids_to_job_id_dependency_string(
+my $no_job_id_string = add_parallel_job_ids_to_job_id_dependency_string(
     {
         job_id_href         => \%job_id,
         family_id_chain_key => $family_id_chain_key . q{no_parallel},
     }
-  );
+);
 
 is( $no_job_id_string, undef, q{No parallel job_ids} );
 

--- a/t/processes_add_sample_id_parallel_job_id_to_family_id_dependency_tree.t
+++ b/t/processes_add_sample_id_parallel_job_id_to_family_id_dependency_tree.t
@@ -91,11 +91,11 @@ diag(
 );
 
 ## Base arguments
-my $family_id             = q{family1};
-my $sample_id             = q{sample2};
-my $path                  = q{MAIN};
-my $family_id_chain_key   = $family_id . $UNDERSCORE . $path;
-my $sample_id_chain_key   = $sample_id . $UNDERSCORE . $path;
+my $family_id           = q{family1};
+my $sample_id           = q{sample2};
+my $path                = q{MAIN};
+my $family_id_chain_key = $family_id . $UNDERSCORE . $path;
+my $sample_id_chain_key = $sample_id . $UNDERSCORE . $path;
 my $infile_index        = 0;
 my $sample_id_parallel_chain_key =
   $sample_id . $UNDERSCORE . q{parallel} . $UNDERSCORE . $path . $infile_index;
@@ -120,11 +120,11 @@ my %job_id = (
 
 add_sample_id_parallel_job_id_to_family_id_dependency_tree(
     {
-        job_id_href           => \%job_id,
-     infile_lane_prefix_href => \%infile_lane_prefix,
-        family_id_chain_key   => $family_id_chain_key,
-        sample_id             => $sample_id . q{no_parallel},
-        path                  => $path,
+        job_id_href             => \%job_id,
+        infile_lane_prefix_href => \%infile_lane_prefix,
+        family_id_chain_key     => $family_id_chain_key,
+        sample_id               => $sample_id . q{no_parallel},
+        path                    => $path,
     }
 );
 
@@ -134,11 +134,11 @@ is( $no_push_result, q{job_id_6}, q{No sample_id parallel job_ids} );
 
 add_sample_id_parallel_job_id_to_family_id_dependency_tree(
     {
-        job_id_href           => \%job_id,
-     infile_lane_prefix_href => \%infile_lane_prefix,
-        family_id_chain_key   => $family_id_chain_key,
-        sample_id             => $sample_id,
-        path                  => $path,
+        job_id_href             => \%job_id,
+        infile_lane_prefix_href => \%infile_lane_prefix,
+        family_id_chain_key     => $family_id_chain_key,
+        sample_id               => $sample_id,
+        path                    => $path,
     }
 );
 

--- a/t/processes_add_sample_ids_job_ids_to_job_id_dependency_string.t
+++ b/t/processes_add_sample_ids_job_ids_to_job_id_dependency_string.t
@@ -29,7 +29,7 @@ our $USAGE = build_usage( {} );
 ##Constants
 Readonly my $NEWLINE    => qq{\n};
 Readonly my $SPACE      => q{ };
-Readonly my $EMPTY_STR      => q{};
+Readonly my $EMPTY_STR  => q{};
 Readonly my $UNDERSCORE => q{_};
 
 my $VERBOSE = 1;
@@ -84,14 +84,15 @@ BEGIN {
     }
 }
 
-use MIP::Processmanagement::Processes qw{add_sample_ids_job_ids_to_job_id_dependency_string};
+use MIP::Processmanagement::Processes
+  qw{add_sample_ids_job_ids_to_job_id_dependency_string};
 
 diag(
 "Test add_sample_ids_job_ids_to_job_id_dependency_string $MIP::Processmanagement::Processes::VERSION, Perl $^V, $EXECUTABLE_NAME"
 );
 
 ## Base arguments
-my $family_id = q{family1};
+my $family_id           = q{family1};
 my $sample_id           = q{sample2};
 my $path                = q{MAIN};
 my $family_id_chain_key = q{family1} . $UNDERSCORE . $path;
@@ -111,11 +112,11 @@ my %infile_lane_prefix = (
 my %job_id = (
     $family_id_chain_key => {
         q{sample1} . $UNDERSCORE . $path => [qw{job_id_1 job_id_2}],
-        q{sample2} . $UNDERSCORE . $path      => [qw{job_id_3}],
-        q{sample3} . $UNDERSCORE . $path      => [qw{job_id_4 job_id_5 job_id_8}],
-			     q{sample4} . $UNDERSCORE . $path      => [undef],
-			     $sample_id_parallel_chain_key => [qw{job_id_10 job_id_11}],
-        $family_id_chain_key => [qw{job_id_6}],
+        q{sample2} . $UNDERSCORE . $path => [qw{job_id_3}],
+        q{sample3} . $UNDERSCORE . $path => [qw{job_id_4 job_id_5 job_id_8}],
+        q{sample4} . $UNDERSCORE . $path => [undef],
+        $sample_id_parallel_chain_key    => [qw{job_id_10 job_id_11}],
+        $family_id_chain_key             => [qw{job_id_6}],
     },
 );
 
@@ -124,63 +125,54 @@ my %job_id = (
 ## No sample no parallel jobs
 
 my $job_ids_string = add_sample_ids_job_ids_to_job_id_dependency_string(
-				{
-				 job_id_href         => \%job_id,
-				 infile_lane_prefix_href => \%infile_lane_prefix,
-				 sample_ids_ref => \@samples,
-				 family_id_chain_key => $family_id_chain_key,
-				 family_id => $family_id,
-				 path => $path,
-				}
-			       );
-my $expected_job_id_string;
-is(
-    $job_ids_string,
-    $expected_job_id_string,
-    q{No sample_id and no parallel jobs to job_id_string}
+    {
+        job_id_href             => \%job_id,
+        infile_lane_prefix_href => \%infile_lane_prefix,
+        sample_ids_ref          => \@samples,
+        family_id_chain_key     => $family_id_chain_key,
+        family_id               => $family_id,
+        path                    => $path,
+    }
 );
+my $expected_job_id_string;
+is( $job_ids_string, $expected_job_id_string,
+    q{No sample_id and no parallel jobs to job_id_string} );
 
 ## 1 sample no parallel jobs
 @samples = qw{sample1};
 
 $job_ids_string = add_sample_ids_job_ids_to_job_id_dependency_string(
-				{
-				 job_id_href         => \%job_id,
-				 infile_lane_prefix_href => \%infile_lane_prefix,
-				 sample_ids_ref => \@samples,
-				 family_id_chain_key => $family_id_chain_key,
-				 family_id => $family_id,
-				 path => $path,
-				}
-			       );
-$expected_job_id_string = q{:job_id_1:job_id_2};
-is(
-    $job_ids_string,
-    $expected_job_id_string,
-    q{Added sample_id and no parallel jobs to job_id_string}
+    {
+        job_id_href             => \%job_id,
+        infile_lane_prefix_href => \%infile_lane_prefix,
+        sample_ids_ref          => \@samples,
+        family_id_chain_key     => $family_id_chain_key,
+        family_id               => $family_id,
+        path                    => $path,
+    }
 );
-
+$expected_job_id_string = q{:job_id_1:job_id_2};
+is( $job_ids_string, $expected_job_id_string,
+    q{Added sample_id and no parallel jobs to job_id_string} );
 
 ## 1 sample no parallel jobs
 
 @samples = qw{sample1 sample2 sample3};
 
 $job_ids_string = add_sample_ids_job_ids_to_job_id_dependency_string(
-				{
-				 job_id_href         => \%job_id,
-				 infile_lane_prefix_href => \%infile_lane_prefix,
-				 sample_ids_ref => \@samples,
-				 family_id_chain_key => $family_id_chain_key,
-				 family_id => $family_id,
-				 path => $path,
-				}
-			       );
-$expected_job_id_string = q{:job_id_1:job_id_2:job_id_3:job_id_10:job_id_11:job_id_4:job_id_5:job_id_8};
-is(
-    $job_ids_string,
-    $expected_job_id_string,
-    q{Added sample_ids and parallel jobs to job_id_string}
+    {
+        job_id_href             => \%job_id,
+        infile_lane_prefix_href => \%infile_lane_prefix,
+        sample_ids_ref          => \@samples,
+        family_id_chain_key     => $family_id_chain_key,
+        family_id               => $family_id,
+        path                    => $path,
+    }
 );
+$expected_job_id_string =
+  q{:job_id_1:job_id_2:job_id_3:job_id_10:job_id_11:job_id_4:job_id_5:job_id_8};
+is( $job_ids_string, $expected_job_id_string,
+    q{Added sample_ids and parallel jobs to job_id_string} );
 done_testing();
 
 ######################

--- a/t/processes_add_sample_job_id_to_sample_id_dependency_tree.t
+++ b/t/processes_add_sample_job_id_to_sample_id_dependency_tree.t
@@ -83,7 +83,8 @@ BEGIN {
     }
 }
 
-use MIP::Processmanagement::Processes qw{add_sample_job_id_to_sample_id_dependency_tree};
+use MIP::Processmanagement::Processes
+  qw{add_sample_job_id_to_sample_id_dependency_tree};
 
 diag(
 "Test add_sample_job_id_to_sample_id_dependency_tree $MIP::Processmanagement::Processes::VERSION, Perl $^V, $EXECUTABLE_NAME"

--- a/t/processes_add_to_job_id_dependency_string.t
+++ b/t/processes_add_to_job_id_dependency_string.t
@@ -29,7 +29,7 @@ our $USAGE = build_usage( {} );
 ##Constants
 Readonly my $NEWLINE    => qq{\n};
 Readonly my $SPACE      => q{ };
-Readonly my $EMPTY_STR      => q{};
+Readonly my $EMPTY_STR  => q{};
 Readonly my $UNDERSCORE => q{_};
 
 my $VERBOSE = 1;
@@ -98,10 +98,10 @@ my $family_id_chain_key = q{family1} . $UNDERSCORE . $path;
 my %job_id = (
     $family_id_chain_key => {
         q{sample1} . $UNDERSCORE . $path => [qw{job_id_1 job_id_2}],
-        q{sample2} . $UNDERSCORE . $path      => [qw{job_id_3}],
-        q{sample3} . $UNDERSCORE . $path      => [qw{job_id_4 job_id_5 job_id_8}],
-			     q{sample4} . $UNDERSCORE . $path      => [undef],
-        $family_id_chain_key => [qw{job_id_6}],
+        q{sample2} . $UNDERSCORE . $path => [qw{job_id_3}],
+        q{sample3} . $UNDERSCORE . $path => [qw{job_id_4 job_id_5 job_id_8}],
+        q{sample4} . $UNDERSCORE . $path => [undef],
+        $family_id_chain_key             => [qw{job_id_6}],
     },
 );
 
@@ -111,18 +111,15 @@ my %job_id = (
 my $sample_id_chain_key = $sample_id . $UNDERSCORE . $path;
 
 my $job_ids_string = add_to_job_id_dependency_string(
-				{
-				 job_id_href         => \%job_id,
-				 family_id_chain_key => $family_id_chain_key,
-				 chain_key           => $sample_id_chain_key,
-				}
-			       );
-my $expected_job_id_string = q{:job_id_3};
-is(
-    $job_ids_string,
-    $expected_job_id_string,
-    q{Added 1 job_id to job_id_string}
+    {
+        job_id_href         => \%job_id,
+        family_id_chain_key => $family_id_chain_key,
+        chain_key           => $sample_id_chain_key,
+    }
 );
+my $expected_job_id_string = q{:job_id_3};
+is( $job_ids_string, $expected_job_id_string,
+    q{Added 1 job_id to job_id_string} );
 
 ## Add 2 job_ids to job_id_string
 $sample_id           = q{sample1};
@@ -130,20 +127,17 @@ $sample_id_chain_key = $sample_id . $UNDERSCORE . $path;
 
 ## Add to job_id string
 $job_ids_string = add_to_job_id_dependency_string(
-				{
-				 job_id_href         => \%job_id,
-				 family_id_chain_key => $family_id_chain_key,
-				 chain_key           => $sample_id_chain_key,
-				}
-			       );
+    {
+        job_id_href         => \%job_id,
+        family_id_chain_key => $family_id_chain_key,
+        chain_key           => $sample_id_chain_key,
+    }
+);
 
 $expected_job_id_string = q{:job_id_1:job_id_2};
 
-is(
-    $job_ids_string,
-    $expected_job_id_string,
-    q{Added 2 job_ids to job_id_string}
-);
+is( $job_ids_string, $expected_job_id_string,
+    q{Added 2 job_ids to job_id_string} );
 
 ## Add 3 job_ids to job_id_string
 $sample_id           = q{sample3};
@@ -151,20 +145,17 @@ $sample_id_chain_key = $sample_id . $UNDERSCORE . $path;
 
 ## Add to job_id string
 $job_ids_string = add_to_job_id_dependency_string(
-				{
-				 job_id_href         => \%job_id,
-				 family_id_chain_key => $family_id_chain_key,
-				 chain_key           => $sample_id_chain_key,
-				}
-			       );
+    {
+        job_id_href         => \%job_id,
+        family_id_chain_key => $family_id_chain_key,
+        chain_key           => $sample_id_chain_key,
+    }
+);
 
 $expected_job_id_string = q{:job_id_4:job_id_5:job_id_8};
 
-is(
-    $job_ids_string,
-    $expected_job_id_string,
-    q{Added 3 job_ids to job_id_string}
-);
+is( $job_ids_string, $expected_job_id_string,
+    q{Added 3 job_ids to job_id_string} );
 
 ## Do not add undef job_ids to job_id_string
 $sample_id           = q{sample4};
@@ -172,21 +163,17 @@ $sample_id_chain_key = $sample_id . $UNDERSCORE . $path;
 
 ## Add to job_id string
 $job_ids_string = add_to_job_id_dependency_string(
-				{
-				 job_id_href         => \%job_id,
-				 family_id_chain_key => $family_id_chain_key,
-				 chain_key           => $sample_id_chain_key,
-				}
-			       );
+    {
+        job_id_href         => \%job_id,
+        family_id_chain_key => $family_id_chain_key,
+        chain_key           => $sample_id_chain_key,
+    }
+);
 
 $expected_job_id_string = $EMPTY_STR;
 
-is(
-    $job_ids_string,
-    $expected_job_id_string,
-    q{Nothing was added to job_id_string}
-);
-
+is( $job_ids_string, $expected_job_id_string,
+    q{Nothing was added to job_id_string} );
 
 done_testing();
 

--- a/t/processes_clear_pan_job_id_dependency_tree.t
+++ b/t/processes_clear_pan_job_id_dependency_tree.t
@@ -84,8 +84,7 @@ BEGIN {
     }
 }
 
-use MIP::Processmanagement::Processes
-  qw{clear_pan_job_id_dependency_tree};
+use MIP::Processmanagement::Processes qw{clear_pan_job_id_dependency_tree};
 
 diag(
 "Test clear_pan_job_id_dependency_tree $MIP::Processmanagement::Processes::VERSION, Perl $^V, $EXECUTABLE_NAME"

--- a/t/qc_covplots_genome.t
+++ b/t/qc_covplots_genome.t
@@ -103,7 +103,7 @@ diag(   q{Test covplots_genome from Rcoverageplots.pm v}
 Readonly my $MAX_COVERAGE_DEPTH => 30;
 
 ## Base arguments
-my $function_base_command = q{covplots_genome};
+my @function_base_commands = qw{ covplots_genome };
 
 my %base_argument = (
     stdoutfile_path => {
@@ -120,7 +120,7 @@ my %base_argument = (
     },
     FILEHANDLE => {
         input           => undef,
-        expected_output => $function_base_command,
+        expected_output => \@function_base_commands,
     },
 );
 
@@ -170,11 +170,11 @@ ARGUMENT_HASH_REF:
 foreach my $argument_href (@arguments) {
     my @commands = test_function(
         {
-            argument_href          => $argument_href,
-            required_argument_href => \%required_argument,
-            module_function_cref   => $module_function_cref,
-            function_base_command  => $function_base_command,
-            do_test_base_command   => 1,
+            argument_href              => $argument_href,
+            required_argument_href     => \%required_argument,
+            module_function_cref       => $module_function_cref,
+            function_base_commands_ref => \@function_base_commands,
+            do_test_base_command       => 1,
         }
     );
 }

--- a/t/qccollect.t
+++ b/t/qccollect.t
@@ -99,7 +99,7 @@ diag(   q{Test qccollect from Qccollect.pm v}
       . $EXECUTABLE_NAME );
 
 ## Base arguments
-my $function_base_command = q{qccollect};
+my @function_base_commands = qw{ qccollect };
 
 my %base_argument = (
     stdoutfile_path => {
@@ -116,7 +116,7 @@ my %base_argument = (
     },
     FILEHANDLE => {
         input           => undef,
-        expected_output => $function_base_command,
+        expected_output => \@function_base_commands,
     },
 );
 
@@ -165,11 +165,11 @@ ARGUMENT_HASH_REF:
 foreach my $argument_href (@arguments) {
     my @commands = test_function(
         {
-            argument_href          => $argument_href,
-            required_argument_href => \%required_argument,
-            module_function_cref   => $module_function_cref,
-            function_base_command  => $function_base_command,
-            do_test_base_command   => 1,
+            argument_href              => $argument_href,
+            required_argument_href     => \%required_argument,
+            module_function_cref       => $module_function_cref,
+            function_base_commands_ref => \@function_base_commands,
+            do_test_base_command       => 1,
         }
     );
 }

--- a/t/rhocall_aggregate.t
+++ b/t/rhocall_aggregate.t
@@ -99,12 +99,12 @@ diag(   q{Test rhocall_aggregate from Rhocall.pm v}
       . $EXECUTABLE_NAME );
 
 ## Base arguments
-my $function_base_command = q{rhocall aggregate};
+my @function_base_commands = qw{ rhocall aggregate };
 
 my %base_argument = (
     FILEHANDLE => {
         input           => undef,
-        expected_output => $function_base_command,
+        expected_output => \@function_base_commands,
     },
     stderrfile_path => {
         input           => q{stderrfile.test},
@@ -124,17 +124,17 @@ my %base_argument = (
 ## to enable testing of each individual argument
 my %required_argument = (
     infile_path => {
-        input           => catfile( qw{ file_path_prefix_contig infile_suffix } ),
-        expected_output => catfile( qw{ file_path_prefix_contig infile_suffix } ),
+        input           => catfile(qw{ file_path_prefix_contig infile_suffix }),
+        expected_output => catfile(qw{ file_path_prefix_contig infile_suffix }),
     },
 );
 
 my %specific_argument = (
     outfile_path => {
-        input => catfile( qw{ outfile_path_prefix_contig infile_suffix } ),
+        input => catfile(qw{ outfile_path_prefix_contig infile_suffix }),
         expected_output => q{--output}
           . $SPACE
-          . catfile( qw{ outfile_path_prefix_contig infile_suffix } ),
+          . catfile(qw{ outfile_path_prefix_contig infile_suffix }),
     },
 );
 
@@ -148,11 +148,11 @@ ARGUMENT_HASH_REF:
 foreach my $argument_href (@arguments) {
     my @commands = test_function(
         {
-            argument_href          => $argument_href,
-            required_argument_href => \%required_argument,
-            module_function_cref   => $module_function_cref,
-            function_base_command  => $function_base_command,
-            do_test_base_command   => 1,
+            argument_href              => $argument_href,
+            required_argument_href     => \%required_argument,
+            module_function_cref       => $module_function_cref,
+            function_base_commands_ref => \@function_base_commands,
+            do_test_base_command       => 1,
         }
     );
 }

--- a/t/rhocall_annotate.t
+++ b/t/rhocall_annotate.t
@@ -99,12 +99,12 @@ diag(   q{Test rhocall_annotate from Rhocall.pm v}
       . $EXECUTABLE_NAME );
 
 ## Base arguments
-my $function_base_command = q{rhocall annotate};
+my @function_base_commands = qw{ rhocall annotate };
 
 my %base_argument = (
     FILEHANDLE => {
         input           => undef,
-        expected_output => $function_base_command,
+        expected_output => \@function_base_commands,
     },
     stderrfile_path => {
         input           => q{stderrfile.test},
@@ -124,29 +124,29 @@ my %base_argument = (
 ## to enable testing of each individual argument
 my %required_argument = (
     infile_path => {
-        input           => catfile( qw{ file_path_prefix_contig infile_suffix } ),
-        expected_output => catfile( qw{ file_path_prefix_contig infile_suffix } ),
+        input           => catfile(qw{ file_path_prefix_contig infile_suffix }),
+        expected_output => catfile(qw{ file_path_prefix_contig infile_suffix }),
     },
 );
 
 my %specific_argument = (
     bedfile_path => {
-        input           => catfile( qw{ path_to_bedfile file.bed } ),
+        input           => catfile(qw{ path_to_bedfile file.bed }),
         expected_output => q{-b}
           . $SPACE
-          . catfile( qw{ path_to_bedfile file.bed } ),
+          . catfile(qw{ path_to_bedfile file.bed }),
     },
     outfile_path => {
-        input => catfile( qw{ outfile_path_prefix_contig infile_suffix } ),
+        input => catfile(qw{ outfile_path_prefix_contig infile_suffix }),
         expected_output => q{--output}
           . $SPACE
-          . catfile( qw{ outfile_path_prefix_contig infile_suffix } ),
+          . catfile(qw{ outfile_path_prefix_contig infile_suffix }),
     },
     rohfile_path => {
-        input           => catfile( qw{ file_path_prefix _contig.roh } ),
+        input           => catfile(qw{ file_path_prefix _contig.roh }),
         expected_output => q{-r}
           . $SPACE
-          . catfile( qw{ file_path_prefix _contig.roh } ),
+          . catfile(qw{ file_path_prefix _contig.roh }),
     },
     v14 => {
         input           => 1,
@@ -164,11 +164,11 @@ ARGUMENT_HASH_REF:
 foreach my $argument_href (@arguments) {
     my @commands = test_function(
         {
-            argument_href          => $argument_href,
-            required_argument_href => \%required_argument,
-            module_function_cref   => $module_function_cref,
-            function_base_command  => $function_base_command,
-            do_test_base_command   => 1,
+            argument_href              => $argument_href,
+            required_argument_href     => \%required_argument,
+            module_function_cref       => $module_function_cref,
+            function_base_commands_ref => \@function_base_commands,
+            do_test_base_command       => 1,
         }
     );
 }

--- a/t/rtg_format.t
+++ b/t/rtg_format.t
@@ -99,12 +99,12 @@ diag(   q{Test rtg_format from Rtg.pm v}
       . $EXECUTABLE_NAME );
 
 ## Base arguments
-my $function_base_command = q{rtg format};
+my @function_base_commands = qw{ rtg format };
 
 my %base_argument = (
     FILEHANDLE => {
         input           => undef,
-        expected_output => $function_base_command,
+        expected_output => \@function_base_commands,
     },
     stderrfile_path => {
         input           => q{stderrfile.test},
@@ -158,11 +158,11 @@ ARGUMENT_HASH_REF:
 foreach my $argument_href (@arguments) {
     my @commands = test_function(
         {
-            argument_href          => $argument_href,
-            do_test_base_command   => 1,
-            function_base_command  => $function_base_command,
-            module_function_cref   => $module_function_cref,
-            required_argument_href => \%required_argument,
+            argument_href              => $argument_href,
+            do_test_base_command       => 1,
+            function_base_commands_ref => \@function_base_commands,
+            module_function_cref       => $module_function_cref,
+            required_argument_href     => \%required_argument,
         }
     );
 }

--- a/t/rtg_vcfeval.t
+++ b/t/rtg_vcfeval.t
@@ -99,12 +99,12 @@ diag(   q{Test rtg_vcfeval from Rtg.pm v}
       . $EXECUTABLE_NAME );
 
 ## Base arguments
-my $function_base_command = q{rtg vcfeval};
+my @function_base_commands = qw{ rtg vcfeval };
 
 my %base_argument = (
     FILEHANDLE => {
         input           => undef,
-        expected_output => $function_base_command,
+        expected_output => \@function_base_commands,
     },
     stderrfile_path => {
         input           => q{stderrfile.test},
@@ -192,11 +192,11 @@ ARGUMENT_HASH_REF:
 foreach my $argument_href (@arguments) {
     my @commands = test_function(
         {
-            argument_href          => $argument_href,
-            do_test_base_command   => 1,
-            function_base_command  => $function_base_command,
-            module_function_cref   => $module_function_cref,
-            required_argument_href => \%required_argument,
+            argument_href              => $argument_href,
+            do_test_base_command       => 1,
+            function_base_commands_ref => \@function_base_commands,
+            module_function_cref       => $module_function_cref,
+            required_argument_href     => \%required_argument,
         }
     );
 }

--- a/t/run_bwa.t
+++ b/t/run_bwa.t
@@ -93,7 +93,7 @@ diag(
 );
 
 ## Base arguments
-my $function_base_command = q{run-bwamem};
+my @function_base_commands = qw{ run-bwamem };
 
 ## Read group header line
 my @read_group_headers = (
@@ -114,7 +114,7 @@ my %base_argument = (
     },
     FILEHANDLE => {
         input           => undef,
-        expected_output => $function_base_command,
+        expected_output => \@function_base_commands,
     },
 );
 
@@ -122,7 +122,7 @@ my %base_argument = (
 my %required_argument = (
     FILEHANDLE => {
         input           => undef,
-        expected_output => $function_base_command,
+        expected_output => \@function_base_commands,
     },
     infile_path => {
         input           => q{test_infile.fastq},
@@ -183,11 +183,11 @@ my @arguments = ( \%required_argument, \%specific_argument );
 foreach my $argument_href (@arguments) {
     my @commands = test_function(
         {
-            argument_href          => $argument_href,
-            required_argument_href => \%required_argument,
-            module_function_cref   => $module_function_cref,
-            function_base_command  => $function_base_command,
-            do_test_base_command   => 1,
+            argument_href              => $argument_href,
+            required_argument_href     => \%required_argument,
+            module_function_cref       => $module_function_cref,
+            function_base_commands_ref => \@function_base_commands,
+            do_test_base_command       => 1,
         }
     );
 }

--- a/t/salmon_index.t
+++ b/t/salmon_index.t
@@ -98,7 +98,7 @@ diag(   q{Test salmon_index from Salmon.pm v}
       . $SPACE
       . $EXECUTABLE_NAME );
 
-my $function_base_command = q{salmon index};
+my @function_base_commands = qw{ salmon index };
 
 my %base_argument = (
     stdoutfile_path => {
@@ -115,7 +115,7 @@ my %base_argument = (
     },
     FILEHANDLE => {
         input           => undef,
-        expected_output => $function_base_command,
+        expected_output => \@function_base_commands,
     },
 );
 
@@ -153,11 +153,11 @@ ARGUMENT_HASH_REF:
 foreach my $argument_href (@arguments) {
     my @commands = test_function(
         {
-            argument_href          => $argument_href,
-            required_argument_href => \%required_argument,
-            module_function_cref   => $module_function_cref,
-            function_base_command  => $function_base_command,
-            do_test_base_command   => 1,
+            argument_href              => $argument_href,
+            required_argument_href     => \%required_argument,
+            module_function_cref       => $module_function_cref,
+            function_base_commands_ref => \@function_base_commands,
+            do_test_base_command       => 1,
         }
     );
 }

--- a/t/salmon_quant.t
+++ b/t/salmon_quant.t
@@ -101,7 +101,7 @@ diag(   q{Test salmon_quant from Salmon.pm v}
 ## Constants
 Readonly my $READ_FILES_COMMAND => q{pigz -dc};
 
-my $function_base_command = q{salmon quant};
+my @function_base_commands = qw{ salmon quant };
 
 my %base_argument = (
     stdoutfile_path => {
@@ -118,7 +118,7 @@ my %base_argument = (
     },
     FILEHANDLE => {
         input           => undef,
-        expected_output => $function_base_command,
+        expected_output => \@function_base_commands,
     },
 );
 
@@ -179,11 +179,11 @@ ARGUMENT_HASH_REF:
 foreach my $argument_href (@arguments) {
     my @commands = test_function(
         {
-            argument_href          => $argument_href,
-            required_argument_href => \%required_argument,
-            module_function_cref   => $module_function_cref,
-            function_base_command  => $function_base_command,
-            do_test_base_command   => 1,
+            argument_href              => $argument_href,
+            required_argument_href     => \%required_argument,
+            module_function_cref       => $module_function_cref,
+            function_base_commands_ref => \@function_base_commands,
+            do_test_base_command       => 1,
         }
     );
 }

--- a/t/sambamba_depth.t
+++ b/t/sambamba_depth.t
@@ -93,12 +93,12 @@ diag(
 );
 
 ## Base arguments
-my $function_base_command = q{sambamba};
+my @function_base_commands = qw{ sambamba };
 
 my %base_argument = (
     FILEHANDLE => {
         input           => undef,
-        expected_output => $function_base_command,
+        expected_output => \@function_base_commands,
     },
 );
 
@@ -106,7 +106,7 @@ my %base_argument = (
 my %required_argument = (
     FILEHANDLE => {
         input           => undef,
-        expected_output => $function_base_command,
+        expected_output => \@function_base_commands,
     },
     infile_path => {
         input           => q{infile.test},
@@ -165,10 +165,10 @@ foreach my $argument_href (@arguments) {
 
     my @commands = test_function(
         {
-            argument_href          => $argument_href,
-            required_argument_href => \%required_argument,
-            module_function_cref   => $module_function_cref,
-            function_base_command  => $function_base_command,
+            argument_href              => $argument_href,
+            required_argument_href     => \%required_argument,
+            module_function_cref       => $module_function_cref,
+            function_base_commands_ref => \@function_base_commands,
         }
     );
 }

--- a/t/sambamba_flagstat.t
+++ b/t/sambamba_flagstat.t
@@ -93,12 +93,12 @@ diag(
 );
 
 ## Base arguments
-my $function_base_command = q{sambamba};
+my @function_base_commands = qw{ sambamba };
 
 my %base_argument = (
     FILEHANDLE => {
         input           => undef,
-        expected_output => $function_base_command,
+        expected_output => \@function_base_commands,
     },
 );
 
@@ -106,7 +106,7 @@ my %base_argument = (
 my %required_argument = (
     FILEHANDLE => {
         input           => undef,
-        expected_output => $function_base_command,
+        expected_output => \@function_base_commands,
     },
     infile_path => {
         input           => q{infile.test},
@@ -137,10 +137,10 @@ foreach my $argument_href (@arguments) {
 
     my @commands = test_function(
         {
-            argument_href          => $argument_href,
-            required_argument_href => \%required_argument,
-            module_function_cref   => $module_function_cref,
-            function_base_command  => $function_base_command,
+            argument_href              => $argument_href,
+            required_argument_href     => \%required_argument,
+            module_function_cref       => $module_function_cref,
+            function_base_commands_ref => \@function_base_commands,
         }
     );
 }

--- a/t/sambamba_index.t
+++ b/t/sambamba_index.t
@@ -93,12 +93,12 @@ diag(
 );
 
 ## Base arguments
-my $function_base_command = q{sambamba};
+my @function_base_commands = qw{ sambamba };
 
 my %base_argument = (
     FILEHANDLE => {
         input           => undef,
-        expected_output => $function_base_command,
+        expected_output => \@function_base_commands,
     },
 );
 
@@ -106,7 +106,7 @@ my %base_argument = (
 my %required_argument = (
     FILEHANDLE => {
         input           => undef,
-        expected_output => $function_base_command,
+        expected_output => \@function_base_commands,
     },
     infile_path => {
         input           => q{infile.test},
@@ -136,10 +136,10 @@ foreach my $argument_href (@arguments) {
 
     my @commands = test_function(
         {
-            argument_href          => $argument_href,
-            required_argument_href => \%required_argument,
-            module_function_cref   => $module_function_cref,
-            function_base_command  => $function_base_command,
+            argument_href              => $argument_href,
+            required_argument_href     => \%required_argument,
+            module_function_cref       => $module_function_cref,
+            function_base_commands_ref => \@function_base_commands,
         }
     );
 }

--- a/t/sambamba_markdup.t
+++ b/t/sambamba_markdup.t
@@ -93,12 +93,12 @@ diag(
 );
 
 ## Base arguments
-my $function_base_command = q{sambamba};
+my @function_base_commands = qw{ sambamba };
 
 my %base_argument = (
     FILEHANDLE => {
         input           => undef,
-        expected_output => $function_base_command,
+        expected_output => \@function_base_commands,
     },
 );
 
@@ -106,7 +106,7 @@ my %base_argument = (
 my %required_argument = (
     FILEHANDLE => {
         input           => undef,
-        expected_output => $function_base_command,
+        expected_output => \@function_base_commands,
     },
     infile_path => {
         input           => q{infile.test},
@@ -160,10 +160,10 @@ foreach my $argument_href (@arguments) {
 
     my @commands = test_function(
         {
-            argument_href          => $argument_href,
-            required_argument_href => \%required_argument,
-            module_function_cref   => $module_function_cref,
-            function_base_command  => $function_base_command,
+            argument_href              => $argument_href,
+            required_argument_href     => \%required_argument,
+            module_function_cref       => $module_function_cref,
+            function_base_commands_ref => \@function_base_commands,
         }
     );
 }

--- a/t/sambamba_sort.t
+++ b/t/sambamba_sort.t
@@ -93,12 +93,12 @@ diag(
 );
 
 ## Base arguments
-my $function_base_command = q{sambamba};
+my @function_base_commands = qw{ sambamba };
 
 my %base_argument = (
     FILEHANDLE => {
         input           => undef,
-        expected_output => $function_base_command,
+        expected_output => \@function_base_commands,
     },
 );
 
@@ -106,7 +106,7 @@ my %base_argument = (
 my %required_argument = (
     FILEHANDLE => {
         input           => undef,
-        expected_output => $function_base_command,
+        expected_output => \@function_base_commands,
     },
     infile_path => {
         input           => q{infile.test},
@@ -148,10 +148,10 @@ foreach my $argument_href (@arguments) {
 
     my @commands = test_function(
         {
-            argument_href          => $argument_href,
-            required_argument_href => \%required_argument,
-            module_function_cref   => $module_function_cref,
-            function_base_command  => $function_base_command,
+            argument_href              => $argument_href,
+            required_argument_href     => \%required_argument,
+            module_function_cref       => $module_function_cref,
+            function_base_commands_ref => \@function_base_commands,
         }
     );
 }

--- a/t/sambamba_view.t
+++ b/t/sambamba_view.t
@@ -93,12 +93,12 @@ diag(
 );
 
 ## Base arguments
-my $function_base_command = q{sambamba};
+my @function_base_commands = qw{ sambamba };
 
 my %base_argument = (
     FILEHANDLE => {
         input           => undef,
-        expected_output => $function_base_command,
+        expected_output => \@function_base_commands,
     },
 );
 
@@ -106,7 +106,7 @@ my %base_argument = (
 my %required_argument = (
     FILEHANDLE => {
         input           => undef,
-        expected_output => $function_base_command,
+        expected_output => \@function_base_commands,
     },
     infile_path => {
         input           => q{infile.test},
@@ -157,10 +157,10 @@ foreach my $argument_href (@arguments) {
 
     my @commands = test_function(
         {
-            argument_href          => $argument_href,
-            required_argument_href => \%required_argument,
-            module_function_cref   => $module_function_cref,
-            function_base_command  => $function_base_command,
+            argument_href              => $argument_href,
+            required_argument_href     => \%required_argument,
+            module_function_cref       => $module_function_cref,
+            function_base_commands_ref => \@function_base_commands,
         }
     );
 }

--- a/t/samtools_depth.t
+++ b/t/samtools_depth.t
@@ -100,12 +100,12 @@ diag(   q{Test samtools_depth from Samtools.pm v}
       . $EXECUTABLE_NAME );
 
 ## Base arguments
-my $function_base_command = q{samtools depth};
+my @function_base_commands = qw{ samtools depth };
 
 my %base_argument = (
     FILEHANDLE => {
         input           => undef,
-        expected_output => $function_base_command,
+        expected_output => \@function_base_commands,
     },
     stderrfile_path => {
         input           => q{stderrfile.test},
@@ -125,7 +125,7 @@ my %base_argument = (
 my %required_argument = (
     FILEHANDLE => {
         input           => undef,
-        expected_output => $function_base_command,
+        expected_output => \@function_base_commands,
     },
     infile_path => {
         input           => q{infile.test},
@@ -137,7 +137,7 @@ my %required_argument = (
 my %specific_argument = (
     FILEHANDLE => {
         input           => undef,
-        expected_output => $function_base_command,
+        expected_output => \@function_base_commands,
     },
     infile_path => {
         input           => q{infile.test},
@@ -171,10 +171,10 @@ foreach my $argument_href (@arguments) {
 
     my @commands = test_function(
         {
-            argument_href          => $argument_href,
-            required_argument_href => \%required_argument,
-            module_function_cref   => $module_function_cref,
-            function_base_command  => $function_base_command,
+            argument_href              => $argument_href,
+            required_argument_href     => \%required_argument,
+            module_function_cref       => $module_function_cref,
+            function_base_commands_ref => \@function_base_commands,
         }
     );
 }

--- a/t/samtools_faidx.t
+++ b/t/samtools_faidx.t
@@ -90,12 +90,12 @@ diag(
 );
 
 ## Base arguments
-my $function_base_command = q{samtools};
+my @function_base_commands = qw{ samtools };
 
 my %base_argument = (
     FILEHANDLE => {
         input           => undef,
-        expected_output => $function_base_command,
+        expected_output => \@function_base_commands,
     },
 );
 
@@ -103,7 +103,7 @@ my %base_argument = (
 my %required_argument = (
     FILEHANDLE => {
         input           => undef,
-        expected_output => $function_base_command,
+        expected_output => \@function_base_commands,
     },
     infile_path => {
         input           => q{infile.test},
@@ -141,10 +141,10 @@ foreach my $argument_href (@arguments) {
 
     my @commands = test_function(
         {
-            argument_href          => $argument_href,
-            required_argument_href => \%required_argument,
-            module_function_cref   => $module_function_cref,
-            function_base_command  => $function_base_command,
+            argument_href              => $argument_href,
+            required_argument_href     => \%required_argument,
+            module_function_cref       => $module_function_cref,
+            function_base_commands_ref => \@function_base_commands,
         }
     );
 }

--- a/t/samtools_idxstats.t
+++ b/t/samtools_idxstats.t
@@ -99,12 +99,12 @@ diag(   q{Test samtools_idxstats from Samtools.pm v}
       . $EXECUTABLE_NAME );
 
 ## Base arguments
-my $function_base_command = q{samtools idxstats};
+my @function_base_commands = qw{ samtools idxstats };
 
 my %base_argument = (
     FILEHANDLE => {
         input           => undef,
-        expected_output => $function_base_command,
+        expected_output => \@function_base_commands,
     },
     stderrfile_path => {
         input           => q{stderrfile.test},
@@ -124,7 +124,7 @@ my %base_argument = (
 my %required_argument = (
     FILEHANDLE => {
         input           => undef,
-        expected_output => $function_base_command,
+        expected_output => \@function_base_commands,
     },
     infile_path => {
         input           => q{infile.test},
@@ -136,7 +136,7 @@ my %required_argument = (
 my %specific_argument = (
     FILEHANDLE => {
         input           => undef,
-        expected_output => $function_base_command,
+        expected_output => \@function_base_commands,
     },
     infile_path => {
         input           => q{infile.test},
@@ -166,10 +166,10 @@ foreach my $argument_href (@arguments) {
 
     my @commands = test_function(
         {
-            argument_href          => $argument_href,
-            required_argument_href => \%required_argument,
-            module_function_cref   => $module_function_cref,
-            function_base_command  => $function_base_command,
+            argument_href              => $argument_href,
+            required_argument_href     => \%required_argument,
+            module_function_cref       => $module_function_cref,
+            function_base_commands_ref => \@function_base_commands,
         }
     );
 }

--- a/t/samtools_index.t
+++ b/t/samtools_index.t
@@ -90,12 +90,12 @@ diag(
 );
 
 ## Base arguments
-my $function_base_command = q{samtools};
+my @function_base_commands = qw{ samtools };
 
 my %base_argument = (
     FILEHANDLE => {
         input           => undef,
-        expected_output => $function_base_command,
+        expected_output => \@function_base_commands,
     },
 );
 
@@ -103,7 +103,7 @@ my %base_argument = (
 my %required_argument = (
     FILEHANDLE => {
         input           => undef,
-        expected_output => $function_base_command,
+        expected_output => \@function_base_commands,
     },
     infile_path => {
         input           => q{infile.test},
@@ -141,10 +141,10 @@ foreach my $argument_href (@arguments) {
 
     my @commands = test_function(
         {
-            argument_href          => $argument_href,
-            required_argument_href => \%required_argument,
-            module_function_cref   => $module_function_cref,
-            function_base_command  => $function_base_command,
+            argument_href              => $argument_href,
+            required_argument_href     => \%required_argument,
+            module_function_cref       => $module_function_cref,
+            function_base_commands_ref => \@function_base_commands,
         }
     );
 }

--- a/t/samtools_mpileup.t
+++ b/t/samtools_mpileup.t
@@ -90,12 +90,12 @@ diag(
 );
 
 ## Base arguments
-my $function_base_command = q{samtools};
+my @function_base_commands = qw{ samtools };
 
 my %base_argument = (
     FILEHANDLE => {
         input           => undef,
-        expected_output => $function_base_command,
+        expected_output => \@function_base_commands,
     },
 );
 
@@ -103,7 +103,7 @@ my %base_argument = (
 my %required_argument = (
     FILEHANDLE => {
         input           => undef,
-        expected_output => $function_base_command,
+        expected_output => \@function_base_commands,
     },
     infile_paths_ref => {
         inputs_ref      => [],
@@ -162,10 +162,10 @@ foreach my $argument_href (@arguments) {
 
     my @commands = test_function(
         {
-            argument_href          => $argument_href,
-            required_argument_href => \%required_argument,
-            module_function_cref   => $module_function_cref,
-            function_base_command  => $function_base_command,
+            argument_href              => $argument_href,
+            required_argument_href     => \%required_argument,
+            module_function_cref       => $module_function_cref,
+            function_base_commands_ref => \@function_base_commands,
         }
     );
 }

--- a/t/samtools_stats.t
+++ b/t/samtools_stats.t
@@ -90,12 +90,12 @@ diag(
 );
 
 ## Base arguments
-my $function_base_command = q{samtools};
+my @function_base_commands = qw{ samtools };
 
 my %base_argument = (
     FILEHANDLE => {
         input           => undef,
-        expected_output => $function_base_command,
+        expected_output => \@function_base_commands,
     },
 );
 
@@ -103,7 +103,7 @@ my %base_argument = (
 my %required_argument = (
     FILEHANDLE => {
         input           => undef,
-        expected_output => $function_base_command,
+        expected_output => \@function_base_commands,
     },
     infile_path => {
         input           => q{infile.test},
@@ -145,10 +145,10 @@ foreach my $argument_href (@arguments) {
 
     my @commands = test_function(
         {
-            argument_href          => $argument_href,
-            required_argument_href => \%required_argument,
-            module_function_cref   => $module_function_cref,
-            function_base_command  => $function_base_command,
+            argument_href              => $argument_href,
+            required_argument_href     => \%required_argument,
+            module_function_cref       => $module_function_cref,
+            function_base_commands_ref => \@function_base_commands,
         }
     );
 }

--- a/t/samtools_view.t
+++ b/t/samtools_view.t
@@ -100,12 +100,12 @@ diag(   q{Test samtools_view from samtools.pl v}
       . $EXECUTABLE_NAME );
 
 ## Base arguments
-my $function_base_command = q{samtools view};
+my @function_base_commands = qw{ samtools view };
 
 my %base_argument = (
     FILEHANDLE => {
         input           => undef,
-        expected_output => $function_base_command,
+        expected_output => \@function_base_commands,
     },
 );
 
@@ -113,7 +113,7 @@ my %base_argument = (
 my %required_argument = (
     FILEHANDLE => {
         input           => undef,
-        expected_output => $function_base_command,
+        expected_output => \@function_base_commands,
     },
     infile_path => {
         input           => q{infile.test},
@@ -179,10 +179,10 @@ foreach my $argument_href (@arguments) {
 
     my @commands = test_function(
         {
-            argument_href          => $argument_href,
-            required_argument_href => \%required_argument,
-            module_function_cref   => $module_function_cref,
-            function_base_command  => $function_base_command,
+            argument_href              => $argument_href,
+            required_argument_href     => \%required_argument,
+            module_function_cref       => $module_function_cref,
+            function_base_commands_ref => \@function_base_commands,
         }
     );
 }

--- a/t/set_active_parameter_pedigree_keys.t
+++ b/t/set_active_parameter_pedigree_keys.t
@@ -167,8 +167,8 @@ set_active_parameter_pedigree_keys(
 my $set_analysis_type     = $active_parameter{analysis_type}{sample_1};
 my $set_expected_coverage = $sample_info{sample}{expected_coverage}{sample_1};
 
-is( $set_analysis_type,     q{wes},    q{Set analysis type} );
-is( $set_expected_coverage, undef,     q(Did not set expected coverage) );
+is( $set_analysis_type,     q{wes}, q{Set analysis type} );
+is( $set_expected_coverage, undef,  q(Did not set expected coverage) );
 done_testing();
 
 ######################

--- a/t/set_default_to_active_parameter.t
+++ b/t/set_default_to_active_parameter.t
@@ -123,11 +123,11 @@ my %active_parameter = (
     gatk_genotypegvcfs_ref_gvcf               => q{test_file},
     markduplicates_picardtools_markduplicates => 1,
     mip                                       => 1,
-    bwa_mem                                  => 0,
-    gatk_baserecalibration                   => 1,
-    gatk_genotypegvcfs                       => 1,
-    gatk_variantrecalibration                => 1,
-    sv_vcfparser                             => 1,
+    bwa_mem                                   => 0,
+    gatk_baserecalibration                    => 1,
+    gatk_genotypegvcfs                        => 1,
+    gatk_variantrecalibration                 => 1,
+    sv_vcfparser                              => 1,
 );
 
 my %parameter = load_yaml(

--- a/t/skewer.t
+++ b/t/skewer.t
@@ -99,12 +99,12 @@ diag(   q{Test skewer from Skewer.pm v}
       . $EXECUTABLE_NAME );
 
 ## Base arguments
-my $function_base_command = q{skewer};
+my @function_base_commands = qw{ skewer };
 
 my %base_argument = (
     FILEHANDLE => {
         input           => undef,
-        expected_output => $function_base_command,
+        expected_output => \@function_base_commands,
     },
     stderrfile_path => {
         input           => q{stderrfile.test},
@@ -171,7 +171,7 @@ my %specific_argument = (
         expected_output => catfile(qw{path to test_infile_1}),
     },
     trim_mode => {
-        input       => q{pe},
+        input           => q{pe},
         expected_output => q{--mode} . $SPACE . q{pe},
     },
     outsuffix => {
@@ -198,11 +198,11 @@ ARGUMENT_HASH_REF:
 foreach my $argument_href (@arguments) {
     my @commands = test_function(
         {
-            argument_href          => $argument_href,
-            do_test_base_command   => 1,
-            function_base_command  => $function_base_command,
-            module_function_cref   => $module_function_cref,
-            required_argument_href => \%required_argument,
+            argument_href              => $argument_href,
+            do_test_base_command       => 1,
+            function_base_commands_ref => \@function_base_commands,
+            module_function_cref       => $module_function_cref,
+            required_argument_href     => \%required_argument,
         }
     );
 }

--- a/t/slurm_build_sbatch_header.t
+++ b/t/slurm_build_sbatch_header.t
@@ -66,7 +66,7 @@ GetOptions(
             exit_code => 1,
         }
     )
-);
+  );
 
 BEGIN {
 
@@ -87,7 +87,7 @@ BEGIN {
     for my $module (@modules) {
         require_ok($module) or BAIL_OUT q{Cannot load} . $SPACE . $module;
     }
-  }
+}
 
 use MIP::Workloadmanager::Slurm qw{ slurm_build_sbatch_header };
 
@@ -100,7 +100,7 @@ diag(   q{Test slurm_build_sbatch_header from SLURM.pm v}
       . $SPACE
       . $PERL_VERSION
       . $SPACE
-. $EXECUTABLE_NAME );
+      . $EXECUTABLE_NAME );
 
 ## Base arguments
 my $sbatch_shebang = q{#SBATCH };
@@ -186,12 +186,12 @@ my @args = (
 ## Coderef - enables generalized use of generate call
 my $module_function_cref = \&slurm_build_sbatch_header;
 
-my $function_base_command = q{#SBATCH };
+my @function_base_commands = qw{ #SBATCH  };
 
 test_write_to_file(
     {
         args_ref             => \@args,
-        base_command         => $function_base_command,
+        base_commands_ref    => \@function_base_commands,
         module_function_cref => $module_function_cref,
         separator            => $separator,
     }

--- a/t/slurm_sacct.t
+++ b/t/slurm_sacct.t
@@ -84,7 +84,7 @@ diag(
 );
 
 ## Base arguments
-my $function_base_command = 'sacct';
+my @function_base_commands = 'sacct';
 
 my %base_argument = (
     stdoutfile_path => {
@@ -95,13 +95,13 @@ my %base_argument = (
         input           => 'stderrfile.test',
         expected_output => '2> stderrfile.test',
     },
-		      stderrfile_path_append => {
+    stderrfile_path_append => {
         input           => 'stderrfile.test',
         expected_output => '2>> stderrfile.test',
     },
     FILEHANDLE => {
         input           => undef,
-        expected_output => $function_base_command,
+        expected_output => \@function_base_commands,
     },
 );
 
@@ -127,9 +127,9 @@ foreach my $argument_href (@arguments) {
 
     my @commands = test_function(
         {
-            argument_href           => $argument_href,
-            module_function_cref    => $module_function_cref,
-            function_base_command   => $function_base_command,
+            argument_href              => $argument_href,
+            module_function_cref       => $module_function_cref,
+            function_base_commands_ref => \@function_base_commands,
         }
     );
 }

--- a/t/slurm_sbatch.t
+++ b/t/slurm_sbatch.t
@@ -84,7 +84,7 @@ diag(
 );
 
 ## Base arguments
-my $function_base_command = 'sbatch';
+my @function_base_commands = 'sbatch';
 
 my %base_argument = (
     stdoutfile_path => {
@@ -101,7 +101,7 @@ my %base_argument = (
     },
     FILEHANDLE => {
         input           => undef,
-        expected_output => $function_base_command,
+        expected_output => \@function_base_commands,
     },
 );
 
@@ -147,10 +147,10 @@ foreach my $argument_href (@arguments) {
 
     my @commands = test_function(
         {
-            argument_href          => $argument_href,
-            required_argument_href => \%required_argument,
-            module_function_cref   => $module_function_cref,
-            function_base_command  => $function_base_command,
+            argument_href              => $argument_href,
+            required_argument_href     => \%required_argument,
+            module_function_cref       => $module_function_cref,
+            function_base_commands_ref => \@function_base_commands,
         }
     );
 }

--- a/t/snpeff_ann.t
+++ b/t/snpeff_ann.t
@@ -99,12 +99,12 @@ diag(   q{Test snpeff_ann from Snpeff.pm v}
       . $EXECUTABLE_NAME );
 
 ## Base arguments
-my $function_base_command = q{ann};
+my @function_base_commands = qw{ ann };
 
 my %base_argument = (
     FILEHANDLE => {
         input           => undef,
-        expected_output => $function_base_command,
+        expected_output => \@function_base_commands,
     },
     stderrfile_path => {
         input           => q{stderrfile.test},
@@ -156,11 +156,11 @@ ARGUMENT_HASH_REF:
 foreach my $argument_href (@arguments) {
     my @commands = test_function(
         {
-            argument_href          => $argument_href,
-            required_argument_href => \%required_argument,
-            module_function_cref   => $module_function_cref,
-            function_base_command  => $function_base_command,
-            do_test_base_command   => 1,
+            argument_href              => $argument_href,
+            required_argument_href     => \%required_argument,
+            module_function_cref       => $module_function_cref,
+            function_base_commands_ref => \@function_base_commands,
+            do_test_base_command       => 1,
         }
     );
 }

--- a/t/snpeff_download.t
+++ b/t/snpeff_download.t
@@ -98,7 +98,7 @@ diag(   q{Test snpeff_download from Snpeff.pm v}
       . $EXECUTABLE_NAME );
 
 ## Base arguments
-my $function_base_command = q{java};
+my @function_base_commands = qw{ java };
 
 my $snpeff_download_base = join $SPACE,
   java_core(
@@ -124,7 +124,7 @@ my %base_argument = (
     },
     FILEHANDLE => {
         input           => undef,
-        expected_output => $function_base_command,
+        expected_output => \@function_base_commands,
     },
 );
 
@@ -137,7 +137,7 @@ my %required_argument = (
     },
     FILEHANDLE => {
         input           => undef,
-        expected_output => $function_base_command,
+        expected_output => \@function_base_commands,
     },
     jar_path => {
         input           => catfile(qw{ path to jar }),
@@ -148,7 +148,7 @@ my %required_argument = (
 my %specific_argument = (
     config_file_path => {
         input           => catfile(qw{ path to config }),
-        expected_output => q{-c} . $SPACE . catfile( qw { path to config }),
+        expected_output => q{-c} . $SPACE . catfile(qw { path to config }),
     },
     verbose => {
         input           => 1,
@@ -156,7 +156,7 @@ my %specific_argument = (
     },
     FILEHANDLE => {
         input           => undef,
-        expected_output => $function_base_command,
+        expected_output => \@function_base_commands,
     },
 );
 
@@ -170,11 +170,11 @@ HASHES_OF_ARGUMENTS:
 foreach my $argument_href (@arguments) {
     my @commands = test_function(
         {
-            argument_href          => $argument_href,
-            required_argument_href => \%required_argument,
-            module_function_cref   => $module_function_cref,
-            function_base_command  => $function_base_command,
-            do_test_base_command   => 1,
+            argument_href              => $argument_href,
+            required_argument_href     => \%required_argument,
+            module_function_cref       => $module_function_cref,
+            function_base_commands_ref => \@function_base_commands,
+            do_test_base_command       => 1,
         }
     );
 }

--- a/t/snpsift_annotate.t
+++ b/t/snpsift_annotate.t
@@ -99,12 +99,12 @@ diag(   q{Test snpsift_annotate from snpsift_annotate.pm v}
       . $EXECUTABLE_NAME );
 
 ## Base arguments
-my $function_base_command = q{annotate};
+my @function_base_commands = qw{ annotate };
 
 my %base_argument = (
     FILEHANDLE => {
         input           => undef,
-        expected_output => $function_base_command,
+        expected_output => \@function_base_commands,
     },
     stderrfile_path => {
         input           => q{stderrfile.test},
@@ -132,8 +132,10 @@ my %required_argument = (
 
 my %specific_argument = (
     config_file_path => {
-        input           => catfile( qw{ snpeff_path snpeff.config } ),
-        expected_output => q{-config} . $SPACE . catfile( qw{ snpeff_path snpeff.config } ),
+        input           => catfile(qw{ snpeff_path snpeff.config }),
+        expected_output => q{-config}
+          . $SPACE
+          . catfile(qw{ snpeff_path snpeff.config }),
     },
     infile_path => {
         input           => catfile(qw{ file_path prefix_contig_analysistype}),
@@ -163,11 +165,11 @@ ARGUMENT_HASH_REF:
 foreach my $argument_href (@arguments) {
     my @commands = test_function(
         {
-            argument_href          => $argument_href,
-            required_argument_href => \%required_argument,
-            module_function_cref   => $module_function_cref,
-            function_base_command  => $function_base_command,
-            do_test_base_command   => 1,
+            argument_href              => $argument_href,
+            required_argument_href     => \%required_argument,
+            module_function_cref       => $module_function_cref,
+            function_base_commands_ref => \@function_base_commands,
+            do_test_base_command       => 1,
         }
     );
 }

--- a/t/snpsift_dbnsfp.t
+++ b/t/snpsift_dbnsfp.t
@@ -99,12 +99,12 @@ diag(   q{Test snpsift_dbnsfp from snpsift_annotate.pm v}
       . $EXECUTABLE_NAME );
 
 ## Base arguments
-my $function_base_command = q{dbnsfp};
+my @function_base_commands = qw{ dbnsfp };
 
 my %base_argument = (
     FILEHANDLE => {
         input           => undef,
-        expected_output => $function_base_command,
+        expected_output => \@function_base_commands,
     },
     stderrfile_path => {
         input           => q{stderrfile.test},
@@ -164,11 +164,11 @@ ARGUMENT_HASH_REF:
 foreach my $argument_href (@arguments) {
     my @commands = test_function(
         {
-            argument_href          => $argument_href,
-            required_argument_href => \%required_argument,
-            module_function_cref   => $module_function_cref,
-            function_base_command  => $function_base_command,
-            do_test_base_command   => 1,
+            argument_href              => $argument_href,
+            required_argument_href     => \%required_argument,
+            module_function_cref       => $module_function_cref,
+            function_base_commands_ref => \@function_base_commands,
+            do_test_base_command       => 1,
         }
     );
 }

--- a/t/star_aln.t
+++ b/t/star_aln.t
@@ -108,7 +108,7 @@ Readonly my $CHIM_SEGMENT_READ_GAP_MAX  => 3;
 Readonly my $LIMIT_BAM_SORT_RAM         => 315_321_372_30;
 Readonly my $THREAD_NUMBER              => 16;
 
-my $function_base_command = q{STAR};
+my @function_base_commands = qw{ STAR };
 
 my %base_argument = (
     stdoutfile_path => {
@@ -125,7 +125,7 @@ my %base_argument = (
     },
     FILEHANDLE => {
         input           => undef,
-        expected_output => $function_base_command,
+        expected_output => \@function_base_commands,
     },
 );
 
@@ -230,7 +230,8 @@ my %specific_argument = (
     read_files_command => {
         input           => q{gunzip} . $SPACE . q{-c},
         expected_output => q{--readFilesCommand}
-          . $SPACE . q{gunzip}
+          . $SPACE
+          . q{gunzip}
           . $SPACE . q{-c},
     },
     thread_number => {
@@ -252,11 +253,11 @@ ARGUMENT_HASH_REF:
 foreach my $argument_href (@arguments) {
     my @commands = test_function(
         {
-            argument_href          => $argument_href,
-            required_argument_href => \%required_argument,
-            module_function_cref   => $module_function_cref,
-            function_base_command  => $function_base_command,
-            do_test_base_command   => 1,
+            argument_href              => $argument_href,
+            required_argument_href     => \%required_argument,
+            module_function_cref       => $module_function_cref,
+            function_base_commands_ref => \@function_base_commands,
+            do_test_base_command       => 1,
         }
     );
 }

--- a/t/star_fusion.t
+++ b/t/star_fusion.t
@@ -102,7 +102,7 @@ diag(   q{Test star_fusion from Star_fusion.pm v}
 Readonly my $READ_LENGTH   => 150;
 Readonly my $THREAD_NUMBER => 16;
 
-my $function_base_command = q{STAR-Fusion};
+my @function_base_commands = qw{ STAR-Fusion };
 
 my %base_argument = (
     stdoutfile_path => {
@@ -119,7 +119,7 @@ my %base_argument = (
     },
     FILEHANDLE => {
         input           => undef,
-        expected_output => $function_base_command,
+        expected_output => \@function_base_commands,
     },
 );
 
@@ -169,11 +169,11 @@ ARGUMENT_HASH_REF:
 foreach my $argument_href (@arguments) {
     my @commands = test_function(
         {
-            argument_href          => $argument_href,
-            required_argument_href => \%required_argument,
-            module_function_cref   => $module_function_cref,
-            function_base_command  => $function_base_command,
-            do_test_base_command   => 1,
+            argument_href              => $argument_href,
+            required_argument_href     => \%required_argument,
+            module_function_cref       => $module_function_cref,
+            function_base_commands_ref => \@function_base_commands,
+            do_test_base_command       => 1,
         }
     );
 }

--- a/t/star_genome_generate.t
+++ b/t/star_genome_generate.t
@@ -102,7 +102,7 @@ diag(   q{Test star_genome_generate from Star.pm v}
 Readonly my $READ_LENGTH   => 150;
 Readonly my $THREAD_NUMBER => 16;
 
-my $function_base_command = q{STAR --runMode genomeGenerate};
+my @function_base_commands = qw{ STAR --runMode genomeGenerate };
 
 my %base_argument = (
     stdoutfile_path => {
@@ -119,7 +119,7 @@ my %base_argument = (
     },
     FILEHANDLE => {
         input           => undef,
-        expected_output => $function_base_command,
+        expected_output => \@function_base_commands,
     },
 );
 
@@ -181,11 +181,11 @@ ARGUMENT_HASH_REF:
 foreach my $argument_href (@arguments) {
     my @commands = test_function(
         {
-            argument_href          => $argument_href,
-            required_argument_href => \%required_argument,
-            module_function_cref   => $module_function_cref,
-            function_base_command  => $function_base_command,
-            do_test_base_command   => 1,
+            argument_href              => $argument_href,
+            required_argument_href     => \%required_argument,
+            module_function_cref       => $module_function_cref,
+            function_base_commands_ref => \@function_base_commands,
+            do_test_base_command       => 1,
         }
     );
 }

--- a/t/svdb_merge.t
+++ b/t/svdb_merge.t
@@ -99,12 +99,12 @@ diag(   q{Test svdb_merge from Svdb.pm v}
       . $EXECUTABLE_NAME );
 
 ## Base arguments
-my $function_base_command = q{svdb --merge};
+my @function_base_commands = qw{ svdb --merge };
 
 my %base_argument = (
     FILEHANDLE => {
         input           => undef,
-        expected_output => $function_base_command,
+        expected_output => \@function_base_commands,
     },
     stderrfile_path => {
         input           => q{stderrfile.test},
@@ -166,11 +166,11 @@ ARGUMENT_HASH_REF:
 foreach my $argument_href (@arguments) {
     my @commands = test_function(
         {
-            argument_href          => $argument_href,
-            required_argument_href => \%required_argument,
-            module_function_cref   => $module_function_cref,
-            function_base_command  => $function_base_command,
-            do_test_base_command   => 1,
+            argument_href              => $argument_href,
+            required_argument_href     => \%required_argument,
+            module_function_cref       => $module_function_cref,
+            function_base_commands_ref => \@function_base_commands,
+            do_test_base_command       => 1,
         }
     );
 }

--- a/t/svdb_query.t
+++ b/t/svdb_query.t
@@ -103,12 +103,12 @@ Readonly my $BND_DISTANCE  => 10_000;
 Readonly my $EVENT_OVERLAP => 0.6;
 
 ## Base arguments
-my $function_base_command = q{svdb --query};
+my @function_base_commands = qw{ svdb --query };
 
 my %base_argument = (
     FILEHANDLE => {
         input           => undef,
-        expected_output => $function_base_command,
+        expected_output => \@function_base_commands,
     },
     stderrfile_path => {
         input           => q{stderrfile.test},
@@ -182,11 +182,11 @@ ARGUMENT_HASH_REF:
 foreach my $argument_href (@arguments) {
     my @commands = test_function(
         {
-            argument_href          => $argument_href,
-            required_argument_href => \%required_argument,
-            module_function_cref   => $module_function_cref,
-            function_base_command  => $function_base_command,
-            do_test_base_command   => 1,
+            argument_href              => $argument_href,
+            required_argument_href     => \%required_argument,
+            module_function_cref       => $module_function_cref,
+            function_base_commands_ref => \@function_base_commands,
+            do_test_base_command       => 1,
         }
     );
 }

--- a/t/tar.t
+++ b/t/tar.t
@@ -100,7 +100,7 @@ diag(   q{Test tar from Tar.pm v}
       . $EXECUTABLE_NAME );
 
 ## Base arguments
-my $function_base_command = q{tar};
+my @function_base_commands = qw{ tar };
 
 my %base_argument = (
     stdoutfile_path => {
@@ -117,7 +117,7 @@ my %base_argument = (
     },
     FILEHANDLE => {
         input           => undef,
-        expected_output => $function_base_command,
+        expected_output => \@function_base_commands,
     },
 );
 
@@ -126,7 +126,7 @@ my %base_argument = (
 my %required_argument = (
     FILEHANDLE => {
         input           => undef,
-        expected_output => $function_base_command,
+        expected_output => \@function_base_commands,
     },
 );
 
@@ -140,16 +140,16 @@ my %specific_argument = (
         expected_output => q{-z},
     },
     file_path => {
-        input           => catfile( qw{ path to file } ),
-        expected_output => q{--file=} . catfile( qw{ path to file } ),
+        input           => catfile(qw{ path to file }),
+        expected_output => q{--file=} . catfile(qw{ path to file }),
     },
     outdirectory_path => {
-        input           => catdir( qw{ a test dir } ),
-        expected_output => q{--directory=} . catdir( qw{a test dir} ),
+        input           => catdir(qw{ a test dir }),
+        expected_output => q{--directory=} . catdir(qw{a test dir}),
     },
     FILEHANDLE => {
         input           => undef,
-        expected_output => $function_base_command,
+        expected_output => \@function_base_commands,
     },
 );
 
@@ -163,11 +163,11 @@ ARGUMENT_HASH_REF:
 foreach my $argument_href (@arguments) {
     my @commands = test_function(
         {
-            argument_href          => $argument_href,
-            required_argument_href => \%required_argument,
-            module_function_cref   => $module_function_cref,
-            function_base_command  => $function_base_command,
-            do_test_base_command   => 1,
+            argument_href              => $argument_href,
+            required_argument_href     => \%required_argument,
+            module_function_cref       => $module_function_cref,
+            function_base_commands_ref => \@function_base_commands,
+            do_test_base_command       => 1,
         }
     );
 }

--- a/t/theta.t
+++ b/t/theta.t
@@ -99,12 +99,12 @@ diag(   q{Test run_theta from Theta.pm v}
       . $EXECUTABLE_NAME );
 
 ## Base arguments
-my $function_base_command = q{RunTHetA};
+my @function_base_commands = qw{ RunTHetA };
 
 my %base_argument = (
     FILEHANDLE => {
         input           => undef,
-        expected_output => $function_base_command,
+        expected_output => \@function_base_commands,
     },
     stderrfile_path => {
         input           => q{stderrfile.test},
@@ -176,11 +176,11 @@ ARGUMENT_HASH_REF:
 foreach my $argument_href (@arguments) {
     my @commands = test_function(
         {
-            argument_href          => $argument_href,
-            do_test_base_command   => 1,
-            function_base_command  => $function_base_command,
-            module_function_cref   => $module_function_cref,
-            required_argument_href => \%required_argument,
+            argument_href              => $argument_href,
+            do_test_base_command       => 1,
+            function_base_commands_ref => \@function_base_commands,
+            module_function_cref       => $module_function_cref,
+            required_argument_href     => \%required_argument,
         }
     );
 }

--- a/t/tiddit_coverage.t
+++ b/t/tiddit_coverage.t
@@ -100,12 +100,12 @@ diag(   q{Test tiddit_coverage from Tiddit.pm v}
       . $EXECUTABLE_NAME );
 
 ## Base arguments
-my $function_base_command = q{TIDDIT.py --cov};
+my @function_base_commands = qw{ TIDDIT.py --cov };
 
 my %base_argument = (
     FILEHANDLE => {
         input           => undef,
-        expected_output => $function_base_command,
+        expected_output => \@function_base_commands,
     },
     stderrfile_path => {
         input           => q{stderrfile.test},
@@ -151,11 +151,11 @@ ARGUMENT_HASH_REF:
 foreach my $argument_href (@arguments) {
     my @commands = test_function(
         {
-            argument_href          => $argument_href,
-            do_test_base_command   => 1,
-            function_base_command  => $function_base_command,
-            module_function_cref   => $module_function_cref,
-            required_argument_href => \%required_argument,
+            argument_href              => $argument_href,
+            do_test_base_command       => 1,
+            function_base_commands_ref => \@function_base_commands,
+            module_function_cref       => $module_function_cref,
+            required_argument_href     => \%required_argument,
         }
     );
 }

--- a/t/tiddit_sv.t
+++ b/t/tiddit_sv.t
@@ -100,12 +100,12 @@ diag(   q{Test tiddit_sv from Tiddit.pm v}
       . $EXECUTABLE_NAME );
 
 ## Base arguments
-my $function_base_command = q{TIDDIT.py};
+my @function_base_commands = qw{ TIDDIT.py };
 
 my %base_argument = (
     FILEHANDLE => {
         input           => undef,
-        expected_output => $function_base_command,
+        expected_output => \@function_base_commands,
     },
     stderrfile_path => {
         input           => q{stderrfile.test},
@@ -167,11 +167,11 @@ ARGUMENT_HASH_REF:
 foreach my $argument_href (@arguments) {
     my @commands = test_function(
         {
-            argument_href          => $argument_href,
-            do_test_base_command   => 1,
-            function_base_command  => $function_base_command,
-            module_function_cref   => $module_function_cref,
-            required_argument_href => \%required_argument,
+            argument_href              => $argument_href,
+            do_test_base_command       => 1,
+            function_base_commands_ref => \@function_base_commands,
+            module_function_cref       => $module_function_cref,
+            required_argument_href     => \%required_argument,
         }
     );
 }

--- a/t/unix_standard_streams.t
+++ b/t/unix_standard_streams.t
@@ -84,7 +84,7 @@ diag(
 );
 
 ## Base arguments
-my $function_base_command = '1> stdoutfile.test';
+my @function_base_commands = '1> stdoutfile.test';
 
 ## Can be duplicated with %base and/or %specific to enable testing of each individual argument
 my %required_argument = (
@@ -109,7 +109,7 @@ my %specific_argument = (
     },
     FILEHANDLE => {
         input           => undef,
-        expected_output => $function_base_command,
+        expected_output => \@function_base_commands,
     },
 );
 
@@ -123,10 +123,10 @@ foreach my $argument_href (@arguments) {
 
     my @commands = test_function(
         {
-            argument_href          => $argument_href,
-            required_argument_href => \%required_argument,
-            module_function_cref   => $module_function_cref,
-            function_base_command  => $function_base_command,
+            argument_href              => $argument_href,
+            required_argument_href     => \%required_argument,
+            module_function_cref       => $module_function_cref,
+            function_base_commands_ref => \@function_base_commands,
         }
     );
 }

--- a/t/unix_write_to_file.t
+++ b/t/unix_write_to_file.t
@@ -110,7 +110,7 @@ my @commands = ( q{commands_ref}, [qw{ test in-line }] );
 test_write_to_file(
     {
         args_ref             => \@commands,
-        base_command         => q{test in-line},
+        base_commands_ref    => [qw{ test in-line }],
         module_function_cref => $module_function_cref,
     }
 );
@@ -120,7 +120,7 @@ test_write_to_file(
 test_write_to_file(
     {
         args_ref             => \@commands,
-        base_command         => q{test},
+        base_commands_ref    => [qw{ test }],
         module_function_cref => $module_function_cref,
         separator            => q{\n},
     }

--- a/t/unzip.t
+++ b/t/unzip.t
@@ -100,7 +100,7 @@ diag(   q{Test unzip from Zip.pm v}
       . $EXECUTABLE_NAME );
 
 ## Base arguments
-my $function_base_command = q{unzip};
+my @function_base_commands = qw{ unzip };
 
 my %base_argument = (
     stderrfile_path => {
@@ -113,7 +113,7 @@ my %base_argument = (
     },
     FILEHANDLE => {
         input           => undef,
-        expected_output => $function_base_command,
+        expected_output => \@function_base_commands,
     },
 );
 
@@ -121,27 +121,27 @@ my %base_argument = (
 ## to enable testing of each individual argument
 my %required_argument = (
     infile_path => {
-        input           => catfile( qw{ path to file } ),
-        expected_output => catfile( qw{ path to file } ),
+        input           => catfile(qw{ path to file }),
+        expected_output => catfile(qw{ path to file }),
     },
 );
 
 my %specific_argument = (
     outdir_path => {
         input           => catdir(qw{ a test path }),
-        expected_output => q{-d} . $SPACE . catdir( qw{ a test path } ),
+        expected_output => q{-d} . $SPACE . catdir(qw{ a test path }),
     },
     stdout => {
         input           => 1,
         expected_output => q{-p},
     },
     infile_path => {
-        input           => catfile( qw{ path to file } ),
-        expected_output => catfile( qw{ path to file } ),
+        input           => catfile(qw{ path to file }),
+        expected_output => catfile(qw{ path to file }),
     },
     FILEHANDLE => {
         input           => undef,
-        expected_output => $function_base_command,
+        expected_output => \@function_base_commands,
     },
     quiet => {
         input           => 1,
@@ -167,11 +167,11 @@ ARGUMENT_HASH_REF:
 foreach my $argument_href (@arguments) {
     my @commands = test_function(
         {
-            argument_href          => $argument_href,
-            required_argument_href => \%required_argument,
-            module_function_cref   => $module_function_cref,
-            function_base_command  => $function_base_command,
-            do_test_base_command   => 1,
+            argument_href              => $argument_href,
+            required_argument_href     => \%required_argument,
+            module_function_cref       => $module_function_cref,
+            function_base_commands_ref => \@function_base_commands,
+            do_test_base_command       => 1,
         }
     );
 }

--- a/t/update_core_number_to_seq_mode.t
+++ b/t/update_core_number_to_seq_mode.t
@@ -59,9 +59,7 @@ BEGIN {
 
 ### Check all internal dependency modules and imports
     ## Modules with import
-    my %perl_module = (
-        'MIP::Script::Utils'       => [qw{help}],
-    );
+    my %perl_module = ( 'MIP::Script::Utils' => [qw{help}], );
 
     while ( my ( $module, $module_import ) = each %perl_module ) {
 
@@ -81,10 +79,11 @@ BEGIN {
 use MIP::Cluster qw(update_core_number_to_seq_mode);
 
 diag(
-    "Test update_core_number_to_seq_mode $MIP::Cluster::VERSION, Perl $^V, $EXECUTABLE_NAME" );
+"Test update_core_number_to_seq_mode $MIP::Cluster::VERSION, Perl $^V, $EXECUTABLE_NAME"
+);
 
 # Core number to test
-Readonly my $CORE_NUMBER   => 1;
+Readonly my $CORE_NUMBER => 1;
 
 my @sequence_run_types = qw(paired-end single-end);
 
@@ -92,12 +91,13 @@ my @returned_core_numbers;
 
 foreach my $sequence_run_type (@sequence_run_types) {
 
-  push @returned_core_numbers, update_core_number_to_seq_mode(
-							      {
-							       core_number => $CORE_NUMBER,
-							       sequence_run_type => $sequence_run_type,
-							      }
-							     );
+    push @returned_core_numbers,
+      update_core_number_to_seq_mode(
+        {
+            core_number       => $CORE_NUMBER,
+            sequence_run_type => $sequence_run_type,
+        }
+      );
 }
 
 ## Test

--- a/t/update_vcfparser_outfile_counter.t
+++ b/t/update_vcfparser_outfile_counter.t
@@ -99,8 +99,8 @@ diag(   q{Test update_vcfparser_outfile_counter from Parameters.pm v}
 
 # Test the number of oufiles when vcfparser is used with select file and sv_vcfparser without.
 my %active_parameter_test = (
-    sv_vcfparser         => { type => q{program} },
-    vcfparser            => { type => q{program} },
+    sv_vcfparser          => { type => q{program} },
+    vcfparser             => { type => q{program} },
     vcfparser_select_file => 1,
 );
 
@@ -114,8 +114,8 @@ is( $active_parameter_test{sv_vcfparser_outfile_count},
 
 # Test the number of oufiles when both vcfparser and sv_vcfparser are used with select files.
 %active_parameter_test = (
-    sv_vcfparser            => { type => q{program} },
-    vcfparser               => { type => q{program} },
+    sv_vcfparser             => { type => q{program} },
+    vcfparser                => { type => q{program} },
     sv_vcfparser_select_file => 1,
     vcfparser_select_file    => 1,
 );

--- a/t/vardict.t
+++ b/t/vardict.t
@@ -101,12 +101,12 @@ diag(   q{Test vardict from Vardict.pm v}
       . $EXECUTABLE_NAME );
 
 ## Base arguments
-my $function_base_command = q{vardict};
+my @function_base_commands = qw{ vardict };
 
 my %base_argument = (
     FILEHANDLE => {
         input           => undef,
-        expected_output => $function_base_command,
+        expected_output => \@function_base_commands,
     },
     stderrfile_path => {
         input           => q{stderrfile.test},
@@ -216,11 +216,11 @@ ARGUMENT_HASH_REF:
 foreach my $argument_href (@arguments) {
     my @commands = test_function(
         {
-            argument_href          => $argument_href,
-            required_argument_href => \%required_argument,
-            module_function_cref   => $module_function_cref,
-            function_base_command  => $function_base_command,
-            do_test_base_command   => 1,
+            argument_href              => $argument_href,
+            required_argument_href     => \%required_argument,
+            module_function_cref       => $module_function_cref,
+            function_base_commands_ref => \@function_base_commands,
+            do_test_base_command       => 1,
         }
     );
 }

--- a/t/vardict_testsomatic.t
+++ b/t/vardict_testsomatic.t
@@ -99,12 +99,12 @@ diag(   q{Test testsomatic.R from Vardict.pm}
       . $EXECUTABLE_NAME );
 
 ## Base arguments
-my $function_base_command = q{testsomatic.R};
+my @function_base_commands = qw{ testsomatic.R };
 
 my %base_argument = (
     FILEHANDLE => {
         input           => undef,
-        expected_output => $function_base_command,
+        expected_output => \@function_base_commands,
     },
     stderrfile_path => {
         input           => q{stderrfile.test},
@@ -130,10 +130,10 @@ ARGUMENT_HASH_REF:
 foreach my $argument_href (@arguments) {
     my @commands = test_function(
         {
-            argument_href          => $argument_href,
-            do_test_base_command   => 1,
-            function_base_command  => $function_base_command,
-            module_function_cref   => $module_function_cref,
+            argument_href              => $argument_href,
+            do_test_base_command       => 1,
+            function_base_commands_ref => \@function_base_commands,
+            module_function_cref       => $module_function_cref,
         }
     );
 }

--- a/t/vardict_teststrandbias.t
+++ b/t/vardict_teststrandbias.t
@@ -33,7 +33,6 @@ Readonly my $COMMA   => q{,};
 Readonly my $NEWLINE => qq{\n};
 Readonly my $SPACE   => q{ };
 
-
 ### User Options
 GetOptions(
 
@@ -100,12 +99,12 @@ diag(   q{Test teststrandbias.R from Vardict.pm}
       . $EXECUTABLE_NAME );
 
 ## Base arguments
-my $function_base_command = q{teststrandbias.R};
+my @function_base_commands = qw{ teststrandbias.R };
 
 my %base_argument = (
     FILEHANDLE => {
         input           => undef,
-        expected_output => $function_base_command,
+        expected_output => \@function_base_commands,
     },
     stderrfile_path => {
         input           => q{stderrfile.test},
@@ -131,10 +130,10 @@ ARGUMENT_HASH_REF:
 foreach my $argument_href (@arguments) {
     my @commands = test_function(
         {
-            argument_href         => $argument_href,
-            do_test_base_command  => 1,
-            function_base_command => $function_base_command,
-            module_function_cref  => $module_function_cref,
+            argument_href              => $argument_href,
+            do_test_base_command       => 1,
+            function_base_commands_ref => \@function_base_commands,
+            module_function_cref       => $module_function_cref,
         }
     );
 }

--- a/t/vardict_var2vcf_paired.t
+++ b/t/vardict_var2vcf_paired.t
@@ -101,12 +101,12 @@ diag(   q{Test var2vcf_paired.pl from Vardict.pm}
       . $EXECUTABLE_NAME );
 
 ## Base arguments
-my $function_base_command = q{var2vcf_paired.pl};
+my @function_base_commands = qw{ var2vcf_paired.pl };
 
 my %base_argument = (
     FILEHANDLE => {
         input           => undef,
-        expected_output => $function_base_command,
+        expected_output => \@function_base_commands,
     },
     stderrfile_path => {
         input           => q{stderrfile.test},
@@ -164,11 +164,11 @@ ARGUMENT_HASH_REF:
 foreach my $argument_href (@arguments) {
     my @commands = test_function(
         {
-            argument_href          => $argument_href,
-            do_test_base_command   => 1,
-            function_base_command  => $function_base_command,
-            module_function_cref   => $module_function_cref,
-            required_argument_href => \%required_argument,
+            argument_href              => $argument_href,
+            do_test_base_command       => 1,
+            function_base_commands_ref => \@function_base_commands,
+            module_function_cref       => $module_function_cref,
+            required_argument_href     => \%required_argument,
         }
     );
 }

--- a/t/vardict_var2vcf_single.t
+++ b/t/vardict_var2vcf_single.t
@@ -101,12 +101,12 @@ diag(   q{Test var2vcf_valid.pl from Vardict.pm}
       . $EXECUTABLE_NAME );
 
 ## Base arguments
-my $function_base_command = q{var2vcf_valid.pl};
+my @function_base_commands = qw{ var2vcf_valid.pl };
 
 my %base_argument = (
     FILEHANDLE => {
         input           => undef,
-        expected_output => $function_base_command,
+        expected_output => \@function_base_commands,
     },
     stderrfile_path => {
         input           => q{stderrfile.test},
@@ -160,11 +160,11 @@ ARGUMENT_HASH_REF:
 foreach my $argument_href (@arguments) {
     my @commands = test_function(
         {
-            argument_href          => $argument_href,
-            do_test_base_command   => 1,
-            function_base_command  => $function_base_command,
-            module_function_cref   => $module_function_cref,
-            required_argument_href => \%required_argument,
+            argument_href              => $argument_href,
+            do_test_base_command       => 1,
+            function_base_commands_ref => \@function_base_commands,
+            module_function_cref       => $module_function_cref,
+            required_argument_href     => \%required_argument,
         }
     );
 }

--- a/t/variant_effect_predictor.t
+++ b/t/variant_effect_predictor.t
@@ -102,12 +102,12 @@ diag(   q{Test variant_effect_predictor from Vep.pm v}
 Readonly my $VARIANT_BUFFERT_SIZE => 20_000;
 
 ## Base arguments
-my $function_base_command = q{vep};
+my @function_base_commands = qw{ vep };
 
 my %base_argument = (
     FILEHANDLE => {
         input           => undef,
-        expected_output => $function_base_command,
+        expected_output => \@function_base_commands,
     },
     stderrfile_path => {
         input           => q{stderrfile.test},
@@ -128,7 +128,7 @@ my %base_argument = (
 my %required_argument = (
     FILEHANDLE => {
         input           => undef,
-        expected_output => $function_base_command,
+        expected_output => \@function_base_commands,
     },
 );
 
@@ -153,7 +153,7 @@ my %specific_argument = (
     },
     FILEHANDLE => {
         input           => undef,
-        expected_output => $function_base_command,
+        expected_output => \@function_base_commands,
     },
     fork => {
         input           => 1,
@@ -215,11 +215,11 @@ HASHES_OF_ARGUMENTS:
 foreach my $argument_href (@arguments) {
     my @commands = test_function(
         {
-            argument_href          => $argument_href,
-            required_argument_href => \%required_argument,
-            module_function_cref   => $module_function_cref,
-            function_base_command  => $function_base_command,
-            do_test_base_command   => 1,
+            argument_href              => $argument_href,
+            required_argument_href     => \%required_argument,
+            module_function_cref       => $module_function_cref,
+            function_base_commands_ref => \@function_base_commands,
+            do_test_base_command       => 1,
         }
     );
 }

--- a/t/variant_effect_predictor_install.t
+++ b/t/variant_effect_predictor_install.t
@@ -101,7 +101,7 @@ diag(   q{Test variant_effect_predictor_install from Vep.pm v}
       . $EXECUTABLE_NAME );
 
 ## Base arguments
-my $function_base_command = q{perl};
+my @function_base_commands = qw{ perl };
 
 my %base_argument = (
     stdoutfile_path => {
@@ -118,7 +118,7 @@ my %base_argument = (
     },
     FILEHANDLE => {
         input           => undef,
-        expected_output => $function_base_command,
+        expected_output => \@function_base_commands,
     },
 );
 
@@ -127,7 +127,7 @@ my %base_argument = (
 my %required_argument = (
     FILEHANDLE => {
         input           => undef,
-        expected_output => $function_base_command,
+        expected_output => \@function_base_commands,
     },
 );
 
@@ -166,7 +166,7 @@ my %specific_argument = (
     },
     FILEHANDLE => {
         input           => undef,
-        expected_output => $function_base_command,
+        expected_output => \@function_base_commands,
     },
 );
 
@@ -180,11 +180,11 @@ ARGUMENT_HASH_REF:
 foreach my $argument_href (@arguments) {
     my @commands = test_function(
         {
-            argument_href          => $argument_href,
-            required_argument_href => \%required_argument,
-            module_function_cref   => $module_function_cref,
-            function_base_command  => $function_base_command,
-            do_test_base_command   => 1,
+            argument_href              => $argument_href,
+            required_argument_href     => \%required_argument,
+            module_function_cref       => $module_function_cref,
+            function_base_commands_ref => \@function_base_commands,
+            do_test_base_command       => 1,
         }
     );
 }

--- a/t/variant_integrity_father.t
+++ b/t/variant_integrity_father.t
@@ -97,7 +97,7 @@ diag(   q{Test variant_integrity_father from Variant_integrity v}
       . $EXECUTABLE_NAME );
 
 ## Base arguments
-my $function_base_command = q{variant_integrity};
+my @function_base_commands = qw{ variant_integrity };
 
 my %base_argument = (
     stderrfile_path => {
@@ -110,7 +110,7 @@ my %base_argument = (
     },
     FILEHANDLE => {
         input           => undef,
-        expected_output => $function_base_command,
+        expected_output => \@function_base_commands,
     },
 );
 
@@ -152,11 +152,11 @@ HASHES_OF_ARGUMENTS:
 foreach my $argument_href (@arguments) {
     my @commands = test_function(
         {
-            argument_href          => $argument_href,
-            required_argument_href => \%required_argument,
-            module_function_cref   => $module_function_cref,
-            function_base_command  => $function_base_command,
-            do_test_base_command   => 1,
+            argument_href              => $argument_href,
+            required_argument_href     => \%required_argument,
+            module_function_cref       => $module_function_cref,
+            function_base_commands_ref => \@function_base_commands,
+            do_test_base_command       => 1,
         }
     );
 }

--- a/t/variant_integrity_mendel.t
+++ b/t/variant_integrity_mendel.t
@@ -97,7 +97,7 @@ diag(   q{Test variant_integrity_mendel from Variant_integrity v}
       . $EXECUTABLE_NAME );
 
 ## Base arguments
-my $function_base_command = q{variant_integrity};
+my @function_base_commands = qw{ variant_integrity };
 
 my %base_argument = (
     stderrfile_path => {
@@ -110,7 +110,7 @@ my %base_argument = (
     },
     FILEHANDLE => {
         input           => undef,
-        expected_output => $function_base_command,
+        expected_output => \@function_base_commands,
     },
 );
 
@@ -152,11 +152,11 @@ HASHES_OF_ARGUMENTS:
 foreach my $argument_href (@arguments) {
     my @commands = test_function(
         {
-            argument_href          => $argument_href,
-            required_argument_href => \%required_argument,
-            module_function_cref   => $module_function_cref,
-            function_base_command  => $function_base_command,
-            do_test_base_command   => 1,
+            argument_href              => $argument_href,
+            required_argument_href     => \%required_argument,
+            module_function_cref       => $module_function_cref,
+            function_base_commands_ref => \@function_base_commands,
+            do_test_base_command       => 1,
         }
     );
 }

--- a/t/vcf2cytosure.t
+++ b/t/vcf2cytosure.t
@@ -101,12 +101,12 @@ diag(   q{Test vcf2cytosure_convert from Vcf2cytosure.pm v}
       . $EXECUTABLE_NAME );
 
 ## Base arguments
-my $function_base_command = q{vcf2cytosure};
+my @function_base_commands = qw{ vcf2cytosure };
 
 my %base_argument = (
     FILEHANDLE => {
         input           => undef,
-        expected_output => $function_base_command,
+        expected_output => \@function_base_commands,
     },
     stderrfile_path => {
         input           => q{stderrfile.test},
@@ -174,11 +174,11 @@ ARGUMENT_HASH_REF:
 foreach my $argument_href (@arguments) {
     my @commands = test_function(
         {
-            argument_href          => $argument_href,
-            do_test_base_command   => 1,
-            function_base_command  => $function_base_command,
-            module_function_cref   => $module_function_cref,
-            required_argument_href => \%required_argument,
+            argument_href              => $argument_href,
+            do_test_base_command       => 1,
+            function_base_commands_ref => \@function_base_commands,
+            module_function_cref       => $module_function_cref,
+            required_argument_href     => \%required_argument,
         }
     );
 }

--- a/t/vcfanno.t
+++ b/t/vcfanno.t
@@ -99,12 +99,12 @@ diag(   q{Test vcfanno from Vcfanno.pm v}
       . $EXECUTABLE_NAME );
 
 ## Base arguments
-my $function_base_command = q{vcfanno};
+my @function_base_commands = qw{ vcfanno };
 
 my %base_argument = (
     FILEHANDLE => {
         input           => undef,
-        expected_output => $function_base_command,
+        expected_output => \@function_base_commands,
     },
     stderrfile_path => {
         input           => q{stderrfile.test},
@@ -158,11 +158,11 @@ ARGUMENT_HASH_REF:
 foreach my $argument_href (@arguments) {
     my @commands = test_function(
         {
-            argument_href          => $argument_href,
-            required_argument_href => \%required_argument,
-            module_function_cref   => $module_function_cref,
-            function_base_command  => $function_base_command,
-            do_test_base_command   => 1,
+            argument_href              => $argument_href,
+            required_argument_href     => \%required_argument,
+            module_function_cref       => $module_function_cref,
+            function_base_commands_ref => \@function_base_commands,
+            do_test_base_command       => 1,
         }
     );
 }

--- a/t/vt_decompose.t
+++ b/t/vt_decompose.t
@@ -99,12 +99,12 @@ diag(   q{Test vt_decompose from Vt.pm v}
       . $EXECUTABLE_NAME );
 
 ## Base arguments
-my $function_base_command = q{vt decompose};
+my @function_base_commands = qw{ vt decompose };
 
 my %base_argument = (
     FILEHANDLE => {
         input           => undef,
-        expected_output => $function_base_command,
+        expected_output => \@function_base_commands,
     },
     stderrfile_path => {
         input           => q{stderrfile.test},
@@ -150,11 +150,11 @@ ARGUMENT_HASH_REF:
 foreach my $argument_href (@arguments) {
     my @commands = test_function(
         {
-            argument_href          => $argument_href,
-            required_argument_href => \%required_argument,
-            module_function_cref   => $module_function_cref,
-            function_base_command  => $function_base_command,
-            do_test_base_command   => 1,
+            argument_href              => $argument_href,
+            required_argument_href     => \%required_argument,
+            module_function_cref       => $module_function_cref,
+            function_base_commands_ref => \@function_base_commands,
+            do_test_base_command       => 1,
         }
     );
 }

--- a/t/vt_normalize.t
+++ b/t/vt_normalize.t
@@ -99,12 +99,12 @@ diag(   q{Test vt_normalize from Vt.pm v}
       . $EXECUTABLE_NAME );
 
 ## Base arguments
-my $function_base_command = q{vt normalize};
+my @function_base_commands = qw{ vt normalize };
 
 my %base_argument = (
     FILEHANDLE => {
         input           => undef,
-        expected_output => $function_base_command,
+        expected_output => \@function_base_commands,
     },
     stderrfile_path => {
         input           => q{stderrfile.test},
@@ -156,11 +156,11 @@ ARGUMENT_HASH_REF:
 foreach my $argument_href (@arguments) {
     my @commands = test_function(
         {
-            argument_href          => $argument_href,
-            required_argument_href => \%required_argument,
-            module_function_cref   => $module_function_cref,
-            function_base_command  => $function_base_command,
-            do_test_base_command   => 1,
+            argument_href              => $argument_href,
+            required_argument_href     => \%required_argument,
+            module_function_cref       => $module_function_cref,
+            function_base_commands_ref => \@function_base_commands,
+            do_test_base_command       => 1,
         }
     );
 }

--- a/t/vt_uniq.t
+++ b/t/vt_uniq.t
@@ -99,12 +99,12 @@ diag(   q{Test vt_uniq from Vt.pm v}
       . $EXECUTABLE_NAME );
 
 ## Base arguments
-my $function_base_command = q{vt uniq};
+my @function_base_commands = qw{ vt uniq };
 
 my %base_argument = (
     FILEHANDLE => {
         input           => undef,
-        expected_output => $function_base_command,
+        expected_output => \@function_base_commands,
     },
     stderrfile_path => {
         input           => q{stderrfile.test},
@@ -146,11 +146,11 @@ ARGUMENT_HASH_REF:
 foreach my $argument_href (@arguments) {
     my @commands = test_function(
         {
-            argument_href          => $argument_href,
-            required_argument_href => \%required_argument,
-            module_function_cref   => $module_function_cref,
-            function_base_command  => $function_base_command,
-            do_test_base_command   => 1,
+            argument_href              => $argument_href,
+            required_argument_href     => \%required_argument,
+            module_function_cref       => $module_function_cref,
+            function_base_commands_ref => \@function_base_commands,
+            do_test_base_command       => 1,
         }
     );
 }

--- a/t/wget.t
+++ b/t/wget.t
@@ -100,7 +100,7 @@ diag(   q{Test wget from Wget.pm v}
       . $EXECUTABLE_NAME );
 
 ## Base arguments
-my $function_base_command = q{wget};
+my @function_base_commands = qw{ wget };
 
 my %base_argument = (
     stdoutfile_path => {
@@ -117,7 +117,7 @@ my %base_argument = (
     },
     FILEHANDLE => {
         input           => undef,
-        expected_output => $function_base_command,
+        expected_output => \@function_base_commands,
     },
 );
 
@@ -130,7 +130,7 @@ my %required_argument = (
     },
     FILEHANDLE => {
         input           => undef,
-        expected_output => $function_base_command,
+        expected_output => \@function_base_commands,
     },
 );
 
@@ -163,11 +163,11 @@ ARGUMENT_HASH_REF:
 foreach my $argument_href (@arguments) {
     my @commands = test_function(
         {
-            argument_href          => $argument_href,
-            required_argument_href => \%required_argument,
-            module_function_cref   => $module_function_cref,
-            function_base_command  => $function_base_command,
-            do_test_base_command   => 1,
+            argument_href              => $argument_href,
+            required_argument_href     => \%required_argument,
+            module_function_cref       => $module_function_cref,
+            function_base_commands_ref => \@function_base_commands,
+            do_test_base_command       => 1,
         }
     );
 }

--- a/templates/code/test.t
+++ b/templates/code/test.t
@@ -23,7 +23,7 @@ use lib catdir( dirname($Bin), q{lib} );
 use MIP::Test::Fixtures qw{ test_standard_cli };
 
 my $VERBOSE = 1;
-our $VERSION = '1.0.0';
+our $VERSION = 1.00;
 
 $VERBOSE = test_standard_cli(
     {

--- a/templates/code/test_commands.t
+++ b/templates/code/test_commands.t
@@ -1,6 +1,6 @@
 #!/usr/bin/env perl
 
-use 5.018;
+use 5.026;
 use Carp;
 use charnames qw{ :full :short };
 use English qw{ -no_match_vars };
@@ -23,7 +23,7 @@ use lib catdir( dirname($Bin), q{lib} );
 use MIP::Test::Fixtures qw{ test_standard_cli };
 
 my $VERBOSE = 1;
-our $VERSION = 1.0.0;
+our $VERSION = 1.00;
 
 $VERBOSE = test_standard_cli(
     {
@@ -60,12 +60,12 @@ diag(   q{Test SUB_ROUTINE from MODULE_NAME.pm v}
       . $EXECUTABLE_NAME );
 
 ## Base arguments
-my $function_base_command = q{BASE_COMMAND};
+my @function_base_commands = qw{ BASE_COMMAND };
 
 my %base_argument = (
     FILEHANDLE => {
         input           => undef,
-        expected_output => $function_base_command,
+        expected_output => \@function_base_commands,
     },
     stderrfile_path => {
         input           => q{stderrfile.test},
@@ -116,11 +116,11 @@ foreach my $argument_href (@arguments) {
 
     my @commands = test_function(
         {
-            argument_href          => $argument_href,
-            do_test_base_command   => 1,
-            function_base_command  => $function_base_command,
-            module_function_cref   => $module_function_cref,
-            required_argument_href => \%required_argument,
+            argument_href              => $argument_href,
+            do_test_base_command       => 1,
+            function_base_commands_ref => \@function_base_commands,
+            module_function_cref       => $module_function_cref,
+            required_argument_href     => \%required_argument,
         }
     );
 }

--- a/templates/code/test_recipe.t
+++ b/templates/code/test_recipe.t
@@ -24,7 +24,7 @@ use lib catdir( dirname($Bin), q{lib} );
 use MIP::Test::Fixtures qw{ test_log test_mip_hashes test_standard_cli };
 
 my $VERBOSE = 1;
-our $VERSION = '1.0.0';
+our $VERSION = 1.00;
 
 $VERBOSE = test_standard_cli(
     {


### PR DESCRIPTION
Changes: 
- The base command in command tests have been changed from a string to an array
- Updated the test template to reflect the new changes
- The test template have been updated to use perl 5.26 
- The template has been updated to use the syntax ``our $VERSION = 1.00;``

Have not updated the version, version syntax and perl version on all the changed tests. I only changed this on the tests that I edited manually. At least the perl version should be quite easy to change with a regex later.