### PR TITLE
feat(chromograph): Modifed chromograph dependencies and recipes

### DIFF
--- a/containers/Singularity.chromograph-0.1
+++ b/containers/Singularity.chromograph-0.1
@@ -51,7 +51,7 @@ From: ubuntu:xenial
     conda config --add channels bioconda
 
     ## Install conda packages
-    conda install --yes pip python=3.7
+    conda install --yes pip python=3.7 matplotlib
 
     ## Clean up after conda
     /opt/conda/bin/conda clean -tipsy

--- a/containers/Singularity.chromograph-0.2
+++ b/containers/Singularity.chromograph-0.2
@@ -6,7 +6,7 @@ From: ubuntu:xenial
 
 %labels
     Maintainer Clinical-Genomics/MIP
-    Version 0.1
+    Version 0.2
 
 %environment
     SHELL=/bin/bash

--- a/definitions/rd_dna_initiation_map.yaml
+++ b/definitions/rd_dna_initiation_map.yaml
@@ -67,9 +67,9 @@ CHAIN_ALL:
       - rhocall_ar
       - vt_ar
       - frequency_annotation
-      - CHAIN_CHROMOGRAPH:
-        - upd_ar
+      - CHAIN_RHOCALL_VIZ:
         - rhocall_viz
+      - CHAIN_CHROMOGRAPH:
         - chromograph_ar
       - frequency_filter
       - cadd_ar

--- a/definitions/rd_dna_parameters.yaml
+++ b/definitions/rd_dna_parameters.yaml
@@ -1529,7 +1529,7 @@ upd_ar:
   associated_recipe:
    - mip
   data_type: SCALAR
-  default: 1
+  default: 0
   file_tag: _upd
   outfile_suffix: ".bed"
   program_executables:

