### PR TITLE
feat(vcfparser): set path for vcfparser.log

### DIFF
--- a/lib/MIP/Program/Mip.pm
+++ b/lib/MIP/Program/Mip.pm
@@ -23,7 +23,7 @@ BEGIN {
     use base qw{ Exporter };
 
     # Set the version for version checking
-    our $VERSION = 1.00;
+    our $VERSION = 1.02;
 
     # Functions and variables which can be optionally exported
     our @EXPORT_OK = qw{ mip_qccollect mip_vcfparser };
@@ -159,6 +159,7 @@ sub mip_vcfparser {
 ## Returns  : @commands
 ## Arguments: $FILEHANDLE                            => Filehandle to write to
 ##          : $infile_path                           => Infile path
+##          : $log_file_path                         => Log file path
 ##          : $padding                               => Pad each gene with X number of nucleotides
 ##          : $parse_vep                             => Parse VEP transcript specific entries
 ##          : $per_gene                              => Output most severe consequence transcript
@@ -178,6 +179,7 @@ sub mip_vcfparser {
     ## Flatten argument(s)
     my $FILEHANDLE;
     my $infile_path;
+    my $log_file_path;
     my $pli_values_file_path;
     my $range_feature_annotation_columns_ref;
     my $range_feature_file_path;
@@ -202,6 +204,10 @@ sub mip_vcfparser {
             defined     => 1,
             required    => 1,
             store       => \$infile_path,
+            strict_type => 1,
+        },
+        log_file_path => {
+            store       => \$log_file_path,
             strict_type => 1,
         },
         padding => {
@@ -268,6 +274,11 @@ sub mip_vcfparser {
     push @commands, $infile_path;
 
     ## Options
+    if ($log_file_path) {
+
+        push @commands, q{--log_file} . $SPACE . $log_file_path;
+    }
+
     if ($parse_vep) {
 
         push @commands, q{--parse_vep};

--- a/lib/MIP/Recipes/Analysis/Mip_vcfparser.pm
+++ b/lib/MIP/Recipes/Analysis/Mip_vcfparser.pm
@@ -27,7 +27,7 @@ BEGIN {
     use base qw{ Exporter };
 
     # Set the version for version checking
-    our $VERSION = 1.15;
+    our $VERSION = 1.16;
 
     # Functions and variables which can be optionally exported
     our @EXPORT_OK =
@@ -236,6 +236,7 @@ sub analysis_mip_vcfparser {
         )
     );
 
+    my $outdir_path   = $io{out}{dir_path};
     my %outfile_path  = %{ $io{out}{file_path_href} };
     my @outfile_paths = @{ $io{out}{file_paths} };
 
@@ -309,6 +310,8 @@ sub analysis_mip_vcfparser {
             $padding = $ANNOTATION_DISTANCE_MT;
         }
 
+        my $log_file_path =
+          catfile( $outdir_path, q{vcfparser} . $UNDERSCORE . $contig . q{.log} );
         my $vcfparser_xargs_file_path_prefix = $xargs_file_path_prefix . $DOT . $contig;
         my @select_feature_annotation_columns;
         my $select_file;
@@ -351,10 +354,11 @@ sub analysis_mip_vcfparser {
 
         mip_vcfparser(
             {
-                FILEHANDLE  => $XARGSFILEHANDLE,
-                infile_path => $infile_path{$contig},
-                padding     => $padding,
-                parse_vep   => $active_parameter_href->{varianteffectpredictor},
+                FILEHANDLE    => $XARGSFILEHANDLE,
+                infile_path   => $infile_path{$contig},
+                log_file_path => $log_file_path,
+                padding       => $padding,
+                parse_vep     => $active_parameter_href->{varianteffectpredictor},
                 range_feature_annotation_columns_ref => \@{
                     $active_parameter_href->{vcfparser_range_feature_annotation_columns}
                 },
@@ -640,6 +644,7 @@ sub analysis_mip_vcfparser_sv_wes {
         )
     );
 
+    my $outdir_path         = $io{out}{dir_path};
     my $outfile_path_prefix = $io{out}{file_path_prefix};
     my @outfile_suffixes    = @{ $io{out}{file_suffixes} };
 
@@ -666,6 +671,7 @@ sub analysis_mip_vcfparser_sv_wes {
     ## vcfparser
     say {$FILEHANDLE} q{## vcfparser};
 
+    my $log_file_path = catfile( $outdir_path, q{vcfparser.log} );
     my @select_feature_annotation_columns;
     my $select_file;
     my $select_file_matching_column;
@@ -695,10 +701,11 @@ sub analysis_mip_vcfparser_sv_wes {
 
     mip_vcfparser(
         {
-            FILEHANDLE  => $FILEHANDLE,
-            infile_path => $infile_path,
-            parse_vep   => $active_parameter_href->{sv_varianteffectpredictor},
-            per_gene    => $active_parameter_href->{sv_vcfparser_per_gene},
+            FILEHANDLE    => $FILEHANDLE,
+            infile_path   => $infile_path,
+            log_file_path => $log_file_path,
+            parse_vep     => $active_parameter_href->{sv_varianteffectpredictor},
+            per_gene      => $active_parameter_href->{sv_vcfparser_per_gene},
             pli_values_file_path =>
               $active_parameter_href->{vep_plugin_pli_value_file_path},
             range_feature_annotation_columns_ref =>
@@ -955,6 +962,7 @@ sub analysis_mip_vcfparser_sv_wgs {
         )
     );
 
+    my $outdir_path         = $io{out}{dir_path};
     my $outdir_path_prefix  = $io{out}{dir_path_prefix};
     my $outfile_path_prefix = $io{out}{file_path_prefix};
     my $outfile_suffix      = $io{out}{file_suffix};
@@ -1010,6 +1018,8 @@ sub analysis_mip_vcfparser_sv_wgs {
             $padding = $ANNOTATION_DISTANCE_MT;
         }
 
+        my $log_file_path =
+          catfile( $outdir_path, q{vcfparser} . $UNDERSCORE . $contig . q{.log} );
         my $vcfparser_outfile_path =
           $outfile_path_prefix . $DOT . $contig . $outfile_suffix;
         my $vcfparser_xargs_file_path_prefix = $xargs_file_path_prefix . $DOT . $contig;
@@ -1017,6 +1027,7 @@ sub analysis_mip_vcfparser_sv_wgs {
         my $select_file;
         my $select_file_matching_column;
         my $select_outfile;
+
         if ( $active_parameter_href->{sv_vcfparser_select_file} ) {
 
             if (
@@ -1056,11 +1067,12 @@ sub analysis_mip_vcfparser_sv_wgs {
 
         mip_vcfparser(
             {
-                FILEHANDLE  => $XARGSFILEHANDLE,
-                infile_path => $infile_path{$contig},
-                padding     => $padding,
-                parse_vep   => $active_parameter_href->{sv_varianteffectpredictor},
-                per_gene    => $active_parameter_href->{sv_vcfparser_per_gene},
+                FILEHANDLE    => $XARGSFILEHANDLE,
+                infile_path   => $infile_path{$contig},
+                log_file_path => $log_file_path,
+                padding       => $padding,
+                parse_vep     => $active_parameter_href->{sv_varianteffectpredictor},
+                per_gene      => $active_parameter_href->{sv_vcfparser_per_gene},
                 pli_values_file_path =>
                   $active_parameter_href->{vep_plugin_pli_value_file_path},
                 range_feature_annotation_columns_ref => \@{

--- a/t/mip_vcfparser.t
+++ b/t/mip_vcfparser.t
@@ -25,7 +25,7 @@ use MIP::Test::Commands qw{ test_function };
 use MIP::Test::Fixtures qw{ test_standard_cli };
 
 my $VERBOSE = 1;
-our $VERSION = 1.01;
+our $VERSION = 1.03;
 
 ## Constants
 Readonly my $PADDING => 50;
@@ -97,6 +97,12 @@ my %required_argument = (
 );
 
 my %specific_argument = (
+    log_file_path => {
+        input           => catfile(qw{ a dir vcfparser_contig.log}),
+        expected_output => q{--log_file}
+          . $SPACE
+          . catfile(qw{ a dir vcfparser_contig.log}),
+    },
     padding => {
         input           => $PADDING,
         expected_output => q{--padding} . $SPACE . $PADDING,


### PR DESCRIPTION
### This PR fixes:

- The vcfparser log is generated at the place where MIP is executed which can lead to unexpected behaviour. With this pull request the log is created in the vcfparser_ar directory for each case. 

### How to test:

- Automatic and continuous test pass

### Expected outcome:
- Installation, unit and integration tests pass

### Review:
- [x] Code review
- [x] New code is executed and covered by tests
- [x] Tests pass
