### PR TITLE
feat(vep and delly): Modifed parameters

### DIFF
--- a/definitions/rd_dna_parameters.yaml
+++ b/definitions/rd_dna_parameters.yaml
@@ -676,7 +676,7 @@ delly_call:
   associated_recipe:
    - mip
   data_type: SCALAR
-  default: 1
+  default: 0
   file_tag: _dellycall
   program_executables:
    - delly
@@ -687,7 +687,7 @@ delly_reformat:
   associated_recipe:
    - mip
   data_type: SCALAR
-  default: 1
+  default: 0
   file_tag: _dellyreformat
   program_executables:
    - delly
@@ -807,7 +807,7 @@ sv_svdb_merge_prioritize:
   associated_recipe:
    - sv_combinevariantcallsets
   data_type: SCALAR
-  mandatory: no
+  default: tiddit,cnvnator,manta
   type: recipe_argument
 sv_vt_decompose:
   associated_recipe:
@@ -935,7 +935,6 @@ sv_vep_features:
    - offline
    - per_gene
    - protein
-   - regulatory
    - symbol
    - tsl
    - uniprot

--- a/templates/grch38_mip_rd_dna_config.yaml
+++ b/templates/grch38_mip_rd_dna_config.yaml
@@ -79,7 +79,6 @@ outdata_dir: cluster_constant_path!/case_id!/analysis_constant_path!
 outscript_dir: cluster_constant_path!/case_id!/analysis_constant_path!/scripts
 sample_info_file: cluster_constant_path!/case_id!/analysis_constant_path!/case_id!_qc_sample_info.yaml
 ## References
-delly_exclude_file: grch38_human_excl_-20150915-.tsv
 expansionhunter_variant_catalog_file_path: grch38_expansionhunter_variant_catalog_-3.0.1-.json
 fqf_vcfanno_config: grch38_frequency_vcfanno_filter_config_-v1.1-.toml
 gatk_baserecalibration_known_sites:
@@ -153,7 +152,7 @@ sv_combinevariantcallsets_bcf_file: 1
 sv_genmod_annotate_regions: 1
 sv_frequency_filter: 1
 sv_genmod_models_case_type: cmms
-sv_svdb_merge_prioritize: tiddit,cnvnator,manta,delly
+sv_svdb_merge_prioritize: tiddit,cnvnator,manta
 sv_svdb_query: 1
 sv_vcfparser_per_gene: 1
 sv_vcfparser_vep_transcripts: 1

--- a/templates/mip_rd_dna_config.yaml
+++ b/templates/mip_rd_dna_config.yaml
@@ -135,7 +135,6 @@ sv_combinevariantcallsets_bcf_file: 1
 sv_genmod_annotate_regions: 1
 sv_frequency_filter: 1
 sv_genmod_models_case_type: cmms
-sv_svdb_merge_prioritize: tiddit,cnvnator,manta,delly
 sv_svdb_query: 1
 sv_vcfparser_per_gene: 1
 sv_vcfparser_select_file_matching_column: 3


### PR DESCRIPTION
### This PR fixes:
- Removed sv_vep_feature "regulatory"
- Switched off delly_call and delly_reformat
- Removed delly from svdb prio string
- Set default string in parameters

### How to test:

- Automatic and continuous test pass

### Expected outcome:
- Installation, unit and integration tests pass

### Review:
- [x] Code review
- [x] New code is executed and covered by tests
- [x] Tests pass