--- a/lib/MIP/Recipes/Analysis/Chromograph.pm
+++ b/lib/MIP/Recipes/Analysis/Chromograph.pm
@@ -28,13 +28,13 @@ BEGIN {
     our $VERSION = 1.03;
 
     # Functions and variables which can be optionally exported
-    our @EXPORT_OK = qw{ analysis_chromograph };
+    our @EXPORT_OK = qw{ analysis_chromograph analysis_chromograph_proband };
 
 }
 
 sub analysis_chromograph {
 
-## Function : Visualize chromosomes using chromograph
+## Function : Visualize chromosomes using chromograph using tiddit coverage data
 ## Returns  :
 ## Arguments: $active_parameter_href   => Active parameters for this analysis hash {REF}
 ##          : $case_id                 => Family id
@@ -132,7 +132,6 @@ sub analysis_chromograph {
 
     check( $tmpl, $arg_href, 1 ) or croak q{Could not parse arguments!};
 
-    use MIP::File::Format::Pedigree qw{ is_sample_proband_in_trio };
     use MIP::Get::File qw{ get_io_files };
     use MIP::Get::Parameter qw{ get_recipe_attributes  get_recipe_resources };
     use MIP::Program::Compression::Tar qw{ tar };
@@ -149,6 +148,7 @@ sub analysis_chromograph {
 
     ## Unpack parameters
     ## Get the io infiles per chain and id
+
     my %io = get_io_files(
         {
             id             => $sample_id,
@@ -230,47 +230,303 @@ sub analysis_chromograph {
     );
     say {$FILEHANDLE} $NEWLINE;
 
-    ## Process potential upd files, only applicable for proband
-    my $is_sample_proband_in_trio = is_sample_proband_in_trio(
+    tar(
         {
-            sample_id        => $sample_id,
-            sample_info_href => $sample_info_href,
+            create       => 1,
+            FILEHANDLE   => $FILEHANDLE,
+            file_path    => $outfile_path,
+            filter_gzip  => 1,
+            in_paths_ref => [$outdir_path],
+        }
+    );
+    say {$FILEHANDLE} $NEWLINE;
+
+    ## Close FILEHANDLES
+    close $FILEHANDLE or $log->logcroak(q{Could not close FILEHANDLE});
+
+    if ( $recipe_mode == 1 ) {
+
+        ## Collect QC metadata info for later use
+        set_recipe_outfile_in_sample_info(
+            {
+                path             => $outfile_path,
+                recipe_name      => $recipe_name,
+                sample_id        => $sample_id,
+                sample_info_href => $sample_info_href,
+            }
+        );
+
+        submit_recipe(
+            {
+                base_command            => $profile_base_command,
+                case_id                 => $case_id,
+                dependency_method       => q{case_to_sample},
+                infile_lane_prefix_href => $infile_lane_prefix_href,
+                job_id_chain            => $job_id_chain,
+                job_id_href             => $job_id_href,
+                log                     => $log,
+                recipe_file_path        => $recipe_file_path,
+                sample_id               => $sample_id,
+                submission_profile      => $active_parameter_href->{submission_profile},
+            }
+        );
+    }
+    return 1;
+}
+
+sub analysis_chromograph_proband {
+
+## Function : Visualize chromosomes using chromograph with tiddit_coverage and upd data
+## Returns  :
+## Arguments: $active_parameter_href   => Active parameters for this analysis hash {REF}
+##          : $case_id                 => Family id
+##          : $file_info_href          => File_info hash {REF}
+##          : $infile_lane_prefix_href => Infile(s) without the ".ending" {REF}
+##          : $job_id_href             => Job id hash {REF}
+##          : $parameter_href          => Parameter hash {REF}
+##          : $profile_base_command    => Submission profile base command
+##          : $recipe_name             => Recipe name
+##          : $sample_id               => Sample id
+##          : $sample_info_href        => Info on samples and case hash {REF}
+
+    my ($arg_href) = @_;
+
+    ## Flatten argument(s)
+    my $active_parameter_href;
+    my $file_info_href;
+    my $infile_lane_prefix_href;
+    my $job_id_href;
+    my $parameter_href;
+    my $recipe_name;
+    my $sample_id;
+    my $sample_info_href;
+
+    ## Default(s)
+    my $case_id;
+    my $profile_base_command;
+
+    my $tmpl = {
+        active_parameter_href => {
+            default     => {},
+            defined     => 1,
+            required    => 1,
+            store       => \$active_parameter_href,
+            strict_type => 1,
+        },
+        case_id => {
+            default     => $arg_href->{active_parameter_href}{case_id},
+            store       => \$case_id,
+            strict_type => 1,
+        },
+        file_info_href => {
+            default     => {},
+            defined     => 1,
+            required    => 1,
+            store       => \$file_info_href,
+            strict_type => 1,
+        },
+        infile_lane_prefix_href => {
+            default     => {},
+            defined     => 1,
+            required    => 1,
+            store       => \$infile_lane_prefix_href,
+            strict_type => 1,
+        },
+        job_id_href => {
+            default     => {},
+            defined     => 1,
+            required    => 1,
+            store       => \$job_id_href,
+            strict_type => 1,
+        },
+        parameter_href => {
+            default     => {},
+            defined     => 1,
+            required    => 1,
+            store       => \$parameter_href,
+            strict_type => 1,
+        },
+        profile_base_command => {
+            default     => q{sbatch},
+            store       => \$profile_base_command,
+            strict_type => 1,
+        },
+        recipe_name => {
+            defined     => 1,
+            required    => 1,
+            store       => \$recipe_name,
+            strict_type => 1,
+        },
+        sample_id => {
+            defined     => 1,
+            required    => 1,
+            store       => \$sample_id,
+            strict_type => 1,
+        },
+        sample_info_href => {
+            default     => {},
+            defined     => 1,
+            required    => 1,
+            store       => \$sample_info_href,
+            strict_type => 1,
+        },
+    };
+
+    check( $tmpl, $arg_href, 1 ) or croak q{Could not parse arguments!};
+
+    use MIP::Get::File qw{ get_io_files };
+    use MIP::Get::Parameter qw{ get_recipe_attributes  get_recipe_resources };
+    use MIP::Program::Compression::Tar qw{ tar };
+    use MIP::Program::Chromograph qw{ chromograph };
+    use MIP::Program::Upd qw{ upd_call };
+    use MIP::Parse::File qw{ parse_io_outfiles };
+    use MIP::Processmanagement::Processes qw{ submit_recipe };
+    use MIP::Sample_info qw{ get_family_member_id set_recipe_outfile_in_sample_info };
+    use MIP::Script::Setup_script qw{ setup_script };
+
+    ### PREPROCESSING:
+
+    ## Retrieve logger object
+    my $log = Log::Log4perl->get_logger($LOG_NAME);
+
+    ## Unpack parameters
+    ## Get the io infiles per chain and id
+    my %io = get_io_files(
+        {
+            id             => $case_id,
+            file_info_href => $file_info_href,
+            parameter_href => $parameter_href,
+            recipe_name    => $recipe_name,
+            stream         => q{in},
+        }
+    );
+    my $infile_name_prefix = $io{in}{file_name_prefix};
+    my $infile_path_prefix = $io{in}{file_path_prefix};
+    my $infile_path        = $infile_path_prefix . q{.vcf.gz};
+
+    my $job_id_chain = get_recipe_attributes(
+        {
+            attribute      => q{chain},
+            parameter_href => $parameter_href,
+            recipe_name    => $recipe_name,
+        }
+    );
+    my $recipe_mode     = $active_parameter_href->{$recipe_name};
+    my %recipe_resource = get_recipe_resources(
+        {
+            active_parameter_href => $active_parameter_href,
+            recipe_name           => $recipe_name,
         }
     );
 
-    if ($is_sample_proband_in_trio) {
-
-        %io = get_io_files(
+    %io = (
+        %io,
+        parse_io_outfiles(
             {
-                id             => $sample_id,
-                file_info_href => $file_info_href,
-                parameter_href => $parameter_href,
-                recipe_name    => $recipe_name,
-                stream         => q{in},
+                chain_id               => $job_id_chain,
+                id                     => $sample_id,
+                file_info_href         => $file_info_href,
+                file_name_prefixes_ref => [$infile_name_prefix],
+                outdata_dir            => $active_parameter_href->{outdata_dir},
+                parameter_href         => $parameter_href,
+                recipe_name            => $recipe_name,
             }
-        );
-        my %upd_infile_path = %{ $io{in}{file_path_href} };
+        )
+    );
 
-        ## Process regions file
-        chromograph(
-            {
-                FILEHANDLE            => $FILEHANDLE,
-                outdir_path           => $outdir_path,
-                upd_regions_file_path => $upd_infile_path{regions},
-            }
-        );
-        say {$FILEHANDLE} $NEWLINE;
+    my $outdir_path         = $io{out}{file_path_prefix};
+    my $outfile_path        = $io{out}{file_path};
+    my $outfile_path_prefix = $io{out}{file_path_prefix};
 
-        ## Process sites file
-        chromograph(
+    ## Filehandles
+    # Create anonymous filehandle
+    my $FILEHANDLE = IO::Handle->new();
+
+    ## Creates recipe directories (info & data & script), recipe script filenames and writes sbatch header
+    my ( $recipe_file_path, $recipe_info_path ) = setup_script(
+        {
+            active_parameter_href           => $active_parameter_href,
+            core_number                     => $recipe_resource{core_number},
+            directory_id                    => $sample_id,
+            FILEHANDLE                      => $FILEHANDLE,
+            job_id_href                     => $job_id_href,
+            log                             => $log,
+            memory_allocation               => $recipe_resource{memory},
+            process_time                    => $recipe_resource{time},
+            recipe_directory                => $recipe_name,
+            recipe_name                     => $recipe_name,
+            source_environment_commands_ref => $recipe_resource{load_env_ref},
+        }
+    );
+
+    %io = get_io_files(
+        {
+            id             => $sample_id,
+            file_info_href => $file_info_href,
+            parameter_href => $parameter_href,
+            recipe_name    => q{tiddit_coverage},
+            stream         => q{out},
+        }
+    );
+    my $tiddit_cov_infile_path = $io{out}{file_path};
+    ### SHELL:
+
+    say {$FILEHANDLE} q{## } . $recipe_name;
+
+    ## UPD
+    ## Get family hash
+    my %family_member_id =
+      get_family_member_id( { sample_info_href => $sample_info_href } );
+
+    my @call_types = qw{ sites regions };
+
+  CALL_TYPE:
+    foreach my $call_type (@call_types) {
+        upd_call(
             {
-                FILEHANDLE          => $FILEHANDLE,
-                outdir_path         => $outdir_path,
-                upd_sites_file_path => $upd_infile_path{sites},
+                af_tag       => q{GNOMADAF},
+                call_type    => $call_type,
+                father_id    => $family_member_id{father},
+                FILEHANDLE   => $FILEHANDLE,
+                infile_path  => $infile_path,
+                mother_id    => $family_member_id{mother},
+                outfile_path => $outfile_path_prefix . $UNDERSCORE . $call_type,
+                proband_id   => $sample_id,
             }
         );
         say {$FILEHANDLE} $NEWLINE;
     }
+
+    ## Process the wig file from tiddit_coverage
+    chromograph(
+        {
+            coverage_file_path => $tiddit_cov_infile_path,
+            FILEHANDLE         => $FILEHANDLE,
+            outdir_path        => $outdir_path,
+            step               => $active_parameter_href->{tiddit_coverage_bin_size},
+        }
+    );
+    say {$FILEHANDLE} $NEWLINE;
+
+    ## Process regions file from UPD
+    chromograph(
+        {
+            FILEHANDLE            => $FILEHANDLE,
+            outdir_path           => $outdir_path,
+            upd_regions_file_path => $outfile_path_prefix . $UNDERSCORE . q{regions},
+        }
+    );
+    say {$FILEHANDLE} $NEWLINE;
+
+    ## Process sites file from UPD
+    chromograph(
+        {
+            FILEHANDLE          => $FILEHANDLE,
+            outdir_path         => $outdir_path,
+            upd_sites_file_path => $outfile_path_prefix . $UNDERSCORE . q{sites},
+        }
+    );
+    say {$FILEHANDLE} $NEWLINE;
 
     tar(
         {
@@ -302,7 +558,7 @@ sub analysis_chromograph {
             {
                 base_command            => $profile_base_command,
                 case_id                 => $case_id,
-                dependency_method       => q{sample_to_island},
+                dependency_method       => q{case_to_sample},
                 infile_lane_prefix_href => $infile_lane_prefix_href,
                 job_id_chain            => $job_id_chain,
                 job_id_href             => $job_id_href,

--- a/lib/MIP/Recipes/Analysis/Tiddit_coverage.pm
+++ b/lib/MIP/Recipes/Analysis/Tiddit_coverage.pm
@@ -26,7 +26,7 @@ BEGIN {
     use base qw{ Exporter };
 
     # Set the version for version checking
-    our $VERSION = 1.03;
+    our $VERSION = 1.04;
 
     # Functions and variables which can be optionally exported
     our @EXPORT_OK = qw{ analysis_tiddit_coverage };
@@ -153,8 +153,8 @@ sub analysis_tiddit_coverage {
             id             => $sample_id,
             file_info_href => $file_info_href,
             parameter_href => $parameter_href,
-            recipe_name    => q{gatk_baserecalibration},
-            stream         => q{out},
+            recipe_name    => $recipe_name,
+            stream         => q{in},
         }
     );
     my $infile_name_prefix = $io{in}{file_name_prefix};

--- a/lib/MIP/Recipes/Pipeline/Analyse_dragen_rd_dna.pm
+++ b/lib/MIP/Recipes/Pipeline/Analyse_dragen_rd_dna.pm
@@ -144,8 +144,7 @@ sub pipeline_analyse_dragen_rd_dna {
     use MIP::Check::Pipeline qw{ check_dragen_rd_dna };
     use MIP::Constants qw{ set_analysis_constants };
     use MIP::Parse::Reference qw{ parse_reference_for_vt };
-    use MIP::Set::Analysis
-      qw{ set_recipe_on_analysis_type set_recipe_on_pedigree set_rankvariants_ar };
+    use MIP::Set::Analysis qw{ set_recipe_on_analysis_type set_rankvariants_ar };
 
     ## Recipes
     use MIP::Log::MIP_log4perl qw{ log_display_recipe_for_user };
@@ -265,15 +264,6 @@ sub pipeline_analyse_dragen_rd_dna {
         {
             analysis_recipe_href    => \%analysis_recipe,
             consensus_analysis_type => $parameter_href->{cache}{consensus_analysis_type},
-        }
-    );
-
-    ## Set recipe depending on pedigree
-    set_recipe_on_pedigree(
-        {
-            analysis_recipe_href => \%analysis_recipe,
-            parameter_href       => $parameter_href,
-            sample_info_href     => $sample_info_href,
         }
     );
 

--- a/lib/MIP/Recipes/Pipeline/Analyse_rd_dna.pm
+++ b/lib/MIP/Recipes/Pipeline/Analyse_rd_dna.pm
@@ -147,14 +147,15 @@ sub pipeline_analyse_rd_dna {
     use MIP::Log::MIP_log4perl qw{ log_display_recipe_for_user };
     use MIP::Parse::Reference qw{ parse_reference_for_vt };
     use MIP::Set::Analysis
-      qw{ set_recipe_on_analysis_type set_recipe_on_pedigree set_recipe_bwa_mem set_recipe_cadd set_recipe_gatk_variantrecalibration set_rankvariants_ar };
+      qw{ set_recipe_on_analysis_type set_recipe_bwa_mem set_recipe_cadd set_recipe_gatk_variantrecalibration set_rankvariants_ar };
 
     ## Recipes
     use MIP::Recipes::Analysis::Analysisrunstatus qw{ analysis_analysisrunstatus };
     use MIP::Recipes::Analysis::Bcftools_mpileup qw { analysis_bcftools_mpileup };
     use MIP::Recipes::Analysis::Cadd qw{ analysis_cadd analysis_cadd_gb_38 };
     use MIP::Recipes::Analysis::Chanjo_sex_check qw{ analysis_chanjo_sex_check };
-    use MIP::Recipes::Analysis::Chromograph qw{ analysis_chromograph };
+    use MIP::Recipes::Analysis::Chromograph
+      qw{ analysis_chromograph analysis_chromograph_proband };
     use MIP::Recipes::Analysis::Cnvnator qw{ analysis_cnvnator };
     use MIP::Recipes::Analysis::Delly_call qw{ analysis_delly_call };
     use MIP::Recipes::Analysis::Delly_reformat qw{ analysis_delly_reformat };
@@ -266,11 +267,11 @@ sub pipeline_analyse_rd_dna {
         bcftools_mpileup  => \&analysis_bcftools_mpileup,
         bwa_mem           => undef,                          # Depends on genome build
         cadd_ar => undef,    # Depends on human reference version
-        chanjo_sexcheck             => \&analysis_chanjo_sex_check,
-        chromograph_ar              => \&analysis_chromograph,
-        cnvnator_ar                 => \&analysis_cnvnator,
-        delly_call                  => \&analysis_delly_call,
-        delly_reformat              => \&analysis_delly_reformat,
+        chanjo_sexcheck => \&analysis_chanjo_sex_check,
+        chromograph_ar  => undef,                         # Depends on pedigree
+        cnvnator_ar     => \&analysis_cnvnator,
+        delly_call      => \&analysis_delly_call,
+        delly_reformat  => \&analysis_delly_reformat,
         endvariantannotationblock   => \&analysis_endvariantannotationblock,
         expansionhunter             => \&analysis_expansionhunter,
         fastqc_ar                   => \&analysis_fastqc,
@@ -313,7 +314,6 @@ sub pipeline_analyse_rd_dna {
         sv_vcfparser              => undef,                   # Depends on analysis type
         tiddit                    => \&analysis_tiddit,
         tiddit_coverage        => \&analysis_tiddit_coverage,
-        upd_ar                 => undef,                          # Depends on pedigree
         varianteffectpredictor => \&analysis_vep,
         variant_integrity_ar   => \&analysis_variant_integrity,
         version_collect_ar     => \&analysis_mip_vercollect,
@@ -370,14 +370,6 @@ sub pipeline_analyse_rd_dna {
         }
     );
 
-    ## Set recipe depending on pedigree
-    set_recipe_on_pedigree(
-        {
-            analysis_recipe_href => \%analysis_recipe,
-            sample_info_href     => $sample_info_href,
-        }
-    );
-
   RECIPE:
     foreach my $recipe ( @{$order_recipes_ref} ) {
 
@@ -400,6 +392,15 @@ sub pipeline_analyse_rd_dna {
 
           SAMPLE_ID:
             foreach my $sample_id ( @{ $active_parameter_href->{sample_ids} } ) {
+
+                ## Set chromograph recipe depending on pedigree and proband
+                _set_chromograph_recipe(
+                    {
+                        analysis_recipe_href => \%analysis_recipe,
+                        sample_id            => $sample_id,
+                        sample_info_href     => $sample_info_href,
+                    }
+                );
 
                 $analysis_recipe{$recipe}->(
                     {
@@ -434,6 +435,69 @@ sub pipeline_analyse_rd_dna {
 
         ## Special case
         exit if ( $recipe eq q{split_fastq_file} );
+    }
+    return;
+}
+
+sub _set_chromograph_recipe {
+
+## Function : Set which recipe to use depending on proband in trio or not
+## Returns  :
+## Arguments: $analysis_recipe_href => Analysis recipe hash {REF}
+##          : $sample_id            => Sample id
+##          : $sample_info_href     => Sample info hash {REF}
+
+    my ($arg_href) = @_;
+
+    ## Flatten argument(s)
+    my $analysis_recipe_href;
+    my $sample_id;
+    my $sample_info_href;
+
+    my $tmpl = {
+        analysis_recipe_href => {
+            default     => {},
+            defined     => 1,
+            required    => 1,
+            store       => \$analysis_recipe_href,
+            strict_type => 1,
+        },
+        sample_id => {
+            defined     => 1,
+            required    => 1,
+            store       => \$sample_id,
+            strict_type => 1,
+        },
+        sample_info_href => {
+            default     => {},
+            defined     => 1,
+            required    => 1,
+            store       => \$sample_info_href,
+            strict_type => 1,
+        },
+    };
+
+    check( $tmpl, $arg_href, 1 ) or croak q{Could not parse arguments!};
+
+    use MIP::File::Format::Pedigree qw{ is_sample_proband_in_trio };
+
+    ## Set default recipe
+    $analysis_recipe_href->{chromograph_ar} = \&analysis_chromograph;
+
+    ## Only run chromograp_proband UPD analysis for trios and proband
+    if ( $sample_info_href->{has_trio} ) {
+
+        my $is_sample_proband_in_trio = is_sample_proband_in_trio(
+            {
+                sample_id        => $sample_id,
+                sample_info_href => $sample_info_href,
+            }
+        );
+        if ($is_sample_proband_in_trio) {
+
+            ## Update recipe to use proband processing instead
+            $analysis_recipe_href->{chromograph_ar} = \&analysis_chromograph_proband;
+        }
     }
     return;
 }

--- a/lib/MIP/Recipes/Pipeline/Analyse_rd_dna_vcf_rerun.pm
+++ b/lib/MIP/Recipes/Pipeline/Analyse_rd_dna_vcf_rerun.pm
@@ -143,7 +143,7 @@ sub pipeline_analyse_rd_dna_vcf_rerun {
     use MIP::Check::Pipeline qw{ check_rd_dna_vcf_rerun };
     use MIP::Parse::Reference qw{ parse_reference_for_vt };
     use MIP::Set::Analysis
-      qw{ set_recipe_cadd set_recipe_on_analysis_type set_recipe_on_pedigree set_rankvariants_ar };
+      qw{ set_recipe_cadd set_recipe_on_analysis_type set_rankvariants_ar };
 
     ## Recipes
     use MIP::Log::MIP_log4perl qw{ log_display_recipe_for_user };
@@ -264,15 +264,6 @@ sub pipeline_analyse_rd_dna_vcf_rerun {
         {
             analysis_recipe_href    => \%analysis_recipe,
             consensus_analysis_type => $parameter_href->{cache}{consensus_analysis_type},
-        }
-    );
-
-    ## Set recipe depending on pedigree
-    set_recipe_on_pedigree(
-        {
-            analysis_recipe_href => \%analysis_recipe,
-            parameter_href       => $parameter_href,
-            sample_info_href     => $sample_info_href,
         }
     );
 

--- a/lib/MIP/Set/Analysis.pm
+++ b/lib/MIP/Set/Analysis.pm
@@ -23,11 +23,11 @@ BEGIN {
     use base qw{ Exporter };
 
     # Set the version for version checking
-    our $VERSION = 1.07;
+    our $VERSION = 1.08;
 
     # Functions and variables which can be optionally exported
     our @EXPORT_OK =
-      qw{ set_recipe_on_analysis_type set_recipe_on_pedigree set_recipe_bwa_mem set_recipe_cadd set_recipe_gatk_variantrecalibration set_rankvariants_ar };
+      qw{ set_recipe_on_analysis_type set_recipe_bwa_mem set_recipe_cadd set_recipe_gatk_variantrecalibration set_rankvariants_ar };
 }
 
 sub set_recipe_on_analysis_type {
@@ -100,49 +100,6 @@ sub set_recipe_on_analysis_type {
         $analysis_recipe_href->{$recipe_name} =
           $analysis_type_recipe{$consensus_analysis_type}{$recipe_name};
     }
-    return;
-}
-
-sub set_recipe_on_pedigree {
-
-## Function : Set which recipe to use depending on pedigree
-## Returns  :
-## Arguments: $analysis_recipe_href => Analysis recipe hash {REF}
-##          : $sample_info_href     => Sample info hash {REF}
-
-    my ($arg_href) = @_;
-
-    ## Flatten argument(s)
-    my $analysis_recipe_href;
-    my $sample_info_href;
-
-    my $tmpl = {
-        analysis_recipe_href => {
-            default     => {},
-            defined     => 1,
-            required    => 1,
-            store       => \$analysis_recipe_href,
-            strict_type => 1,
-        },
-        sample_info_href => {
-            default     => {},
-            defined     => 1,
-            required    => 1,
-            store       => \$sample_info_href,
-            strict_type => 1,
-        },
-    };
-
-    check( $tmpl, $arg_href, 1 ) or croak q{Could not parse arguments!};
-
-    use MIP::Recipes::Analysis::Upd qw{ analysis_upd };
-
-    ## Only run upd analysis for trios
-    if ( $sample_info_href->{has_trio} ) {
-
-        $analysis_recipe_href->{upd_ar} = \&analysis_upd;
-    }
-
     return;
 }
 

--- a/lib/MIP/Set/Analysis.pm
+++ b/lib/MIP/Set/Analysis.pm
@@ -23,84 +23,11 @@ BEGIN {
     use base qw{ Exporter };
 
     # Set the version for version checking
-    our $VERSION = 1.08;
+    our $VERSION = 1.09;
 
     # Functions and variables which can be optionally exported
     our @EXPORT_OK =
-      qw{ set_recipe_on_analysis_type set_recipe_bwa_mem set_recipe_cadd set_recipe_gatk_variantrecalibration set_rankvariants_ar };
-}
-
-sub set_recipe_on_analysis_type {
-
-## Function : Set which recipe to use depending on consensus analysis type
-## Returns  :
-## Arguments: $analysis_recipe_href    => Analysis recipe hash {REF}
-##          : $consensus_analysis_type => Consensus analysis type
-
-    my ($arg_href) = @_;
-
-    ## Flatten argument(s)
-    my $analysis_recipe_href;
-    my $consensus_analysis_type;
-
-    my $tmpl = {
-        analysis_recipe_href => {
-            default     => {},
-            defined     => 1,
-            required    => 1,
-            store       => \$analysis_recipe_href,
-            strict_type => 1,
-        },
-        consensus_analysis_type => {
-            defined     => 1,
-            required    => 1,
-            store       => \$consensus_analysis_type,
-            strict_type => 1,
-        },
-    };
-
-    check( $tmpl, $arg_href, 1 ) or croak q{Could not parse arguments!};
-
-    use MIP::Recipes::Analysis::Gatk_variantrecalibration
-      qw{ analysis_gatk_variantrecalibration_wes analysis_gatk_variantrecalibration_wgs };
-    use MIP::Recipes::Analysis::Mip_vcfparser
-      qw{ analysis_mip_vcfparser_sv_wes analysis_mip_vcfparser_sv_wgs };
-    use MIP::Recipes::Analysis::Vep qw{ analysis_vep_sv_wes analysis_vep_sv_wgs };
-
-    my %analysis_type_recipe = (
-        vrn => {
-            sv_varianteffectpredictor => \&analysis_vep_sv_wgs,
-            sv_vcfparser              => \&analysis_mip_vcfparser_sv_wgs,
-        },
-        wes => {
-            gatk_variantrecalibration => \&analysis_gatk_variantrecalibration_wes,
-            sv_varianteffectpredictor => \&analysis_vep_sv_wes,
-            sv_vcfparser              => \&analysis_mip_vcfparser_sv_wes,
-        },
-        wgs => {
-            gatk_variantrecalibration => \&analysis_gatk_variantrecalibration_wgs,
-            sv_varianteffectpredictor => \&analysis_vep_sv_wgs,
-            sv_vcfparser              => \&analysis_mip_vcfparser_sv_wgs,
-        },
-    );
-
-    ## If not a defined consensus analysis type e.g. "mixed"
-    if ( not exists $analysis_type_recipe{$consensus_analysis_type} ) {
-
-        ## Use wgs as fallback
-        $consensus_analysis_type = q{wgs};
-    }
-
-  ANALYSIS_RECIPE:
-    foreach my $recipe_name ( keys %{$analysis_recipe_href} ) {
-
-        next ANALYSIS_RECIPE
-          if ( not exists $analysis_type_recipe{$consensus_analysis_type}{$recipe_name} );
-
-        $analysis_recipe_href->{$recipe_name} =
-          $analysis_type_recipe{$consensus_analysis_type}{$recipe_name};
-    }
-    return;
+      qw{ set_recipe_bwa_mem set_recipe_cadd set_recipe_chromograph set_recipe_gatk_variantrecalibration set_recipe_on_analysis_type set_rankvariants_ar };
 }
 
 sub set_recipe_bwa_mem {
@@ -229,6 +156,71 @@ sub set_recipe_cadd {
     return;
 }
 
+sub set_recipe_chromograph {
+
+## Function : Set which recipe to use depending on proband in trio and proband or not
+## Returns  :
+## Arguments: $analysis_recipe_href => Analysis recipe hash {REF}
+##          : $sample_id            => Sample id
+##          : $sample_info_href     => Sample info hash {REF}
+
+    my ($arg_href) = @_;
+
+    ## Flatten argument(s)
+    my $analysis_recipe_href;
+    my $sample_id;
+    my $sample_info_href;
+
+    my $tmpl = {
+        analysis_recipe_href => {
+            default     => {},
+            defined     => 1,
+            required    => 1,
+            store       => \$analysis_recipe_href,
+            strict_type => 1,
+        },
+        sample_id => {
+            defined     => 1,
+            required    => 1,
+            store       => \$sample_id,
+            strict_type => 1,
+        },
+        sample_info_href => {
+            default     => {},
+            defined     => 1,
+            required    => 1,
+            store       => \$sample_info_href,
+            strict_type => 1,
+        },
+    };
+
+    check( $tmpl, $arg_href, 1 ) or croak q{Could not parse arguments!};
+
+    use MIP::File::Format::Pedigree qw{ is_sample_proband_in_trio };
+    use MIP::Recipes::Analysis::Chromograph
+      qw{ analysis_chromograph analysis_chromograph_proband };
+
+    ## Set default recipe
+    $analysis_recipe_href->{chromograph_ar} = \&analysis_chromograph;
+
+    ## Only run chromograp_proband UPD analysis for trios and proband
+    if ( $sample_info_href->{has_trio} ) {
+
+        my $is_sample_proband_in_trio = is_sample_proband_in_trio(
+            {
+                sample_id        => $sample_id,
+                sample_info_href => $sample_info_href,
+            }
+        );
+        if ($is_sample_proband_in_trio) {
+
+            ## Update recipe to use proband processing instead
+            $analysis_recipe_href->{chromograph_ar} = \&analysis_chromograph_proband;
+        }
+    }
+    return;
+}
+
 sub set_recipe_gatk_variantrecalibration {
 
 ## Function : Update which gatk variant recalibration to use depending on number of samples
@@ -289,6 +281,79 @@ q{Switched from VariantRecalibration to CNNScoreVariants for single sample analy
     ## Use new CNN recipe for single samples
     $analysis_recipe_href->{gatk_variantrecalibration} = \&analysis_gatk_cnnscorevariants;
 
+    return;
+}
+
+sub set_recipe_on_analysis_type {
+
+## Function : Set which recipe to use depending on consensus analysis type
+## Returns  :
+## Arguments: $analysis_recipe_href    => Analysis recipe hash {REF}
+##          : $consensus_analysis_type => Consensus analysis type
+
+    my ($arg_href) = @_;
+
+    ## Flatten argument(s)
+    my $analysis_recipe_href;
+    my $consensus_analysis_type;
+
+    my $tmpl = {
+        analysis_recipe_href => {
+            default     => {},
+            defined     => 1,
+            required    => 1,
+            store       => \$analysis_recipe_href,
+            strict_type => 1,
+        },
+        consensus_analysis_type => {
+            defined     => 1,
+            required    => 1,
+            store       => \$consensus_analysis_type,
+            strict_type => 1,
+        },
+    };
+
+    check( $tmpl, $arg_href, 1 ) or croak q{Could not parse arguments!};
+
+    use MIP::Recipes::Analysis::Gatk_variantrecalibration
+      qw{ analysis_gatk_variantrecalibration_wes analysis_gatk_variantrecalibration_wgs };
+    use MIP::Recipes::Analysis::Mip_vcfparser
+      qw{ analysis_mip_vcfparser_sv_wes analysis_mip_vcfparser_sv_wgs };
+    use MIP::Recipes::Analysis::Vep qw{ analysis_vep_sv_wes analysis_vep_sv_wgs };
+
+    my %analysis_type_recipe = (
+        vrn => {
+            sv_varianteffectpredictor => \&analysis_vep_sv_wgs,
+            sv_vcfparser              => \&analysis_mip_vcfparser_sv_wgs,
+        },
+        wes => {
+            gatk_variantrecalibration => \&analysis_gatk_variantrecalibration_wes,
+            sv_varianteffectpredictor => \&analysis_vep_sv_wes,
+            sv_vcfparser              => \&analysis_mip_vcfparser_sv_wes,
+        },
+        wgs => {
+            gatk_variantrecalibration => \&analysis_gatk_variantrecalibration_wgs,
+            sv_varianteffectpredictor => \&analysis_vep_sv_wgs,
+            sv_vcfparser              => \&analysis_mip_vcfparser_sv_wgs,
+        },
+    );
+
+    ## If not a defined consensus analysis type e.g. "mixed"
+    if ( not exists $analysis_type_recipe{$consensus_analysis_type} ) {
+
+        ## Use wgs as fallback
+        $consensus_analysis_type = q{wgs};
+    }
+
+  ANALYSIS_RECIPE:
+    foreach my $recipe_name ( keys %{$analysis_recipe_href} ) {
+
+        next ANALYSIS_RECIPE
+          if ( not exists $analysis_type_recipe{$consensus_analysis_type}{$recipe_name} );
+
+        $analysis_recipe_href->{$recipe_name} =
+          $analysis_type_recipe{$consensus_analysis_type}{$recipe_name};
+    }
     return;
 }
 

--- a/t/analysis_chromograph_proband.t
+++ b/t/analysis_chromograph_proband.t
@@ -1,0 +1,124 @@
+#!/usr/bin/env perl
+
+use 5.026;
+use Carp;
+use charnames qw{ :full :short };
+use English qw{ -no_match_vars };
+use File::Basename qw{ dirname };
+use File::Spec::Functions qw{ catdir catfile };
+use FindBin qw{ $Bin };
+use open qw{ :encoding(UTF-8) :std };
+use Params::Check qw{ allow check last_error };
+use Test::More;
+use utf8;
+use warnings qw{ FATAL utf8 };
+
+## CPANM
+use autodie qw { :all };
+use Modern::Perl qw{ 2018 };
+use Readonly;
+use Test::Trap;
+
+## MIPs lib/
+use lib catdir( dirname($Bin), q{lib} );
+use MIP::Constants qw{ $COLON $COMMA $SPACE };
+use MIP::Test::Fixtures qw{ test_log test_mip_hashes test_standard_cli };
+
+my $VERBOSE = 1;
+our $VERSION = 1.00;
+
+$VERBOSE = test_standard_cli(
+    {
+        verbose => $VERBOSE,
+        version => $VERSION,
+    }
+);
+
+BEGIN {
+
+    use MIP::Test::Fixtures qw{ test_import };
+
+### Check all internal dependency modules and imports
+## Modules with import
+    my %perl_module = (
+        q{MIP::Recipes::Analysis::Chromograph} => [qw{ analysis_chromograph_proband }],
+        q{MIP::Test::Fixtures} => [qw{ test_log test_mip_hashes test_standard_cli }],
+    );
+
+    test_import( { perl_module_href => \%perl_module, } );
+}
+
+use MIP::Recipes::Analysis::Chromograph qw{ analysis_chromograph_proband };
+
+diag(   q{Test analysis_chromograph_proband from Chromograph.pm v}
+      . $MIP::Recipes::Analysis::Chromograph::VERSION
+      . $COMMA
+      . $SPACE . q{Perl}
+      . $SPACE
+      . $PERL_VERSION
+      . $SPACE
+      . $EXECUTABLE_NAME );
+
+Readonly my $TIDDIT_BIN_SIZE => 500;
+
+my $log = test_log( { log_name => q{MIP}, no_screen => 1, } );
+
+## Given analysis parameters
+my $recipe_name    = q{chromograph_ar};
+my $slurm_mock_cmd = catfile( $Bin, qw{ data modules slurm-mock.pl } );
+
+my %active_parameter = test_mip_hashes(
+    {
+        mip_hash_name => q{active_parameter},
+        recipe_name   => $recipe_name,
+    }
+);
+$active_parameter{$recipe_name}                     = 1;
+$active_parameter{recipe_core_number}{$recipe_name} = 1;
+$active_parameter{recipe_time}{$recipe_name}        = 1;
+$active_parameter{tiddit_coverage_bin_size}         = $TIDDIT_BIN_SIZE;
+my $sample_id = $active_parameter{sample_ids}[0];
+my $case_id   = $active_parameter{case_id};
+
+my %file_info = test_mip_hashes(
+    {
+        mip_hash_name => q{file_info},
+        recipe_name   => $recipe_name,
+    }
+);
+%{ $file_info{io}{TEST}{$case_id}{$recipe_name} } = test_mip_hashes(
+    {
+        mip_hash_name => q{io},
+    }
+);
+
+my %infile_lane_prefix;
+my %job_id;
+my %parameter = test_mip_hashes(
+    {
+        mip_hash_name => q{recipe_parameter},
+        recipe_name   => $recipe_name,
+    }
+);
+$parameter{$recipe_name}{chain} = q{TEST};
+@{ $parameter{cache}{order_recipes_ref} } = ( q{tiddit_coverage}, $recipe_name );
+my %sample_info;
+
+my $is_ok = analysis_chromograph_proband(
+    {
+        active_parameter_href   => \%active_parameter,
+        file_info_href          => \%file_info,
+        infile_lane_prefix_href => \%infile_lane_prefix,
+        job_id_href             => \%job_id,
+        parameter_href          => \%parameter,
+        profile_base_command    => $slurm_mock_cmd,
+        recipe_name             => $recipe_name,
+        sample_id               => $sample_id,
+        sample_info_href        => \%sample_info,
+    }
+);
+
+## Then return TRUE
+ok( $is_ok, q{ Executed analysis recipe } . $recipe_name );
+
+done_testing();

--- a/t/set_recipe_chromograph.t
+++ b/t/set_recipe_chromograph.t
@@ -1,0 +1,131 @@
+#!/usr/bin/env perl
+
+use 5.026;
+use Carp;
+use charnames qw{ :full :short };
+use English qw{ -no_match_vars };
+use File::Basename qw{ dirname };
+use File::Spec::Functions qw{ catdir };
+use FindBin qw{ $Bin };
+use open qw{ :encoding(UTF-8) :std };
+use Params::Check qw{ allow check last_error };
+use Test::More;
+use utf8;
+use warnings qw{ FATAL utf8 };
+
+## CPANM
+use autodie qw { :all };
+use Modern::Perl qw{ 2018 };
+use Readonly;
+
+## MIPs lib/
+use lib catdir( dirname($Bin), q{lib} );
+use MIP::Constants qw{ $COMMA $SPACE };
+use MIP::Test::Fixtures qw{ test_mip_hashes test_standard_cli };
+
+my $VERBOSE = 1;
+our $VERSION = 1.00;
+
+$VERBOSE = test_standard_cli(
+    {
+        verbose => $VERBOSE,
+        version => $VERSION,
+    }
+);
+
+BEGIN {
+
+    use MIP::Test::Fixtures qw{ test_import };
+
+### Check all internal dependency modules and imports
+## Modules with import
+    my %perl_module = (
+        q{MIP::Recipes::Analysis::Chromograph} =>
+          [qw{ analysis_chromograph analysis_chromograph_proband }],
+        q{MIP::Set::Analysis}  => [qw{ set_recipe_chromograph }],
+        q{MIP::Test::Fixtures} => [qw{ test_mip_hashes test_standard_cli }],
+    );
+
+    test_import( { perl_module_href => \%perl_module, } );
+}
+
+use MIP::Set::Analysis qw{ set_recipe_chromograph };
+use MIP::Recipes::Analysis::Chromograph
+  qw{ analysis_chromograph analysis_chromograph_proband };
+
+diag(   q{Test set_recipe_chromograph from Analysis.pm v}
+      . $MIP::Set::Analysis::VERSION
+      . $COMMA
+      . $SPACE . q{Perl}
+      . $SPACE
+      . $PERL_VERSION
+      . $SPACE
+      . $EXECUTABLE_NAME );
+
+## Given
+my %analysis_recipe;
+my %sample_info    = test_mip_hashes( { mip_hash_name => q{qc_sample_info}, } );
+my $proband_id     = q{ADM1059A1};
+my $not_proband_id = q{ADM1059A2};
+
+## Given a non trio
+$sample_info{has_trio} = 0;
+
+## Set chromograph recipe depending on pedigree and proband
+set_recipe_chromograph(
+    {
+        analysis_recipe_href => \%analysis_recipe,
+        sample_id            => $proband_id,
+        sample_info_href     => \%sample_info,
+    }
+);
+my %expected_single_sample_recipe = ( chromograph_ar => \&analysis_chromograph, );
+
+## Then use not proband and not trio recipe
+is_deeply(
+    \%analysis_recipe,
+    \%expected_single_sample_recipe,
+    q{Set single sample recipe for not trio}
+);
+
+## Given a trio when not proband
+$sample_info{has_trio} = 1;
+
+## Set chromograph recipe depending on pedigree and proband
+set_recipe_chromograph(
+    {
+        analysis_recipe_href => \%analysis_recipe,
+        sample_id            => $not_proband_id,
+        sample_info_href     => \%sample_info,
+    }
+);
+my %expected_trio_not_proband_recipe = ( chromograph_ar => \&analysis_chromograph, );
+
+## Then use not proband and not trio recipe
+is_deeply(
+    \%analysis_recipe,
+    \%expected_trio_not_proband_recipe,
+    q{Set sample recipe when trio but not proband}
+);
+
+## Given a trio when proband
+
+## Set chromograph recipe depending on pedigree and proband
+set_recipe_chromograph(
+    {
+        analysis_recipe_href => \%analysis_recipe,
+        sample_id            => $proband_id,
+        sample_info_href     => \%sample_info,
+    }
+);
+my %expected_trio_and_proband_recipe =
+  ( chromograph_ar => \&analysis_chromograph_proband, );
+
+## Then use proband and trio recipe
+is_deeply(
+    \%analysis_recipe,
+    \%expected_trio_and_proband_recipe,
+    q{Set sample recipe when trio and proband}
+);
+
+done_testing();


### PR DESCRIPTION
- Moved rhocall_viz to its own chain and left recipe switch default to
  0
- Turned off upd recipe switch and removed from inititatio map, but left recipes intact
- Split chromograph recipes into one recipe when processing only
  tiddit_coverage data (not proband and in trio) and another recipe when
proband in trio and then processing both tiddit_coverage and UPD (within
recipe).
- Added chromograph recipe switch in pipeline engine for using correct
  recipe depending on trio and proband status. All members will always
be processed by either one of the chromograph recipes.
- Modifed tiddit_coverage io in stream for correct inheritance

### This PR fixes:

- Chromograph dependecies issues

### How to test:

- Automatic and continuous test pass

### Expected outcome:
- Installation, unit and integration tests pass

### Review:
- [ ] Code review
- [ ] New code is executed and covered by tests
- [ ] Tests pass
