### PR TITLE
feat(delly_exclude): Added download of exclude file for delly calling

### DIFF
--- a/definitions/download_rd_dna_parameters.yaml
+++ b/definitions/download_rd_dna_parameters.yaml
@@ -85,6 +85,13 @@ dbsnp:
   data_type: SCALAR
   default: 1
   type: recipe
+delly_exclude:
+  analysis_mode: case
+  associated_recipe:
+   - mip
+  data_type: SCALAR
+  default: 1
+  type: recipe
 download_pipeline_type:
   associated_recipe:
    - mip
@@ -164,6 +171,7 @@ recipe_core_number:
     clinvar: 1
     dbnsfp: 1
     dbsnp: 1
+    delly_exclude: 1
     expansionhunter: 1
     genomic_superdups: 1
     giab: 1
@@ -190,6 +198,7 @@ recipe_time:
     clinvar: 1
     dbnsfp: 15
     dbsnp: 1
+    delly_exclude: 1
     expansionhunter: 1
     genomic_superdups: 1
     giab: 1

--- a/definitions/rd_dna_parameters.yaml
+++ b/definitions/rd_dna_parameters.yaml
@@ -663,7 +663,7 @@ delly_exclude_file:
    - delly_call
    - delly_reformat
   data_type: SCALAR
-  default: hg19_human_excl_-0.7.6-.tsv
+  default: hg19_human_excl_-20150227-.tsv
   exists_check: file
   reference: reference_dir
   type: path

