### PR TITLE
Hotfix/vcfparser

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 All notable changes to this project will be documented in this file.
 This project adheres to [Semantic Versioning](http://semver.org/).
 
+##[7.1.4]
+- Fix bug in outfile_path when mitochondria contig is not part of gene panel
+
 ## [7.2.3]
 - Increased sv_varianteffectpredictor memory parameter 8 -> 9 Gb
 

--- a/lib/MIP/Constants.pm
+++ b/lib/MIP/Constants.pm
@@ -60,7 +60,7 @@ BEGIN {
 ## Constants
 ## Set MIP version
 ## Constants
-Readonly our $MIP_VERSION => q{v7.1.3};
+Readonly our $MIP_VERSION => q{v7.1.4};
 
 ## Cli
 Readonly our $MOOSEX_APP_SCEEN_WIDTH => 160;

--- a/lib/MIP/Recipes/Analysis/Mip_vcfparser.pm
+++ b/lib/MIP/Recipes/Analysis/Mip_vcfparser.pm
@@ -27,7 +27,7 @@ BEGIN {
     use base qw{ Exporter };
 
     # Set the version for version checking
-    our $VERSION = 1.15;
+    our $VERSION = 1.16;
 
     # Functions and variables which can be optionally exported
     our @EXPORT_OK =
@@ -1224,7 +1224,6 @@ sub _add_all_mt_var_from_research_to_clinical {
             strict_type => 1,
         },
         outfile_path => {
-            defined     => 1,
             required    => 1,
             store       => \$outfile_path,
             strict_type => 1,
@@ -1232,6 +1231,8 @@ sub _add_all_mt_var_from_research_to_clinical {
     };
 
     check( $tmpl, $arg_href, 1 ) or croak q{Could not parse arguments!};
+
+    return if ( not defined $outfile_path );
 
     if ( $add_all_mt_var and $contig =~ / MT | M /sxm ) {
 


### PR DESCRIPTION
### This PR fixes:

- Fixed bug with outfile path when mitochondria contig is not part of gene panel

### How to test:

- Automatic and continuous test pass

### Expected outcome:
- Installation, unit and integration tests pass

### Review:
- [x] Code review
- [x] New code is executed and covered by tests
- [x] Tests pass
