### PR TITLE
feat(download_check): Added runstatus recipe for download pipelines. Fix

### DIFF
--- a/definitions/download_rd_dna_parameters.yaml
+++ b/definitions/download_rd_dna_parameters.yaml
@@ -227,6 +227,7 @@ recipe_core_number:
     manta_call_regions: 1
     mills_and_1000g_indels: 1
     gatk_mitochondrial_ref: 1
+    runstatus: 1
     rank_model: 1
     reduced_penetrance: 1
     scout_exons: 1
@@ -266,6 +267,7 @@ recipe_time:
     gatk_mitochondrial_ref: 1
     rank_model: 1
     reduced_penetrance: 1
+    runstatus: 1
     scout_exons: 1
     svrank_model: 1
     sv_vcfanno_config: 1
@@ -282,6 +284,13 @@ reference_feature:
    - mip
   data_type: HASH
   type: mip
+runstatus:
+  analysis_mode: case
+  associated_recipe:
+   - mip
+  data_type: SCALAR
+  default: 1
+  type: recipe
 scout_exons:
   analysis_mode: case
   associated_recipe:

--- a/definitions/download_rd_rna_parameters.yaml
+++ b/definitions/download_rd_rna_parameters.yaml
@@ -60,6 +60,7 @@ recipe_core_number:
     human_reference: 1
     gencode_annotation: 1
     mills_and_1000g_indels: 1
+    runstatus: 1
   type: mip
 recipe_time:
   associated_recipe:
@@ -72,9 +73,17 @@ recipe_time:
     human_reference: 1
     gencode_annotation: 1
     mills_and_1000g_indels: 1
+    runstatus: 1
   type: mip
 reference_feature:
   associated_recipe:
    - mip
   data_type: HASH
   type: mip
+runstatus:
+  analysis_mode: case
+  associated_recipe:
+   - mip
+  data_type: SCALAR
+  default: 1
+  type: recipe

--- a/definitions/rd_dna_parameters.yaml
+++ b/definitions/rd_dna_parameters.yaml
@@ -1887,6 +1887,7 @@ genmod_annotate_spidex_file:
    - rankvariant
   data_type: SCALAR
   exists_check: file
+  mandatory: no
   reference: reference_dir
   type: path
 genmod_models_case_type:

--- a/lib/MIP/Recipes/Download/Runstatus.pm
+++ b/lib/MIP/Recipes/Download/Runstatus.pm
@@ -1,4 +1,4 @@
-package MIP::Recipes::Download::RECIPE_NAME;
+package MIP::Recipes::Download::Runstatus;
 
 use 5.026;
 use Carp;
@@ -18,7 +18,7 @@ use autodie qw{ :all };
 use Readonly;
 
 ## MIPs lib/
