### PR TITLE
fix(rna): no capture kit for rna

### DIFF
--- a/lib/MIP/Get/Parameter.pm
+++ b/lib/MIP/Get/Parameter.pm
@@ -420,7 +420,6 @@ sub get_gatk_intervals {
             strict_type => 1,
         },
         exome_target_bed_href => {
-            default     => {},
             store       => \$exome_target_bed_href,
             strict_type => 1,
         },


### PR DESCRIPTION
### This PR fixes:

Since the RNA pipeline doesn't have the capture_kit key in it's pedigree the parameter $active_parameter_href->{exome_target_bed} is undef. This caused problem for the get_gatk_intervals sub in the baserecalibration recipe where it was required to be a hash. In this sub the parameter is only needed for wes. There is still a type check for wes samples on that parameter, where it is actually needed.     

### How to test:

- Automatic and continuous test pass

### Expected outcome:
- Installation, unit and integration tests pass

### Review:
- [x] Code review
- [ ] New code is executed and covered by tests
- [ ] Tests pass
