### PR TITLE
fix(sv_varianteffectpredictor): memory increase

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 All notable changes to this project will be documented in this file.
 This project adheres to [Semantic Versioning](http://semver.org/).
 
+## [7.1.5]
+- Increased sv_varianteffectpredictor memory parameter 9 -> 18 Gb
+
 ## [7.1.4]
 - Fix bug in outfile_path when mitochondria contig is not part of gene panel
 

--- a/definitions/rd_dna_parameters.yaml
+++ b/definitions/rd_dna_parameters.yaml
@@ -219,7 +219,7 @@ recipe_memory:
     split_fastq_file: 2
     sv_annotate: 7
     sv_reformat: 24
-    sv_varianteffectpredictor: 9
+    sv_varianteffectpredictor: 18
     tiddit: 8
     vcf2cytosure_ar: 6
     varianteffectpredictor: 7

--- a/lib/MIP/Constants.pm
+++ b/lib/MIP/Constants.pm
@@ -60,7 +60,7 @@ BEGIN {
 ## Constants
 ## Set MIP version
 ## Constants
-Readonly our $MIP_VERSION => q{v7.1.4};
+Readonly our $MIP_VERSION => q{v7.1.5};
 
 ## Cli
 Readonly our $MOOSEX_APP_SCEEN_WIDTH => 160;


### PR DESCRIPTION
### This PR fixes:

sv_varianteffectpredictor fails with memory errors for some samples. This PR increases the memory of sv_varianteffectpredictor to 18 G per process. Have tried 12 and 15 G as well without success.

### How to test:

- Automatic and continuous test pass

### Expected outcome:
- Installation, unit and integration tests pass

### Review:
- [x] Runs on hasta
- [x] Code review
- [ ] New code is executed and covered by tests
- [ ] Tests pass