-use MIP::Constants qw{ $LOG $NEWLINE $SPACE $UNDERSCORE };
+use MIP::Constants qw{ $LOG $NEWLINE $SPACE $TAB $UNDERSCORE };
 
 BEGIN {
 
@@ -29,40 +29,30 @@ BEGIN {
     our $VERSION = 1.00;
 
     # Functions and variables which can be optionally exported
-    our @EXPORT_OK = qw{ download_RECIPE_NAME };
+    our @EXPORT_OK = qw{ download_runstatus };
 
 }
 
-sub download_RECIPE_NAME {
+sub download_runstatus {
 
-## Function : Download RECIPE_NAME
+## Function : Download run status
 ## Returns  :
 ## Arguments: $active_parameter_href => Active parameters for this download hash {REF}
-##          : $genome_version        => Human genome version
 ##          : $job_id_href           => The job_id hash {REF}
 ##          : $profile_base_command  => Submission profile base command
 ##          : $recipe_name           => Recipe name
-##          : $reference_href        => Reference hash {REF}
-##          : $reference_version     => Reference version
-##          : $quiet                 => Quiet (no output)
 ##          : $temp_directory        => Temporary directory for recipe
-##          : $verbose               => Verbosity
 
     my ($arg_href) = @_;
 
     ## Flatten argument(s)
     my $active_parameter_href;
-    my $genome_version;
     my $job_id_href;
     my $recipe_name;
-    my $reference_href;
-    my $reference_version;
 
     ## Default(s)
     my $profile_base_command;
-    my $quiet;
     my $temp_directory;
-    my $verbose;
 
     my $tmpl = {
         active_parameter_href => {
@@ -70,10 +60,6 @@ sub download_RECIPE_NAME {
             defined     => 1,
             required    => 1,
             store       => \$active_parameter_href,
-            strict_type => 1,
-        },
-        genome_version => {
-            store       => \$genome_version,
             strict_type => 1,
         },
         job_id_href => {
@@ -94,25 +80,6 @@ sub download_RECIPE_NAME {
             store       => \$recipe_name,
             strict_type => 1,
         },
-        reference_href => {
-            default     => {},
-            defined     => 1,
-            required    => 1,
-            store       => \$reference_href,
-            strict_type => 1,
-        },
-        reference_version => {
-            defined     => 1,
-            required    => 1,
-            store       => \$reference_version,
-            strict_type => 1,
-        },
-        quiet => {
-            allow       => [ undef, 0, 1 ],
-            default     => 1,
-            store       => \$quiet,
-            strict_type => 1,
-        },
         temp_directory => {
             store       => \$temp_directory,
             strict_type => 1,
@@ -121,11 +88,10 @@ sub download_RECIPE_NAME {
 
     check( $tmpl, $arg_href, 1 ) or croak q{Could not parse arguments!};
 
+    use MIP::Check::File qw{ check_mip_process_files };
     use MIP::Get::Parameter qw{ get_recipe_resources };
-    use MIP::Recipes::Download::Get_reference qw{ get_reference };
     use MIP::Script::Setup_script qw{ setup_script };
-    use MIP::Processmanagement::Slurm_processes
-      qw{ slurm_submit_job_no_dependency_dead_end };
+    use MIP::Processmanagement::Processes qw{ submit_recipe };
 
     ### PREPROCESSING:
 
@@ -152,19 +118,19 @@ sub download_RECIPE_NAME {
     ## Creates recipe directories (info & data & script), recipe script filenames and writes sbatch header
     my ( $recipe_file_path, $recipe_info_path ) = setup_script(
         {
-            active_parameter_href      => $active_parameter_href,
-            core_number                => $recipe_resource{core_number},
-            directory_id               => q{mip_download},
-            FILEHANDLE                 => $FILEHANDLE,
-            job_id_href                => $job_id_href,
-            log                        => $log,
-            memory_allocation          => $recipe_resource{memory},
-            outdata_dir                => $reference_dir,
-            outscript_dir              => $reference_dir,
-            process_time               => $recipe_resource{time},
-            recipe_data_directory_path => $active_parameter_href->{reference_dir},
-            recipe_directory           => $recipe_name . $UNDERSCORE . $reference_version,
-            recipe_name                => $recipe_name,
+            active_parameter_href           => $active_parameter_href,
+            core_number                     => $recipe_resource{core_number},
+            directory_id                    => q{mip_download},
+            FILEHANDLE                      => $FILEHANDLE,
+            job_id_href                     => $job_id_href,
+            log                             => $log,
+            memory_allocation               => $recipe_resource{memory},
+            outdata_dir                     => $reference_dir,
+            outscript_dir                   => $reference_dir,
+            process_time                    => $recipe_resource{time},
+            recipe_data_directory_path      => $active_parameter_href->{reference_dir},
+            recipe_directory                => $recipe_name,
+            recipe_name                     => $recipe_name,
             source_environment_commands_ref => $recipe_resource{load_env_ref},
         }
     );
@@ -173,29 +139,35 @@ sub download_RECIPE_NAME {
 
     say {$FILEHANDLE} q{## } . $recipe_name;
 
-    get_reference(
+    ## Set status flagg
+    say {$FILEHANDLE} q?STATUS="0"?;
+
+    check_mip_process_files(
         {
-            FILEHANDLE     => $FILEHANDLE,
-            recipe_name    => $recipe_name,
-            reference_dir  => $reference_dir,
-            reference_href => $reference_href,
-            quiet          => $quiet,
-            verbose        => $verbose,
+            FILEHANDLE => $FILEHANDLE,
+            paths_ref  => $active_parameter_href->{runstatus_paths},
         }
     );
+
+    say {$FILEHANDLE} q?if [ "$STATUS" -eq 1 ]; then?;
+    say {$FILEHANDLE} $TAB . q?exit 1?;
+    say {$FILEHANDLE} q?fi?, $NEWLINE;
 
     ## Close FILEHANDLES
     close $FILEHANDLE or $log->logcroak(q{Could not close FILEHANDLE});
 
     if ( $recipe_mode == 1 ) {
 
-        ## No upstream or downstream dependencies
-        slurm_submit_job_no_dependency_dead_end(
+        submit_recipe(
             {
-                base_command     => $profile_base_command,
-                job_id_href      => $job_id_href,
-                log              => $log,
-                sbatch_file_name => $recipe_file_path,
+                base_command        => $profile_base_command,
+                dependency_method   => q{add_to_all},
+                job_dependency_type => q{afterany},
+                job_id_chain        => q{PAN},
+                job_id_href         => $job_id_href,
+                log                 => $log,
+                recipe_file_path    => $recipe_file_path,
+                submission_profile  => $active_parameter_href->{submission_profile},
             }
         );
     }

--- a/t/check_mip_process_files.t
+++ b/t/check_mip_process_files.t
@@ -1,0 +1,93 @@
+#!/usr/bin/env perl
+
+use 5.026;
+use Carp;
+use charnames qw{ :full :short };
+use Cwd;
+use English qw{ -no_match_vars };
+use File::Basename qw{ dirname };
+use File::Spec::Functions qw{ catdir catfile };
+use FindBin qw{ $Bin };
+use File::Temp;
+use open qw{ :encoding(UTF-8) :std };
+use Params::Check qw{ allow check last_error };
+use Test::More;
+use utf8;
+use warnings qw{ FATAL utf8 };
+
+## CPANM
+use autodie qw { :all };
+use Modern::Perl qw{ 2018 };
+use Readonly;
+
+## MIPs lib/
+use lib catdir( dirname($Bin), q{lib} );
+use MIP::Constants qw{ $COLON $COMMA $SPACE };
+use MIP::Test::Fixtures qw{ test_standard_cli };
+
+my $VERBOSE = 1;
+our $VERSION = 1.00;
+
+$VERBOSE = test_standard_cli(
+    {
+        verbose => $VERBOSE,
+        version => $VERSION,
+    }
+);
+
+BEGIN {
+
+    use MIP::Test::Fixtures qw{ test_import };
+
+### Check all internal dependency modules and imports
+## Modules with import
+    my %perl_module = (
+        q{MIP::Check::File}    => [qw{ check_mip_process_files }],
+        q{MIP::Test::Fixtures} => [qw{ test_standard_cli }],
+    );
+
+    test_import( { perl_module_href => \%perl_module, } );
+}
+
+use MIP::Check::File qw{ check_mip_process_files };
+use MIP::Unix::System qw{ system_cmd_call };
+
+diag(   q{Test check_mip_process_files from File.pm v}
+      . $MIP::Check::File::VERSION
+      . $COMMA
+      . $SPACE . q{Perl}
+      . $SPACE
+      . $PERL_VERSION
+      . $SPACE
+      . $EXECUTABLE_NAME );
+
+my $test_dir       = File::Temp->newdir();
+my $test_file_path = catfile( $test_dir, q{test.sh} );
+
+open my $FILEHANDLE, q{>}, $test_file_path
+  or croak q{Cannot write to} . $SPACE . $test_file_path . $COLON . $SPACE . $OS_ERROR;
+
+## Given path that exists and one that does not
+my @paths = ( $test_file_path, catfile( cwd(), q{does_not_exist.test} ) );
+
+my $is_ok = check_mip_process_files(
+    {
+        FILEHANDLE => $FILEHANDLE,
+        paths_ref  => \@paths,
+    }
+);
+
+close $FILEHANDLE;
+
+## Then bash function should be written
+ok( $is_ok, q{Wrote bash test} );
+
+my %return = system_cmd_call( { command_string => q{bash } . $test_file_path } );
+
+## Then "test.sh" file should be found
+like( $return{output}[0], qr/Found\s+file/sxm, q{Found file test} );
+
+## Then does_not_exist.test file should not be found
+like( $return{error}[0], qr/Could\s+not\s+find/sxm, q{Could not find file test} );
+
+done_testing();

--- a/t/download_runstatus.t
+++ b/t/download_runstatus.t
@@ -1,0 +1,97 @@
+#!/usr/bin/env perl
+
+use 5.026;
+use Carp;
+use charnames qw{ :full :short };
+use English qw{ -no_match_vars };
+use File::Basename qw{ dirname };
+use File::Spec::Functions qw{ catdir catfile };
+use File::Temp;
+use FindBin qw{ $Bin };
+use open qw{ :encoding(UTF-8) :std };
+use Params::Check qw{ allow check last_error };
+use Test::More;
+use utf8;
+use warnings qw{ FATAL utf8 };
+
+## CPANM
+use autodie qw { :all };
+use Modern::Perl qw{ 2018 };
+use Readonly;
+
+## MIPs lib/
+use lib catdir( dirname($Bin), q{lib} );
+use MIP::Constants qw{ $COMMA $SPACE };
+use MIP::Test::Fixtures qw{ test_log test_mip_hashes test_standard_cli };
+
+my $VERBOSE = 1;
+our $VERSION = 1.00;
+
+$VERBOSE = test_standard_cli(
+    {
+        verbose => $VERBOSE,
+        version => $VERSION,
+    }
+);
+
+BEGIN {
+
+    use MIP::Test::Fixtures qw{ test_import };
+
+### Check all internal dependency modules and imports
+## Modules with import
+    my %perl_module = (
+        q{MIP::Recipes::Download::Runstatus} => [qw{ download_runstatus }],
+        q{MIP::Test::Fixtures} => [qw{ test_log test_mip_hashes test_standard_cli }],
+    );
+
+    test_import( { perl_module_href => \%perl_module, } );
+}
+
+use MIP::Recipes::Download::Runstatus qw{ download_runstatus };
+
+diag(   q{Test download_runstatus from Runstatus.pm v}
+      . $MIP::Recipes::Download::Runstatus::VERSION
+      . $COMMA
+      . $SPACE . q{Perl}
+      . $SPACE
+      . $PERL_VERSION
+      . $SPACE
+      . $EXECUTABLE_NAME );
+
+my $test_dir  = File::Temp->newdir();
+my $file_path = catfile( $test_dir, q{recipe_script.sh} );
+my $log       = test_log( { log_name => uc q{mip_download}, no_screen => 1, } );
+
+## Given download parameters for recipe
+my $recipe_name    = q{runstatus};
+my $slurm_mock_cmd = catfile( $Bin, qw{ data modules slurm-mock.pl } );
+
+my %active_parameter = test_mip_hashes(
+    {
+        mip_hash_name => q{download_active_parameter},
+    }
+);
+$active_parameter{$recipe_name}                     = 1;
+$active_parameter{project_id}                       = q{test};
+$active_parameter{reference_dir}                    = catfile($test_dir);
+$active_parameter{recipe_core_number}{$recipe_name} = 1;
+$active_parameter{recipe_time}{$recipe_name}        = 1;
+@{ $active_parameter{runstatus_paths} } = (q{a_test_file.txt});
+
+my %job_id;
+
+my $is_ok = download_runstatus(
+    {
+        active_parameter_href => \%active_parameter,
+        job_id_href           => \%job_id,
+        profile_base_command  => $slurm_mock_cmd,
+        recipe_name           => $recipe_name,
+        temp_directory        => catfile($test_dir),
+    }
+);
+
+## Then
+ok( $is_ok, q{ Executed download recipe } . $recipe_name );
+
+done_testing();


### PR DESCRIPTION
- Runstatus will check file existence
- Always execute after all potential downloads have completed
- Write to stderr if an expected file has not been found and also exit
  with an error code of "1"
- Write to stdout for all files that are found
- Adds a sacct command in trap functions to write each STATUS of
  download recipes to "log.status" file just like in analysis
- Added to both rd_dna and rd_rna pipelines
- Added tests

### This PR fixes:

- The above

### How to test:

- Automatic and continuous test pass

### Expected outcome:
- Installation, unit and integration tests pass

### Review:
- [x] Code review
- [x] New code is executed and covered by tests
- [x] Tests pass
