### PR TITLE
fix(vcfparser): Fixed bug with outfile path when mitochondria contig is

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,11 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 - rhocall: 0.4 -> 0.5.1
 - upd: 0.1
 
+##[7.1.4]
+- Fix bug in outfile_path when mitochondria contig is not part of gene panel
+
+## [7.1.3]
+- Increased sv_varianteffectpredictor memory parameter 8 -> 9 Gb
 
 ##[7.1.2]
 - Update samtools_subsample_mt to fix bug in downsampling of MT bam

--- a/lib/MIP/Constants.pm
+++ b/lib/MIP/Constants.pm
@@ -74,7 +74,7 @@ Readonly our %ANALYSIS => (
 );
 
 ## Set MIP version
-Readonly our $MIP_VERSION => q{v7.1.2};
+Readonly our $MIP_VERSION => q{v7.1.4};
 
 ## Cli
 Readonly our $MOOSEX_APP_SCEEN_WIDTH => 160;

--- a/lib/MIP/Recipes/Analysis/Mip_vcfparser.pm
+++ b/lib/MIP/Recipes/Analysis/Mip_vcfparser.pm
@@ -27,7 +27,7 @@ BEGIN {
     use base qw{ Exporter };
 
     # Set the version for version checking
-    our $VERSION = 1.16;
+    our $VERSION = 1.17;
 
     # Functions and variables which can be optionally exported
     our @EXPORT_OK =
@@ -1237,7 +1237,6 @@ sub _add_all_mt_var_from_research_to_clinical {
             strict_type => 1,
         },
         outfile_path => {
-            defined     => 1,
             required    => 1,
             store       => \$outfile_path,
             strict_type => 1,
@@ -1245,6 +1244,8 @@ sub _add_all_mt_var_from_research_to_clinical {
     };
 
     check( $tmpl, $arg_href, 1 ) or croak q{Could not parse arguments!};
+
+    return if ( not defined $outfile_path );
 
     if ( $add_all_mt_var and $contig =~ / $MT_CONTIG_ID_REG_EXP /sxm ) {
 


### PR DESCRIPTION
not part of gene panel

### This PR fixes:

- See above

### How to test:

- Automatic and continuous test pass

### Expected outcome:
- Installation, unit and integration tests pass

### Review:
- [ ] Code review
- [ ] New code is executed and covered by tests
- [ ] Tests pass
