### PR TITLE
feat(tiddit_cov): Added generation of wig outfile from tiddit_coverage.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,14 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 - GATK: 4.1.0.0-0 -> 4.1.2.0-1
 - samtools: 1.9-h8ee4bcc_1 -> 1.9=h8571acd_11 
 
+## [7.0.10]
+- option: tiddit_bin_size -> tiddit_coverage_bin_size
+- Added generation of wig coverage data file using tiddit_coverage
+
+**New recipes**
+*Rd_dna*
+- tiddit_coverage
+
 ## [7.0.9]
 - Removed plink memory allocation from rd_dna_vcf_rerun
 

--- a/definitions/rd_dna_initiation_map.yaml
+++ b/definitions/rd_dna_initiation_map.yaml
@@ -16,6 +16,8 @@ CHAIN_ALL:
          - chanjo_sexcheck
       - CHAIN_STSUBSMT:
          - samtools_subsample_mt
+      - CHAIN_TCOV:
+         - tiddit_coverage
       - CHAIN_SBCOV:
          - sambamba_depth
       - CHAIN_PTMME:

--- a/definitions/rd_dna_parameters.yaml
+++ b/definitions/rd_dna_parameters.yaml
@@ -190,6 +190,7 @@ recipe_core_number:
     sv_reformat: 1
     sv_varianteffectpredictor: 0
     sv_vcfparser: 13
+    tiddit_coverage: 1
     variant_integrity_ar: 1
     vcf2cytosure_ar: 0
     vt_ar: 13
@@ -277,6 +278,7 @@ recipe_time:
     sv_varianteffectpredictor: 10
     sv_vcfparser: 2
     tiddit: 20
+    tiddit_coverage: 5
     varianteffectpredictor: 10
     variant_integrity_ar: 1
     vcfparser_ar: 5
@@ -596,6 +598,17 @@ sambamba_depth_quality_control:
   data_type: SCALAR
   default: 1
   type: recipe_argument
+tiddit_coverage:
+  analysis_mode: sample
+  associated_recipe:
+   - mip
+  data_type: SCALAR
+  default: 1
+  file_tag: _tcov
+  outfile_suffix: ".wig"
+  program_executables:
+   - TIDDIT.py
+  type: recipe
 picardtools_collectmultiplemetrics:
   analysis_mode: sample
   associated_recipe:
@@ -725,9 +738,10 @@ tiddit:
    - TIDDIT.py
   recipe_type: structural_variant_callers
   type: recipe
-tiddit_bin_size:
+tiddit_coverage_bin_size:
   associated_recipe:
    - tiddit
+   - tiddit_coverage
    - vcf2cytosure_ar
   data_type: SCALAR
   default: 500

--- a/lib/MIP/Cli/Mip/Analyse/Rd_dna.pm
+++ b/lib/MIP/Cli/Mip/Analyse/Rd_dna.pm
@@ -20,7 +20,7 @@ use Moose::Util::TypeConstraints;
 ## MIPs lib
 use MIP::Main::Analyse qw{ mip_analyse };
 
-our $VERSION = 1.24;
+our $VERSION = 1.25;
 
 extends(qw{ MIP::Cli::Mip::Analyse });
 
