### PR TITLE
feat(sambamba_index): Detected a possible race condition between cp of

### DIFF
--- a/lib/MIP/Recipes/Analysis/Expansionhunter.pm
+++ b/lib/MIP/Recipes/Analysis/Expansionhunter.pm
@@ -24,7 +24,7 @@ BEGIN {
     use base qw{ Exporter };
 
     # Set the version for version checking
-    our $VERSION = 1.16;
+    our $VERSION = 1.18;
 
     # Functions and variables which can be optionally exported
     our @EXPORT_OK = qw{ analysis_expansionhunter };
@@ -141,7 +141,6 @@ sub analysis_expansionhunter {
     use MIP::Get::File qw{ get_io_files };
     use MIP::Get::Parameter
       qw{ get_package_source_env_cmds get_pedigree_sample_id_attributes get_recipe_attributes get_recipe_resources };
-    use MIP::Gnu::Coreutils qw{ gnu_cp };
     use MIP::Parse::File qw{ parse_io_outfiles };
     use MIP::Processmanagement::Processes qw{ print_wait submit_recipe };
     use MIP::Program::Variantcalling::Bcftools
@@ -268,22 +267,6 @@ sub analysis_expansionhunter {
 
     }
     say {$FILEHANDLE} q{wait}, $NEWLINE;
-
-    ## Rename the bam file index file so that Expansion Hunter can find it
-    say {$FILEHANDLE} q{## Rename index file};
-  SAMPLE_ID:
-    foreach my $sample_id ( @{ $active_parameter_href->{sample_ids} } ) {
-
-        gnu_cp(
-            {
-                FILEHANDLE   => $FILEHANDLE,
-                force        => 1,
-                infile_path  => $exphun_sample_file_info{$sample_id}{out} . q{.bai},
-                outfile_path => $exphun_sample_file_info{$sample_id}{in} . q{.bai},
-            }
-        );
-        say {$FILEHANDLE} $NEWLINE;
-    }
 
     ## Run Expansion Hunter
     say {$FILEHANDLE} q{## Run ExpansionHunter};

--- a/lib/MIP/Recipes/Analysis/Gatk_baserecalibration.pm
+++ b/lib/MIP/Recipes/Analysis/Gatk_baserecalibration.pm
@@ -26,7 +26,7 @@ BEGIN {
     use base qw{ Exporter };
 
     # Set the version for version checking
-    our $VERSION = 1.14;
+    our $VERSION = 1.15;
 
     # Functions and variables which can be optionally exported
     our @EXPORT_OK = qw{ analysis_gatk_baserecalibration };
@@ -157,6 +157,7 @@ sub analysis_gatk_baserecalibration {
     use MIP::Get::File qw{ get_merged_infile_prefix get_io_files };
     use MIP::Get::Parameter
       qw{ get_gatk_intervals get_recipe_attributes get_recipe_resources };
+    use MIP::Gnu::Coreutils qw{ gnu_cp };
     use MIP::Parse::File qw{ parse_io_outfiles };
     use MIP::Processmanagement::Processes qw{ submit_recipe };
     use MIP::Program::Alignment::Gatk
@@ -427,6 +428,20 @@ sub analysis_gatk_baserecalibration {
             outfile_path         => $outfile_path_prefix . $outfile_suffix,
             referencefile_path   => $referencefile_path,
             temp_directory       => $temp_directory,
+        }
+    );
+    say {$FILEHANDLE} $NEWLINE;
+
+    ## Rename the bam file index file so that Expansion Hunter can find it
+    say {$FILEHANDLE}
+      q{## Copy index file to ".bam.bai" so that Expansionhunter can find it downstream};
+
+    gnu_cp(
+        {
+            FILEHANDLE   => $FILEHANDLE,
+            force        => 1,
+            infile_path  => $outfile_path_prefix . q{.bai},
+            outfile_path => $outfile_path_prefix . $outfile_suffix . q{.bai},
         }
     );
     say {$FILEHANDLE} $NEWLINE;


### PR DESCRIPTION
BAM index file and reading the file being copied.

- Create index file required for Expansionhunter in gatk baserecal
  recipe instead of in expansionhunter recipe

### This PR fixes:

- Sambamba depth error 

### How to test:

- Automatic and continuous test pass

### Expected outcome:
- Installation, unit and integration tests pass

### Review:
- [x] Code review
- [x] New code is executed and covered by tests
- [ ] Tests pass
