### PR TITLE
feat(vcfparser): Refacored setting INFO key-value pairs to vcf record…

### DIFF
--- a/lib/MIP/File/Format/Vcf.pm
+++ b/lib/MIP/File/Format/Vcf.pm
@@ -16,7 +16,7 @@ use autodie qw{ :all };
 use Readonly;
 
 ## MIPs lib/
-use MIP::Constants qw{ $SPACE $TAB };
+use MIP::Constants qw{ $EQUALS $SEMICOLON $SPACE $TAB };
 
 BEGIN {
     require Exporter;
@@ -26,8 +26,12 @@ BEGIN {
     our $VERSION = 1.01;
 
     # Functions and variables which can be optionally exported
-    our @EXPORT_OK =
-      qw{ check_vcf_variant_line parse_vcf_header set_line_elements_in_vcf_record  };
+    our @EXPORT_OK = qw{
+      check_vcf_variant_line
+      parse_vcf_header
+      set_info_key_pairs_in_vcf_record
+      set_line_elements_in_vcf_record
+    };
 }
 
 ## Constants
@@ -159,6 +163,42 @@ sub parse_vcf_header {
     return 1;
 }
 
+sub set_info_key_pairs_in_vcf_record {
+
+## Function : Adds INFO key value pairs to record hash
+## Returns  :
+## Arguments: $vcf_record_href => Hash for variant line data {REF}
+
+    my ($arg_href) = @_;
+
+    ## Flatten argument(s)
+    my $vcf_record_href;
+
+    my $tmpl = {
+        vcf_record_href => {
+            default  => {},
+            defined  => 1,
+            required => 1,
+            store    => \$vcf_record_href,
+        },
+    };
+
+    check( $tmpl, $arg_href, 1 ) or croak q{Could not parse arguments!};
+
+    ## Add INFO elements
+    my @info_elements = split $SEMICOLON, $vcf_record_href->{INFO};
+
+    ## Collect key value pairs from INFO field elements
+  ELEMENT:
+    foreach my $element (@info_elements) {
+
+        my ( $key, $value ) = split $EQUALS, $element;
+
+        $vcf_record_href->{INFO_key_value}{$key} = $value;
+    }
+    return;
+}
+
 sub set_line_elements_in_vcf_record {
 
 ## Function : Adds variant line elements to record hash
@@ -170,7 +210,6 @@ sub set_line_elements_in_vcf_record {
     my ($arg_href) = @_;
 
     ## Flatten argument(s)
-
     my $line_elements_ref;
     my $vcf_format_columns_ref;
     my $vcf_record_href;

--- a/t/set_info_key_pairs_in_vcf_record.t
+++ b/t/set_info_key_pairs_in_vcf_record.t
@@ -1,0 +1,77 @@
+#!/usr/bin/env perl
+
+use 5.026;
+use Carp;
+use charnames qw{ :full :short };
+use English qw{ -no_match_vars };
+use File::Basename qw{ dirname };
+use File::Spec::Functions qw{ catdir };
+use FindBin qw{ $Bin };
+use open qw{ :encoding(UTF-8) :std };
+use Params::Check qw{ allow check last_error };
+use Test::More;
+use utf8;
+use warnings qw{ FATAL utf8 };
+
+## CPANM
+use autodie qw { :all };
+use Modern::Perl qw{ 2017 };
+use Readonly;
+
+## MIPs lib/
+use lib catdir( dirname($Bin), q{lib} );
+use MIP::Constants qw{ $COMMA $SPACE };
+use MIP::Test::Fixtures qw{ test_standard_cli };
+
+my $VERBOSE = 1;
+our $VERSION = 1.00;
+
+$VERBOSE = test_standard_cli(
+    {
+        verbose => $VERBOSE,
+        version => $VERSION,
+    }
+);
+
+BEGIN {
+
+    use MIP::Test::Fixtures qw{ test_import };
+
+### Check all internal dependency modules and imports
+## Modules with import
+    my %perl_module = (
+        q{MIP::File::Format::Vcf} => [qw{ set_info_key_pairs_in_vcf_record }],
+        q{MIP::Test::Fixtures}    => [qw{ test_standard_cli }],
+    );
+
+    test_import( { perl_module_href => \%perl_module, } );
+}
+
+use MIP::File::Format::Vcf qw{ set_info_key_pairs_in_vcf_record };
+
+diag(   q{Test set_info_key_pairs_in_vcf_record from Vcf.pm v}
+      . $MIP::File::Format::Vcf::VERSION
+      . $COMMA
+      . $SPACE . q{Perl}
+      . $SPACE
+      . $PERL_VERSION
+      . $SPACE
+      . $EXECUTABLE_NAME );
+
+## Given an VCF INFO record element
+my %vcf_record = ( INFO => q{AF=1;HGNC_ID=ADK}, );
+
+set_info_key_pairs_in_vcf_record( { vcf_record_href => \%vcf_record, } );
+
+my %expected_vcf_record = (
+    INFO           => q{AF=1;HGNC_ID=ADK},
+    INFO_key_value => {
+        AF      => 1,
+        HGNC_ID => q{ADK},
+    },
+);
+
+## Then key-value pairs should be added under INFO_key_value
+is_deeply( \%vcf_record, \%expected_vcf_record, q{Set INFO key-value pair to hash} );
+
+done_testing();

--- a/vcfparser.pl
+++ b/vcfparser.pl
@@ -415,8 +415,10 @@ sub read_infile_vcf {
 
     check( $tmpl, $arg_href, 1 ) or croak q{Could not parse arguments!};
 
-    use MIP::File::Format::Vcf
-      qw{ check_vcf_variant_line parse_vcf_header set_line_elements_in_vcf_record };
+    use MIP::File::Format::Vcf qw{
+      check_vcf_variant_line parse_vcf_header
+      set_info_key_pairs_in_vcf_record
+      set_line_elements_in_vcf_record };
     use MIP::Vcfparser qw{
       add_feature_file_meta_data_to_vcf
       add_program_to_meta_data_header
@@ -546,7 +548,7 @@ sub read_infile_vcf {
             }
         );
 
-## Adds variant line elements to record hash
+        ## Adds variant line elements to record hash
         set_line_elements_in_vcf_record(
             {
                 line_elements_ref      => \@line_elements,
@@ -555,19 +557,11 @@ sub read_infile_vcf {
             }
         );
 
-        my @info_elements = split( /;/, $record{INFO} );    #Add INFO elements
+        ## Adds INFO key value pairs to record hash
+        set_info_key_pairs_in_vcf_record( { vcf_record_href => \%record, } );
 
-        ## Collect key value pairs in INFO field
-        foreach my $element (@info_elements) {
-
-            my @key_value_pairs =
-              split( "=", $element );    #key index = 0 and value index = 1
-
-            $record{INFO_key_value}{ $key_value_pairs[0] } =
-              $key_value_pairs[1];
-        }
-
-        ## Checks if an interval tree exists (per chr) and collects features from input array and adds annotations to line
+        ## Checks if an interval tree exists (per chr) and
+        ## collects features from input array and adds annotations to line
         %noid_region = tree_annotations(
             {
                 tree_href         => $tree_href,


### PR DESCRIPTION
… hash

- Added test

### This PR fixes:

- Refactor of setting key-value pairs in vcf record hash

### How to test:

- Automatic and continuous test pass

### Expected outcome:
- Installation, unit and integration tests pass

### Review:
- [ ] Code review
- [x] New code is executed and covered by tests
- [x] Tests pass
