### PR TITLE
program for running mip code checks

### DIFF
--- a/.perlcriticrc_mip
+++ b/.perlcriticrc_mip
@@ -1,0 +1,5 @@
+## Modifications to perl critic policies for MIP development
+
+## Increase the number of lines between open and close filhandle, default 9
+[InputOutput::RequireBriefOpen]
+lines = 100

--- a/.perlcriticrc_mip
+++ b/.perlcriticrc_mip
@@ -1,5 +1,9 @@
 ## Modifications to perl critic policies for MIP development
 
-## Increase the number of lines between open and close filhandle, default 9
+## Increase the number of lines between open and close filehandle, default 9
 [InputOutput::RequireBriefOpen]
 lines = 100
+
+[InputOutput::RequireCheckedSyscalls]
+functions = :builtins
+exclude_functions = print say

--- a/documentation/Code/Best_practise.md
+++ b/documentation/Code/Best_practise.md
@@ -1,9 +1,26 @@
 # Perl Best Practices
 
-Following best practices is a good way to create maintainable and readable code and should always be encouraged. However, learning what these best practices are and when they apply in the context of your code can be hard to determine. Luckily, there are several tools to help guide you on your way. 
+Following best practices is a good way to create maintainable and readable code and should always be encouraged. However, learning what these best practices are and when they apply in the context of your code can be hard to determine. Luckily, there are several tools to help guide you on your way.
 
 ## Code standards
 All code that are present with MIP has to be processed by both [Perltidy] and [Perlcritic].
+
+### mip-check
+MIP supplies a bash script that runs Perlcritic and Perltidy on perl scripts. Perltidy modifies the files in place and the files are then analyzed by Perl critic with a level 1 severity with a few exceptions as specified in the .perlcriticrc_mip file.
+
+Which files to operate on are supplied on the command line. If no files are given the script uses `git status` to check for new and modified perl scripts and uses that as input.
+
+#### Examples
+```bash
+## Run mip-check on newly edited files
+bash mip-check
+
+## Run mip-check on two files at level 2 severity
+bash mip-check -s 2 somefile1.pl somefile2.pm
+
+## Run mip-check on all files in a directory
+bash mip-check lib/MIP/Check/*
+```
 
 ### Perl Critic
 
@@ -15,9 +32,9 @@ Perl critic allows different degrees of severity. Severity values are integers r
 
 ```
 perlcritic --severity 4 --verbose 11 my_perl_script.pl
-``` 
+```
 
-Perl critic also has [web interface] to instantly analyze your code. 
+Perl critic also has [web interface] to instantly analyze your code.
 
 
 ### Perl Tidy

--- a/mip-check
+++ b/mip-check
@@ -2,17 +2,17 @@
 
 version=0.01
 
-usage="$(basename "$0") [-h] [-s n] FILES[OPTIONAL]
-Program for tidying perl scripts and running perl critic. Default input files are new and modified files. 
+usage="$(basename "$0") [-h] [-v] [-s n] FILES[OPTIONAL]
+Program for tidying perl scripts and running perl critic. Default input files are new and modified files.
 Version: $version
 
 where:
     -h  show this help text
-    -s  set the perl critic severity (default: 2)
-	-v  show version number"
-    
-## Set default severity for perl critic 
-critic_severity=2
+    -s  set the perl critic severity (default: 1)
+    -v  show version number"
+
+## Set default severity for perl critic
+critic_severity=1
 
 while getopts ':hs:v' option; do
     case "$option" in
@@ -26,7 +26,7 @@ while getopts ':hs:v' option; do
             exit 1
             ;;
 		v) echo "Version: $version"
-			exit 
+			exit
 			;;
         \?) printf "illegal option: -%s\n" "$OPTARG" >&2
             echo "$usage" >&2
@@ -59,8 +59,8 @@ do
 
     ## Run perltidy
     perltidy --maximum-line-length=90 --iterations=2 -b -bext='/' $infile
-    
-    ## Run perlcritic 
+
+    ## Run perlcritic
     perlcritic \-${critic_severity} \-p ${mip_dir}/.perlcriticrc_mip $infile
 
 done

--- a/mip-check
+++ b/mip-check
@@ -1,0 +1,66 @@
+#!/usr/bin/env bash
+
+version=0.01
+
+usage="$(basename "$0") [-h] [-s n] FILES[OPTIONAL]
+Program for tidying perl scripts and running perl critic. Default input files are new and modified files. 
+Version: $version
+
+where:
+    -h  show this help text
+    -s  set the perl critic severity (default: 2)
+	-v  show version number"
+    
+## Set default severity for perl critic 
+critic_severity=2
+
+while getopts ':hs:v' option; do
+    case "$option" in
+        h) echo "$usage"
+            exit
+            ;;
+        s) critic_severity=$OPTARG
+            ;;
+        :) printf "missing argument for -%s\n" "$OPTARG" >&2
+            echo "$usage" >&2
+            exit 1
+            ;;
+		v) echo "Version: $version"
+			exit 
+			;;
+        \?) printf "illegal option: -%s\n" "$OPTARG" >&2
+            echo "$usage" >&2
+            exit 1
+            ;;
+    esac
+done
+shift $((OPTIND - 1))
+
+## Get infiles from command line
+infiles=( "$@" )
+## Otherwise, get infiles from git
+if [ ${#infiles[@]} -lt 1 ] ; then
+    infiles=$(git status --short | perl -nae 'print $F[1] . q{ }')
+fi
+
+## Get current dir
+mip_dir="$(dirname "$(readlink -f "$0")")"
+
+for infile in ${infiles[@]}
+do
+    ## Only operate on perl files
+    if ! [[ $infile =~ .*\.(t|pm|pl)$ ]] ; then
+        echo "Skipping: $infile"
+        continue
+    fi
+
+    echo ""
+    echo "Infile: $infile"
+
+    ## Run perltidy
+    perltidy --maximum-line-length=90 --iterations=2 -b -bext='/' $infile
+    
+    ## Run perlcritic 
+    perlcritic \-${critic_severity} \-p ${mip_dir}/.perlcriticrc_mip $infile
+
+done


### PR DESCRIPTION
Draft for a simple bash script that automates perltidy and perlcritic. As default it runs on the files that are new or have been modified. Perl critic severity has been set to level 2 as default. Increased the code line length to 90 and tried to change the number of lines in between open and close filehandles. 

Later we can include a check to see that the $VERSION line has been updated for modified files. Open for suggestions on how to change it or modify the behaviour of perlcritic and perltidy further (or skip modifications all together)