--- a/lib/MIP/Recipes/Download/Delly_exclude.pm
+++ b/lib/MIP/Recipes/Download/Delly_exclude.pm
@@ -1,0 +1,205 @@
+package MIP::Recipes::Download::Delly_exclude;
+
+use 5.026;
+use Carp;
+use charnames qw{ :full :short };
+use English qw{ -no_match_vars };
+use File::Basename qw{ dirname };
+use File::Spec::Functions qw{ catfile };
+use open qw{ :encoding(UTF-8) :std };
+use Params::Check qw{ allow check last_error };
+use strict;
+use utf8;
+use warnings;
+use warnings qw{ FATAL utf8 };
+
+## CPANM
+use autodie qw{ :all };
+use Readonly;
+
+## MIPs lib/
+use MIP::Constants qw{ $NEWLINE $SPACE $UNDERSCORE };
+
+BEGIN {
+
+    require Exporter;
+    use base qw{ Exporter };
+
+    # Set the version for version checking
+    our $VERSION = 1.00;
+
+    # Functions and variables which can be optionally exported
+    our @EXPORT_OK = qw{ download_delly_exclude };
+
+}
+
+sub download_delly_exclude {
+
+## Function : Download delly exclude files for variant calling
+## Returns  :
+## Arguments: $active_parameter_href => Active parameters for this download hash {REF}
+##          : $genome_version        => Human genome version
+##          : $job_id_href           => The job_id hash {REF}
+##          : $profile_base_command  => Submission profile base command
+##          : $recipe_name           => Recipe name
+##          : $reference_href        => Reference hash {REF}
+##          : $reference_version     => Reference version
+##          : $quiet                 => Quiet (no output)
+##          : $temp_directory        => Temporary directory for recipe
+##          : $verbose               => Verbosity
+
+    my ($arg_href) = @_;
+
+    ## Flatten argument(s)
+    my $active_parameter_href;
+    my $genome_version;
+    my $job_id_href;
+    my $recipe_name;
+    my $reference_href;
+    my $reference_version;
+
+    ## Default(s)
+    my $profile_base_command;
+    my $quiet;
+    my $temp_directory;
+    my $verbose;
+
+    my $tmpl = {
+        active_parameter_href => {
+            default     => {},
+            defined     => 1,
+            required    => 1,
+            store       => \$active_parameter_href,
+            strict_type => 1,
+        },
+        genome_version => {
+            store       => \$genome_version,
+            strict_type => 1,
+        },
+        job_id_href => {
+            default     => {},
+            defined     => 1,
+            required    => 1,
+            store       => \$job_id_href,
+            strict_type => 1,
+        },
+        profile_base_command => {
+            default     => q{sbatch},
+            store       => \$profile_base_command,
+            strict_type => 1,
+        },
+        recipe_name => {
+            defined     => 1,
+            required    => 1,
+            store       => \$recipe_name,
+            strict_type => 1,
+        },
+        reference_href => {
+            default     => {},
+            defined     => 1,
+            required    => 1,
+            store       => \$reference_href,
+            strict_type => 1,
+        },
+        reference_version => {
+            defined     => 1,
+            required    => 1,
+            store       => \$reference_version,
+            strict_type => 1,
+        },
+        quiet => {
+            allow       => [ undef, 0, 1 ],
+            default     => 1,
+            store       => \$quiet,
+            strict_type => 1,
+        },
+        temp_directory => {
+            store       => \$temp_directory,
+            strict_type => 1,
+        },
+    };
+
+    check( $tmpl, $arg_href, 1 ) or croak q{Could not parse arguments!};
+
+    use MIP::Get::Parameter qw{ get_recipe_resources };
+    use MIP::Recipes::Download::Get_reference qw{ get_reference };
+    use MIP::Script::Setup_script qw{ setup_script };
+    use MIP::Processmanagement::Slurm_processes
+      qw{ slurm_submit_job_no_dependency_dead_end };
+
+    ### PREPROCESSING:
+
+    ## Retrieve logger object
+    my $log = Log::Log4perl->get_logger( uc q{mip_download} );
+
+    ## Unpack parameters
+    my $reference_dir = $active_parameter_href->{reference_dir};
+
+    my %recipe_resource = get_recipe_resources(
+        {
+            active_parameter_href => $active_parameter_href,
+            recipe_name           => $recipe_name,
+        }
+    );
+
+    ## Set recipe mode
+    my $recipe_mode = $active_parameter_href->{$recipe_name};
+
+    ## Filehandle(s)
+    # Create anonymous filehandle
+    my $FILEHANDLE = IO::Handle->new();
+
+    ## Creates recipe directories (info & data & script), recipe script filenames and writes sbatch header
+    my ( $recipe_file_path, $recipe_info_path ) = setup_script(
+        {
+            active_parameter_href      => $active_parameter_href,
+            core_number                => $recipe_resource{core_number},
+            directory_id               => q{mip_download},
+            FILEHANDLE                 => $FILEHANDLE,
+            job_id_href                => $job_id_href,
+            log                        => $log,
+            memory_allocation          => $recipe_resource{memory},
+            outdata_dir                => $reference_dir,
+            outscript_dir              => $reference_dir,
+            process_time               => $recipe_resource{time},
+            recipe_data_directory_path => $active_parameter_href->{reference_dir},
+            recipe_directory           => $recipe_name . $UNDERSCORE . $reference_version,
+            recipe_name                => $recipe_name,
+            source_environment_commands_ref => $recipe_resource{load_env_ref},
+        }
+    );
+
+    ### SHELL:
+
+    say {$FILEHANDLE} q{## } . $recipe_name;
+
+    get_reference(
+        {
+            FILEHANDLE     => $FILEHANDLE,
+            recipe_name    => $recipe_name,
+            reference_dir  => $reference_dir,
+            reference_href => $reference_href,
+            quiet          => $quiet,
+            verbose        => $verbose,
+        }
+    );
+
+    ## Close FILEHANDLES
+    close $FILEHANDLE or $log->logcroak(q{Could not close FILEHANDLE});
+
+    if ( $recipe_mode == 1 ) {
+
+        ## No upstream or downstream dependencies
+        slurm_submit_job_no_dependency_dead_end(
+            {
+                base_command     => $profile_base_command,
+                job_id_href      => $job_id_href,
+                log              => $log,
+                sbatch_file_name => $recipe_file_path,
+            }
+        );
+    }
+    return 1;
+}
+
+1;

--- a/lib/MIP/Recipes/Pipeline/Download_rd_dna.pm
+++ b/lib/MIP/Recipes/Pipeline/Download_rd_dna.pm
@@ -25,7 +25,7 @@ BEGIN {
     use base qw{ Exporter };
 
     # Set the version for version checking
-    our $VERSION = 1.07;
+    our $VERSION = 1.08;
 
     # Functions and variables which can be optionally exported
     our @EXPORT_OK = qw{ pipeline_download_rd_dna };
@@ -92,6 +92,7 @@ sub pipeline_download_rd_dna {
     use MIP::Recipes::Download::Clinvar qw{ download_clinvar };
     use MIP::Recipes::Download::Dbnsfp qw{ download_dbnsfp };
     use MIP::Recipes::Download::Dbsnp qw{ download_dbsnp };
+    use MIP::Recipes::Download::Delly_exclude qw{ download_delly_exclude };
     use MIP::Recipes::Download::Expansionhunter qw{ download_expansionhunter };
     use MIP::Recipes::Download::Gatk_mitochondrial_ref
       qw{ download_gatk_mitochondrial_ref };
@@ -122,6 +123,7 @@ sub pipeline_download_rd_dna {
         clinvar                => \&download_clinvar,
         dbnsfp                 => \&download_dbnsfp,
         dbsnp                  => \&download_dbsnp,
+        delly_exclude          => \&download_delly_exclude,
         expansionhunter        => \&download_expansionhunter,
         gatk_mitochondrial_ref => \&download_gatk_mitochondrial_ref,
         genomic_superdups      => \&download_genomic_superdups,

--- a/t/data/test_data/download_active_parameters.yaml
+++ b/t/data/test_data/download_active_parameters.yaml
@@ -42,6 +42,9 @@ reference:
     - '138'
     - gold_standard_dbsnp
     - '146'
+  delly_exclude:
+    - 20150227
+    - 20150915
   expansionhunter:
     - 3.0.0
   gatk_mitochondrial_ref:
@@ -318,6 +321,17 @@ reference_feature:
         outfile_decompress: gzip
         outfile_index: hg38_variant_-gold_standard_dbsnp-.vcf.gz.tbi
         url_prefix: ftp://gsapubftp-anonymous@ftp.broadinstitute.org/bundle/hg38/beta/
+  delly_exclude:
+    grch37:
+      20150227: #latest commit for file on master branch
+        file: human.hg19.excl.tsv
+        outfile: hg19_human_excl_-20150227-.tsv
+        url_prefix: https://raw.githubusercontent.com/dellytools/delly/master/excludeTemplates/
+    hg38:
+      20150915: #latest commit for file on master branch
+        file: human.hg38.excl.tsv
+        outfile: hg38_human_excl_-20150915-.tsv
+        url_prefix: https://raw.githubusercontent.com/dellytools/delly/master/excludeTemplates/
   expansionhunter:
     grch37:
       3.0.0:

--- a/t/download_delly_exclude.t
+++ b/t/download_delly_exclude.t
@@ -1,0 +1,103 @@
+#!/usr/bin/env perl
+
+use 5.026;
+use Carp;
+use charnames qw{ :full :short };
+use English qw{ -no_match_vars };
+use File::Basename qw{ dirname };
+use File::Spec::Functions qw{ catdir catfile };
+use File::Temp;
+use FindBin qw{ $Bin };
+use open qw{ :encoding(UTF-8) :std };
+use Params::Check qw{ allow check last_error };
+use Test::More;
+use utf8;
+use warnings qw{ FATAL utf8 };
+
+## CPANM
+use autodie qw { :all };
+use Modern::Perl qw{ 2014 };
+use Readonly;
+
+## MIPs lib/
+use lib catdir( dirname($Bin), q{lib} );
+use MIP::Constants qw{ $COMMA $SPACE };
+use MIP::Test::Fixtures qw{ test_log test_mip_hashes test_standard_cli };
+
+my $VERBOSE = 1;
+our $VERSION = 1.00;
+
+$VERBOSE = test_standard_cli(
+    {
+        verbose => $VERBOSE,
+        version => $VERSION,
+    }
+);
+
+BEGIN {
+
+    use MIP::Test::Fixtures qw{ test_import };
+
+### Check all internal dependency modules and imports
+## Modules with import
+    my %perl_module = (
+        q{MIP::Recipes::Download::Delly_exclude} => [qw{ download_delly_exclude }],
+        q{MIP::Test::Fixtures} => [qw{ test_log test_mip_hashes test_standard_cli }],
+    );
+
+    test_import( { perl_module_href => \%perl_module, } );
+}
+
+use MIP::Recipes::Download::Delly_exclude qw{ download_delly_exclude };
+
+diag(   q{Test download_delly_exclude from Delly_exclude.pm v}
+      . $MIP::Recipes::Download::Delly_exclude::VERSION
+      . $COMMA
+      . $SPACE . q{Perl}
+      . $SPACE
+      . $PERL_VERSION
+      . $SPACE
+      . $EXECUTABLE_NAME );
+
+my $test_dir  = File::Temp->newdir();
+my $file_path = catfile( $test_dir, q{recipe_script.sh} );
+my $log       = test_log( { log_name => uc q{mip_download}, no_screen => 1, } );
+
+## Given download parameters for recipe
+my $genome_version    = q{grch37};
+my $recipe_name       = q{delly_exclude};
+my $reference_version = q{20150227};
+my $slurm_mock_cmd    = catfile( $Bin, qw{ data modules slurm-mock.pl } );
+
+my %active_parameter = test_mip_hashes(
+    {
+        mip_hash_name => q{download_active_parameter},
+    }
+);
+$active_parameter{$recipe_name}                     = 1;
+$active_parameter{project_id}                       = q{test};
+$active_parameter{reference_dir}                    = catfile($test_dir);
+$active_parameter{recipe_core_number}{$recipe_name} = 1;
+$active_parameter{recipe_time}{$recipe_name}        = 1;
+my $reference_href =
+  $active_parameter{reference_feature}{$recipe_name}{$genome_version}{$reference_version};
+
+my %job_id;
+
+my $is_ok = download_delly_exclude(
+    {
+        active_parameter_href => \%active_parameter,
+        genome_version        => $genome_version,
+        job_id_href           => \%job_id,
+        profile_base_command  => $slurm_mock_cmd,
+        recipe_name           => $recipe_name,
+        reference_href        => $reference_href,
+        reference_version     => $reference_version,
+        temp_directory        => catfile($test_dir),
+    }
+);
+
+## Then
+ok( $is_ok, q{ Executed download recipe } . $recipe_name );
+
+done_testing();

--- a/templates/mip_download_rd_dna_config_-1.0-.yaml
+++ b/templates/mip_download_rd_dna_config_-1.0-.yaml
@@ -39,6 +39,9 @@ reference:
     - 138
     - gold_standard_dbsnp
     - 146
+  delly_exclude:
+    - 20150227
+    - 20150915
   expansionhunter:
     - 3.0.0
   gatk_mitochondrial_ref:
@@ -313,6 +316,17 @@ reference_feature:
         outfile_index: hg38_dbsnp_-146-.vcf.gz.tbi
         url_prefix: ftp://gsapubftp-anonymous@ftp.broadinstitute.org/bundle/hg38/
         outfile_decompress: gzip
+  delly_exclude:
+    grch37:
+      20150227: #latest commit for file on master branch
+        file: human.hg19.excl.tsv
+        outfile: hg19_human_excl_-20150227-.tsv
+        url_prefix: https://raw.githubusercontent.com/dellytools/delly/master/excludeTemplates/
+    hg38:
+      20150915: #latest commit for file on master branch
+        file: human.hg38.excl.tsv
+        outfile: hg38_human_excl_-20150915-.tsv
+        url_prefix: https://raw.githubusercontent.com/dellytools/delly/master/excludeTemplates/
   expansionhunter:
     grch37:
       3.0.0:


### PR DESCRIPTION
both grch37 and hg38. Fix #831.

### This PR fixes:

- #831

### How to test:

- Automatic and continuous test pass
- Manual download using mip download

### Expected outcome:
- Installation, unit and integration tests pass
- Mip downloads delly exclude files for grch37 and hg38

### Review:
- [x] Code review
- [x] New code is executed and covered by tests
- [x] Tests pass
- [x] Manual download pass
