### PR TITLE
Change travis badge to reflect build status on master

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # MIP - Mutation Identification Pipeline
 
-[![Build Status](https://travis-ci.org/Clinical-Genomics/MIP.svg?branch=develop)](https://travis-ci.org/Clinical-Genomics/MIP)
+[![Build Status](https://travis-ci.org/Clinical-Genomics/MIP.svg?branch=master)](https://travis-ci.org/Clinical-Genomics/MIP)
 
 MIP enables identification of potential disease causing variants from sequencing data.
 


### PR DESCRIPTION
The travis badge on MIP's master branch reflected the build status for the develop branch