@@ -669,6 +669,16 @@ q{Default: grch37_dbsnp_-138-.vcf, grch37_1000g_indels_-phase1-.vcf, grch37_mill
     );
 
     option(
+        q{tiddit_coverage} => (
+            cmd_aliases   => [qw{ tcv }],
+            cmd_tags      => [q{Analysis recipe switch}],
+            documentation => q{Generate coverage data from alignment},
+            is            => q{rw},
+            isa           => enum( [ 0, 1, 2 ] ),
+        )
+    );
+
+    option(
         q{picardtools_collectmultiplemetrics} => (
             cmd_aliases   => [qw{ ptcmm }],
             cmd_flag      => q{ppt_col_mul_met},
@@ -791,7 +801,7 @@ q{Default: grch37_dbsnp_-138-.vcf, grch37_1000g_indels_-phase1-.vcf, grch37_mill
     );
 
     option(
-        q{tiddit_bin_size} => (
+        q{tiddit_coverage_bin_size} => (
             cmd_aliases   => [qw{ tidbin }],
             cmd_tags      => [q{Default: 500}],
             documentation => q{Size of coverage bins in calculation},

--- a/lib/MIP/Constants.pm
+++ b/lib/MIP/Constants.pm
@@ -60,7 +60,7 @@ BEGIN {
 ## Constants
 ## Set MIP version
 ## Constants
-Readonly our $MIP_VERSION => q{v7.0.9};
+Readonly our $MIP_VERSION => q{v7.0.10};
 
 ## Cli
 Readonly our $MOOSEX_APP_SCEEN_WIDTH => 160;

--- a/lib/MIP/Program/Variantcalling/Tiddit.pm
+++ b/lib/MIP/Program/Variantcalling/Tiddit.pm
@@ -15,6 +15,7 @@ use warnings qw{ FATAL utf8 };
 use Readonly;
 
 ## MIPs lib/
+use MIP::Constants qw{ $SPACE };
 use MIP::Unix::Standard_streams qw{ unix_standard_streams };
 use MIP::Unix::Write_to_file qw{ unix_write_to_file };
 
@@ -30,20 +31,18 @@ BEGIN {
 
 }
 
-## Constants
-Readonly my $SPACE => q{ };
-
 sub tiddit_coverage {
 
-## Function : Perl wrapper for Tiddit coverage. Based on Tiddit 1.0.2.
+## Function : Perl wrapper for Tiddit coverage. Based on Tiddit 2.7.1.
 ## Returns  : @commands
 ## Arguments: $bin_size               => Bin size
 ##          : $FILEHANDLE             => Filehandle to write to
 ##          : $infile_path            => Infile path
-##          : $outfile_path_prefix    => Outfile path. Write documents to FILE
+##          : $outfile_path_prefix    => Outfile path prefix
 ##          : $stderrfile_path        => Stderrfile path
 ##          : $stderrfile_path_append => Append stderr info to file path
 ##          : $stdoutfile_path        => Stdoutfile path
+##          : $output_wig             => Generate wig instead of bed
 
     my ($arg_href) = @_;
 
@@ -57,10 +56,11 @@ sub tiddit_coverage {
 
     ## Default(s)
     my $bin_size;
+    my $output_wig;
 
     my $tmpl = {
         bin_size => {
-            allow       => qr/ ^\d+$ /sxm,
+            allow       => [ undef, qr/ ^\d+$ /sxm ],
             default     => 500,
             store       => \$bin_size,
             strict_type => 1,
@@ -87,6 +87,12 @@ sub tiddit_coverage {
             store       => \$stdoutfile_path,
             strict_type => 1,
         },
+        output_wig => {
+            allow       => [ undef, 0, 1 ],
+            default     => 0,
+            store       => \$output_wig,
+            strict_type => 1,
+        },
     };
 
     check( $tmpl, $arg_href, 1 ) or croak q{Could not parse arguments!};
@@ -106,7 +112,11 @@ sub tiddit_coverage {
         push @commands, q{-z} . $SPACE . $bin_size;
     }
 
-    # Specify infile
+    if ($output_wig) {
+
+        push @commands, q{-w};
+    }
+
     push @commands, q{--bam} . $SPACE . $infile_path;
 
     push @commands,
@@ -131,7 +141,7 @@ sub tiddit_coverage {
 
 sub tiddit_sv {
 
-## Function : Perl wrapper for writing tiddit sv recipe to $FILEHANDLE or return commands array. Based on tiddit 1.0.2.
+## Function : Perl wrapper for writing tiddit sv recipe to $FILEHANDLE or return commands array. Based on tiddit 2.7.1.
 ## Returns  : @commands
 ## Arguments: $FILEHANDLE                      => Filehandle to write to
 ##          : $infile_path                     => Infile path

--- a/lib/MIP/Recipes/Analysis/Tiddit_coverage.pm
+++ b/lib/MIP/Recipes/Analysis/Tiddit_coverage.pm
@@ -223,10 +223,7 @@ sub analysis_tiddit_coverage {
 
     ### SHELL:
 
-    ## tiddit --cov
     say {$FILEHANDLE} q{## Generating coverage data from alignment};
-
-    ## Get parameters
 
     tiddit_coverage(
         {

--- a/lib/MIP/Recipes/Analysis/Tiddit_coverage.pm
+++ b/lib/MIP/Recipes/Analysis/Tiddit_coverage.pm
@@ -1,0 +1,274 @@
+package MIP::Recipes::Analysis::Tiddit_coverage;
+
+use 5.026;
+use Carp;
+use charnames qw{ :full :short };
+use English qw{ -no_match_vars };
+use File::Spec::Functions qw{ catdir catfile };
+use open qw{ :encoding(UTF-8) :std };
+use Params::Check qw{ check allow last_error };
+use strict;
+use utf8;
+use warnings;
+use warnings qw{ FATAL utf8 };
+
+## CPANM
+use autodie qw{ :all };
+use List::MoreUtils qw { any };
+use Readonly;
+
+BEGIN {
+
+    require Exporter;
+    use base qw{ Exporter };
+
+    # Set the version for version checking
+    our $VERSION = 1.00;
+
+    # Functions and variables which can be optionally exported
+    our @EXPORT_OK = qw{ analysis_tiddit_coverage };
+
+}
+
+## Constants
+Readonly my $NEWLINE    => qq{\n};
+Readonly my $SPACE      => q{ };
+Readonly my $UNDERSCORE => q{_};
+
+sub analysis_tiddit_coverage {
+
+## Function : Generate coverage data from BAM files.
+## Returns  :
+## Arguments: $active_parameter_href   => Active parameters for this analysis hash {REF}
+##          : $case_id                 => Family id
+##          : $file_info_href          => The file_info hash {REF}
+##          : $infile_lane_prefix_href => Infile(s) without the ".ending" {REF}
+##          : $job_id_href             => Job id hash {REF}
+##          : $parameter_href          => Parameter hash {REF}
+##          : $profile_base_command    => Submission profile base command
+##          : $recipe_name             => Program name
+##          : $sample_id               => Sample id
+##          : $sample_info_href        => Info on samples and case hash {REF}
+
+    my ($arg_href) = @_;
+
+    ## Flatten argument(s)
+    my $active_parameter_href;
+    my $file_info_href;
+    my $infile_lane_prefix_href;
+    my $job_id_href;
+    my $parameter_href;
+    my $recipe_name;
+    my $sample_id;
+    my $sample_info_href;
+
+    ## Default(s)
+    my $case_id;
+    my $profile_base_command;
+
+    my $tmpl = {
+        active_parameter_href => {
+            default     => {},
+            defined     => 1,
+            required    => 1,
+            store       => \$active_parameter_href,
+            strict_type => 1,
+        },
+        case_id => {
+            default     => $arg_href->{active_parameter_href}{case_id},
+            store       => \$case_id,
+            strict_type => 1,
+        },
+        file_info_href => {
+            default     => {},
+            defined     => 1,
+            required    => 1,
+            store       => \$file_info_href,
+            strict_type => 1,
+        },
+        infile_lane_prefix_href => {
+            default     => {},
+            defined     => 1,
+            required    => 1,
+            store       => \$infile_lane_prefix_href,
+            strict_type => 1,
+        },
+        job_id_href => {
+            default     => {},
+            defined     => 1,
+            required    => 1,
+            store       => \$job_id_href,
+            strict_type => 1,
+        },
+        parameter_href => {
+            default     => {},
+            defined     => 1,
+            required    => 1,
+            store       => \$parameter_href,
+            strict_type => 1,
+        },
+        profile_base_command => {
+            default     => q{sbatch},
+            store       => \$profile_base_command,
+            strict_type => 1,
+        },
+        recipe_name => {
+            defined     => 1,
+            required    => 1,
+            store       => \$recipe_name,
+            strict_type => 1,
+        },
+        sample_id => {
+            defined     => 1,
+            required    => 1,
+            store       => \$sample_id,
+            strict_type => 1,
+        },
+        sample_info_href => {
+            default     => {},
+            defined     => 1,
+            required    => 1,
+            store       => \$sample_info_href,
+            strict_type => 1,
+        },
+    };
+
+    check( $tmpl, $arg_href, 1 ) or croak q{Could not parse arguments!};
+
+    use MIP::Get::File qw{ get_io_files };
+    use MIP::Get::Parameter qw{ get_recipe_attributes get_recipe_resources };
+    use MIP::Parse::File qw{ parse_io_outfiles };
+    use MIP::Processmanagement::Processes qw{ submit_recipe };
+    use MIP::Program::Variantcalling::Tiddit qw{ tiddit_coverage };
+    use MIP::Sample_info qw{ set_recipe_outfile_in_sample_info };
+    use MIP::Script::Setup_script qw{ setup_script };
+
+    ### PREPROCESSING:
+
+    ## Retrieve logger object
+    my $log = Log::Log4perl->get_logger( uc q{mip_analyse} );
+
+    ## Unpack parameters
+    ## Get the io infiles per chain and id
+    my %io = get_io_files(
+        {
+            id             => $sample_id,
+            file_info_href => $file_info_href,
+            parameter_href => $parameter_href,
+            recipe_name    => $recipe_name,
+            stream         => q{in},
+        }
+    );
+    my $indir_path_prefix  = $io{in}{dir_path_prefix};
+    my $infile_name_prefix = $io{in}{file_name_prefix};
+    my $infile_path_prefix = $io{in}{file_path_prefix};
+    my $infile_suffix      = $io{in}{file_suffix};
+    my $infile_path        = $infile_path_prefix . $infile_suffix;
+
+    my $job_id_chain = get_recipe_attributes(
+        {
+            parameter_href => $parameter_href,
+            recipe_name    => $recipe_name,
+            attribute      => q{chain},
+        }
+    );
+    my $recipe_mode     = $active_parameter_href->{$recipe_name};
+    my %recipe_resource = get_recipe_resources(
+        {
+            active_parameter_href => $active_parameter_href,
+            recipe_name           => $recipe_name,
+        }
+    );
+
+    %io = (
+        %io,
+        parse_io_outfiles(
+            {
+                chain_id               => $job_id_chain,
+                id                     => $sample_id,
+                file_info_href         => $file_info_href,
+                file_name_prefixes_ref => [$infile_name_prefix],
+                outdata_dir            => $active_parameter_href->{outdata_dir},
+                parameter_href         => $parameter_href,
+                recipe_name            => $recipe_name,
+            }
+        )
+    );
+
+    my $outfile_name_prefix = $io{out}{file_name_prefix};
+    my $outfile_path_prefix = $io{out}{file_path_prefix};
+    my $outfile_suffix      = $io{out}{file_suffix};
+    my $outfile_path        = $outfile_path_prefix . $outfile_suffix;
+
+    ## Filehandles
+    # Create anonymous filehandle
+    my $FILEHANDLE = IO::Handle->new();
+
+    ## Creates recipe directories (info & data & script), recipe script filenames and writes sbatch header
+    my ( $recipe_file_path, $recipe_info_path ) = setup_script(
+        {
+            active_parameter_href           => $active_parameter_href,
+            core_number                     => $recipe_resource{core_number},
+            directory_id                    => $sample_id,
+            FILEHANDLE                      => $FILEHANDLE,
+            log                             => $log,
+            memory_allocation               => $recipe_resource{memory},
+            job_id_href                     => $job_id_href,
+            process_time                    => $recipe_resource{time},
+            recipe_directory                => $recipe_name,
+            recipe_name                     => $recipe_name,
+            source_environment_commands_ref => $recipe_resource{load_env_ref},
+        }
+    );
+
+    ### SHELL:
+
+    ## tiddit --cov
+    say {$FILEHANDLE} q{## Generating coverage data from alignment};
+
+    ## Get parameters
+
+    tiddit_coverage(
+        {
+            bin_size            => $active_parameter_href->{tiddit_coverage_bin_size},
+            FILEHANDLE          => $FILEHANDLE,
+            infile_path         => $infile_path,
+            outfile_path_prefix => $outfile_path,
+            output_wig          => 1,
+        }
+    );
+    say {$FILEHANDLE} $NEWLINE;
+    close $FILEHANDLE;
+
+    if ( $recipe_mode == 1 ) {
+
+        ## Collect QC metadata info for later use
+        set_recipe_outfile_in_sample_info(
+            {
+                infile           => $outfile_name_prefix,
+                path             => $outfile_path,
+                recipe_name      => $recipe_name,
+                sample_id        => $sample_id,
+                sample_info_href => $sample_info_href,
+            }
+        );
+
+        submit_recipe(
+            {
+                base_command            => $profile_base_command,
+                dependency_method       => q{sample_to_island},
+                case_id                 => $case_id,
+                infile_lane_prefix_href => $infile_lane_prefix_href,
+                job_id_href             => $job_id_href,
+                log                     => $log,
+                job_id_chain            => $job_id_chain,
+                recipe_file_path        => $recipe_file_path,
+                sample_id               => $sample_id,
+                submission_profile      => $active_parameter_href->{submission_profile},
+            }
+        );
+    }
+    return 1;
+}
+
+1;

--- a/lib/MIP/Recipes/Pipeline/Analyse_rd_dna.pm
+++ b/lib/MIP/Recipes/Pipeline/Analyse_rd_dna.pm
@@ -25,7 +25,7 @@ BEGIN {
     use base qw{ Exporter };
 
     # Set the version for version checking
-    our $VERSION = 1.14;
+    our $VERSION = 1.15;
 
     # Functions and variables which can be optionally exported
     our @EXPORT_OK = qw{ pipeline_analyse_rd_dna };
@@ -202,6 +202,7 @@ sub pipeline_analyse_rd_dna {
     use MIP::Recipes::Analysis::Sv_combinevariantcallsets
       qw{ analysis_sv_combinevariantcallsets };
     use MIP::Recipes::Analysis::Tiddit qw{ analysis_tiddit };
+    use MIP::Recipes::Analysis::Tiddit_coverage qw{ analysis_tiddit_coverage };
     use MIP::Recipes::Analysis::Variant_integrity qw{ analysis_variant_integrity };
     use MIP::Recipes::Analysis::Vcf2cytosure qw{ analysis_vcf2cytosure };
     use MIP::Recipes::Analysis::Vep qw{ analysis_vep };
@@ -293,11 +294,12 @@ sub pipeline_analyse_rd_dna {
         sv_varianteffectpredictor => undef,                   # Depends on analysis type
         sv_vcfparser              => undef,                   # Depends on analysis type
         tiddit                    => \&analysis_tiddit,
-        varianteffectpredictor    => \&analysis_vep,
-        variant_integrity_ar => \&analysis_variant_integrity,
-        vcfparser_ar         => \&analysis_mip_vcfparser,
-        vcf2cytosure_ar      => \&analysis_vcf2cytosure,
-        vt_ar                => \&analysis_vt,
+        tiddit_coverage        => \&analysis_tiddit_coverage,
+        varianteffectpredictor => \&analysis_vep,
+        variant_integrity_ar   => \&analysis_variant_integrity,
+        vcfparser_ar           => \&analysis_mip_vcfparser,
+        vcf2cytosure_ar        => \&analysis_vcf2cytosure,
+        vt_ar                  => \&analysis_vt,
     );
 
     ## Special case for rankvariants recipe

--- a/t/analysis_tiddit_coverage.t
+++ b/t/analysis_tiddit_coverage.t
@@ -1,0 +1,119 @@
+#!/usr/bin/env perl
+
+use 5.026;
+use Carp;
+use charnames qw{ :full :short };
+use English qw{ -no_match_vars };
+use File::Basename qw{ dirname };
+use File::Spec::Functions qw{ catdir catfile };
+use FindBin qw{ $Bin };
+use open qw{ :encoding(UTF-8) :std };
+use Params::Check qw{ allow check last_error };
+use Test::More;
+use utf8;
+use warnings qw{ FATAL utf8 };
+
+## CPANM
+use autodie qw { :all };
+use Modern::Perl qw{ 2014 };
+use Readonly;
+use Test::Trap;
+
+## MIPs lib/
+use lib catdir( dirname($Bin), q{lib} );
+use MIP::Constants qw{ $COLON $COMMA $SPACE };
+use MIP::Test::Fixtures qw{ test_log test_mip_hashes test_standard_cli };
+
+my $VERBOSE = 1;
+our $VERSION = 1.00;
+
+$VERBOSE = test_standard_cli(
+    {
+        verbose => $VERBOSE,
+        version => $VERSION,
+    }
+);
+
+BEGIN {
+
+    use MIP::Test::Fixtures qw{ test_import };
+
+### Check all internal dependency modules and imports
+## Modules with import
+    my %perl_module = (
+        q{MIP::Recipes::Analysis::Tiddit_coverage} => [qw{ analysis_tiddit_coverage }],
+        q{MIP::Test::Fixtures} => [qw{ test_log test_mip_hashes test_standard_cli }],
+    );
+
+    test_import( { perl_module_href => \%perl_module, } );
+}
+
+use MIP::Recipes::Analysis::Tiddit_coverage qw{ analysis_tiddit_coverage };
+
+diag(   q{Test analysis_tiddit_coverage from Tiddit_coverage.pm v}
+      . $MIP::Recipes::Analysis::Tiddit_coverage::VERSION
+      . $COMMA
+      . $SPACE . q{Perl}
+      . $SPACE
+      . $PERL_VERSION
+      . $SPACE
+      . $EXECUTABLE_NAME );
+
+my $log = test_log( { log_name => q{MIP}, no_screen => 1, } );
+
+## Given analysis parameters
+my $recipe_name    = q{tiddit_coverage};
+my $slurm_mock_cmd = catfile( $Bin, qw{ data modules slurm-mock.pl } );
+
+my %active_parameter = test_mip_hashes(
+    {
+        mip_hash_name => q{active_parameter},
+        recipe_name   => $recipe_name,
+    }
+);
+$active_parameter{$recipe_name}                     = 1;
+$active_parameter{recipe_core_number}{$recipe_name} = 1;
+$active_parameter{recipe_time}{$recipe_name}        = 1;
+my $sample_id = $active_parameter{sample_ids}[0];
+
+my %file_info = test_mip_hashes(
+    {
+        mip_hash_name => q{file_info},
+        recipe_name   => $recipe_name,
+    }
+);
+%{ $file_info{io}{TEST}{$sample_id}{$recipe_name} } = test_mip_hashes(
+    {
+        mip_hash_name => q{io},
+    }
+);
+
+my %infile_lane_prefix;
+my %job_id;
+my %parameter = test_mip_hashes(
+    {
+        mip_hash_name => q{recipe_parameter},
+        recipe_name   => $recipe_name,
+    }
+);
+@{ $parameter{cache}{order_recipes_ref} } = ($recipe_name);
+my %sample_info;
+
+my $is_ok = analysis_tiddit_coverage(
+    {
+        active_parameter_href   => \%active_parameter,
+        file_info_href          => \%file_info,
+        infile_lane_prefix_href => \%infile_lane_prefix,
+        job_id_href             => \%job_id,
+        parameter_href          => \%parameter,
+        profile_base_command    => $slurm_mock_cmd,
+        recipe_name             => $recipe_name,
+        sample_id               => $sample_id,
+        sample_info_href        => \%sample_info,
+    }
+);
+
+## Then return TRUE
+ok( $is_ok, q{ Executed analysis recipe } . $recipe_name );
+
+done_testing();

--- a/t/tiddit_coverage.t
+++ b/t/tiddit_coverage.t
@@ -4,10 +4,9 @@ use 5.026;
 use Carp;
 use charnames qw{ :full :short };
 use English qw{ -no_match_vars };
-use File::Basename qw{ basename dirname  };
+use File::Basename qw{ dirname };
 use File::Spec::Functions qw{ catdir };
 use FindBin qw{ $Bin };
-use Getopt::Long;
 use open qw{ :encoding(UTF-8) :std };
 use Params::Check qw{ allow check last_error };
 use Test::More;
@@ -21,70 +20,32 @@ use Readonly;
 
 ## MIPs lib/
 use lib catdir( dirname($Bin), q{lib} );
-use MIP::Script::Utils qw{ help };
-
-our $USAGE = build_usage( {} );
+use MIP::Constants qw{ $COMMA $SPACE };
+use MIP::Test::Commands qw{ test_function };
+use MIP::Test::Fixtures qw{ test_standard_cli };
 
 my $VERBOSE = 1;
-our $VERSION = 1.0.0;
+our $VERSION = 1.01;
 
-## Constants
-Readonly my $COMMA    => q{,};
-Readonly my $NEWLINE  => qq{\n};
-Readonly my $SPACE    => q{ };
-Readonly my $BIN_SIZE => 500;
-
-### User Options
-GetOptions(
-
-    # Display help text
-    q{h|help} => sub {
-        done_testing();
-        say {*STDOUT} $USAGE;
-        exit;
-    },
-
-    # Display version number
-    q{v|version} => sub {
-        done_testing();
-        say {*STDOUT} $NEWLINE
-          . basename($PROGRAM_NAME)
-          . $SPACE
-          . $VERSION
-          . $NEWLINE;
-        exit;
-    },
-    q{vb|verbose} => $VERBOSE,
-  )
-  or (
-    done_testing(),
-    help(
-        {
-            USAGE     => $USAGE,
-            exit_code => 1,
-        }
-    )
-  );
+$VERBOSE = test_standard_cli(
+    {
+        verbose => $VERBOSE,
+        version => $VERSION,
+    }
+);
 
 BEGIN {
 
+    use MIP::Test::Fixtures qw{ test_import };
+
 ### Check all internal dependency modules and imports
 ## Modules with import
-    my %perl_module = ( q{MIP::Script::Utils} => [qw{ help }], );
+    my %perl_module = (
+        q{MIP::Program::Variantcalling::Tiddit} => [qw{ tiddit_coverage }],
+        q{MIP::Test::Fixtures}                  => [qw{ test_standard_cli }],
+    );
 
-  PERL_MODULE:
-    while ( my ( $module, $module_import ) = each %perl_module ) {
-        use_ok( $module, @{$module_import} )
-          or BAIL_OUT q{Cannot load} . $SPACE . $module;
-    }
-
-## Modules
-    my @modules = (q{MIP::Program::Variantcalling::Tiddit});
-
-  MODULE:
-    for my $module (@modules) {
-        require_ok($module) or BAIL_OUT q{Cannot load} . $SPACE . $module;
-    }
+    test_import( { perl_module_href => \%perl_module, } );
 }
 
 use MIP::Program::Variantcalling::Tiddit qw{ tiddit_coverage };
@@ -98,6 +59,9 @@ diag(   q{Test tiddit_coverage from Tiddit.pm v}
       . $PERL_VERSION
       . $SPACE
       . $EXECUTABLE_NAME );
+
+## Constants
+Readonly my $BIN_SIZE => 500;
 
 ## Base arguments
 my @function_base_commands = qw{ TIDDIT.py --cov };
@@ -139,6 +103,10 @@ my %specific_argument = (
         input           => q{outfile_path_prefix},
         expected_output => q{-o outfile_path_prefix},
     },
+    output_wig => {
+        input           => 1,
+        expected_output => q{-w},
+    },
 );
 
 ## Coderef - enables generalized use of generate call
@@ -149,6 +117,7 @@ my @arguments = ( \%base_argument, \%specific_argument );
 
 ARGUMENT_HASH_REF:
 foreach my $argument_href (@arguments) {
+
     my @commands = test_function(
         {
             argument_href              => $argument_href,
@@ -161,36 +130,3 @@ foreach my $argument_href (@arguments) {
 }
 
 done_testing();
-
-######################
-####SubRoutines#######
-######################
-
-sub build_usage {
-
-## Function  : Build the USAGE instructions
-## Returns   :
-## Arguments : $program_name => Name of the script
-
-    my ($arg_href) = @_;
-
-    ## Default(s)
-    my $program_name;
-
-    my $tmpl = {
-        program_name => {
-            default     => basename($PROGRAM_NAME),
-            store       => \$program_name,
-            strict_type => 1,
-        },
-    };
-
-    check( $tmpl, $arg_href, 1 ) or croak q{Could not parse arguments!};
-
-    return <<"END_USAGE";
- $program_name [options]
-    -vb/--verbose Verbose
-    -h/--help Display this help message
-    -v/--version Display version
-END_USAGE
-}

--- a/templates/mip_rd_dna_config.yaml
+++ b/templates/mip_rd_dna_config.yaml
@@ -58,6 +58,7 @@ load_env:
     method: conda
     installation: etiddit
     tiddit:
+    tiddit_coverage:
     vcf2cytosure_ar:
 project_id: travis_test
 ## Input


### PR DESCRIPTION
Added sample level recipe. Fix  #863

- Added "-w" option to tiddit_coverage API
- Added new MIP CLI tiddit coverage bin size and connected it to
  tiddit, tiddit_coverage and vcf2cytosure_ar
- Added new sample level recipe: tiddit_coverge
- Placed it in the init map after BAM recal

### This PR fixes:

- #863 

### How to test:

- Automatic and continuous test pass

### Expected outcome:
- Installation, unit and integration tests pass

### Review:
- [ ] Code review
- [ ] New code is executed and covered by tests
- [ ] Tests pass
