### PR TITLE
feat(vcfparser): Use array ref instead to enable using the same sub r…

### DIFF
--- a/lib/MIP/Vcfparser.pm
+++ b/lib/MIP/Vcfparser.pm
@@ -269,7 +269,7 @@ sub add_transcript_to_feature_file {
 ## Returns  :
 ## Arguments: $hgnc_id          => Hgnc id
 ##          : $select_data_href => Select file data {REF}
-##          : $transcript       => Transcript
+##          : $transcripts_ref  => Transcript {REF}
 ##          : $vcf_record_href  => Hash for variant line data {REF}
 
     my ($arg_href) = @_;
@@ -277,7 +277,7 @@ sub add_transcript_to_feature_file {
     ## Flatten argument(s)
     my $hgnc_id;
     my $select_data_href;
-    my $transcript;
+    my $transcripts_ref;
     my $vcf_record_href;
 
     my $tmpl = {
@@ -290,10 +290,11 @@ sub add_transcript_to_feature_file {
             store       => \$select_data_href,
             strict_type => 1,
         },
-        transcript => {
+        transcripts_ref => {
+            default     => [],
             defined     => 1,
             required    => 1,
-            store       => \$transcript,
+            store       => \$transcripts_ref,
             strict_type => 1,
         },
         vcf_record_href => {
@@ -307,7 +308,7 @@ sub add_transcript_to_feature_file {
     check( $tmpl, $arg_href, 1 ) or croak q{Could not parse arguments!};
 
     ## Add all transcripts to range transcripts
-    push @{ $vcf_record_href->{range_transcripts} }, $transcript;
+    push @{ $vcf_record_href->{range_transcripts} }, @{$transcripts_ref};
 
     ## Do not add to select feature
     return if ( not keys %{$select_data_href} or not defined $hgnc_id );
@@ -316,7 +317,7 @@ sub add_transcript_to_feature_file {
     return if ( not $select_data_href->{$hgnc_id} );
 
     ## Add all transcripts to selected transcripts
-    push @{ $vcf_record_href->{select_transcripts} }, $transcript;
+    push @{ $vcf_record_href->{select_transcripts} }, @{$transcripts_ref};
 
     return;
 }

--- a/t/add_transcript_to_feature_file.t
+++ b/t/add_transcript_to_feature_file.t
@@ -24,7 +24,7 @@ use MIP::Constants qw{ $COMMA $SPACE };
 use MIP::Test::Fixtures qw{ test_standard_cli };
 
 my $VERBOSE = 1;
-our $VERSION = 1.00;
+our $VERSION = 1.01;
 
 $VERBOSE = test_standard_cli(
     {
@@ -65,7 +65,7 @@ my %vcf_record;
 add_transcript_to_feature_file(
     {
         vcf_record_href => \%vcf_record,
-        transcript      => $transcript,
+        transcripts_ref => [$transcript],
     }
 );
 
@@ -85,7 +85,7 @@ add_transcript_to_feature_file(
     {
         vcf_record_href  => \%vcf_record,
         select_data_href => \%select_data,
-        transcript       => $transcript,
+        transcripts_ref  => [$transcript],
     }
 );
 
@@ -106,7 +106,7 @@ add_transcript_to_feature_file(
         hgnc_id          => $hgnc_id,
         vcf_record_href  => \%vcf_record,
         select_data_href => \%select_data,
-        transcript       => $transcript,
+        transcripts_ref  => [$transcript],
     }
 );
 
@@ -127,7 +127,7 @@ add_transcript_to_feature_file(
         hgnc_id          => $hgnc_id,
         vcf_record_href  => \%vcf_record,
         select_data_href => \%select_data,
-        transcript       => $transcript,
+        transcripts_ref  => [$transcript],
     }
 );
 

--- a/vcfparser.pl
+++ b/vcfparser.pl
@@ -912,7 +912,7 @@ sub parse_vep_csq {
                     {
                         hgnc_id          => $transcript_csq{hgnc_id},
                         select_data_href => $select_data_href,
-                        transcript       => $transcript,
+                        transcripts_ref  => [$transcript],
                         vcf_record_href  => $record_href,
                     }
                 );
@@ -922,7 +922,7 @@ sub parse_vep_csq {
             ## Not part of a coding region
             add_transcript_to_feature_file(
                 {
-                    transcript      => $transcript,
+                    transcripts_ref => [$transcript],
                     vcf_record_href => $record_href,
                 }
             );
@@ -972,8 +972,14 @@ sub parse_vep_csq {
         if (    not keys %{$consequence_href}
             and not exists $record_href->{range_transcripts} )
         {
+
             ## Add all transcripts to range transcripts
-            push( @{ $record_href->{range_transcripts} }, @transcripts );
+            add_transcript_to_feature_file(
+                {
+                    transcripts_ref => \@transcripts,
+                    vcf_record_href => $record_href,
+                }
+            );
         }
     }
 


### PR DESCRIPTION
…outine for adding transcripts

- Modified sub and test accordingly

### This PR fixes:

- Using array ref as param call for transcripts - enabling reuse of sub

### How to test:

- Automatic and continuous test pass

### Expected outcome:
- Installation, unit and integration tests pass

### Review:
- [ ] Code review
- [ ] New code is executed and covered by tests
- [ ] Tests pass
