### PR TITLE
fix(tiddit_coverage): outfile_path_prefix

### DIFF
--- a/lib/MIP/Recipes/Analysis/Tiddit_coverage.pm
+++ b/lib/MIP/Recipes/Analysis/Tiddit_coverage.pm
@@ -23,7 +23,7 @@ BEGIN {
     use base qw{ Exporter };
 
     # Set the version for version checking
-    our $VERSION = 1.00;
+    our $VERSION = 1.01;
 
     # Functions and variables which can be optionally exported
     our @EXPORT_OK = qw{ analysis_tiddit_coverage };
@@ -230,7 +230,7 @@ sub analysis_tiddit_coverage {
             bin_size            => $active_parameter_href->{tiddit_coverage_bin_size},
             FILEHANDLE          => $FILEHANDLE,
             infile_path         => $infile_path,
-            outfile_path_prefix => $outfile_path,
+            outfile_path_prefix => $outfile_path_prefix,
             output_wig          => 1,
         }
     );


### PR DESCRIPTION

### This PR fixes:
Removes the suffix from the outfile path given to tiddit. Tiddit will give the outfile a suffix depending on which outfile format that was chosen. 

### How to test:

- Automatic and continuous test pass

### Expected outcome:
- Installation, unit and integration tests pass

### Review:
- [x] Code review
- [ ] New code is executed and covered by tests
- [ ] Tests pass
