### PR TITLE
feat(sbatch_reservation): Adds the reservation option to sbatch API

### DIFF
--- a/definitions/mip_parameters.yaml
+++ b/definitions/mip_parameters.yaml
@@ -41,6 +41,12 @@ email_types:
   element_separator: ,
   mandatory: no
   type: mip
+job_reservation_name:
+  associated_recipe:
+   - mip
+  data_type: SCALAR
+  mandatory: no
+  type: mip
 log_file:
   associated_recipe:
    - mip

--- a/lib/MIP/Cli/Mip.pm
+++ b/lib/MIP/Cli/Mip.pm
@@ -94,6 +94,15 @@ sub _build_usage {
     );
 
     option(
+        q{job_reservation_name} => (
+            cmd_aliases   => [qw{ job_res_name }],
+            documentation => q{Allocate node resources from named reservation},
+            is            => q{rw},
+            isa           => Str,
+        )
+    );
+
+    option(
         q{log_file} => (
             cmd_aliases   => [qw{ log }],
             documentation => q{Log file},

--- a/lib/MIP/Processmanagement/Processes.pm
+++ b/lib/MIP/Processmanagement/Processes.pm
@@ -1718,10 +1718,11 @@ sub submit_recipe {
 ##          : $job_dependency_type     => Job dependency type
 ##          : $log                     => Log object
 ##          : $parallel_chains_ref     => Info on parallel chains array {REF}
-##          : $sample_id               => Sample id
-##          : $sample_ids_ref          => Sample ids {REF}
 ##          : $recipe_file_path        => Recipe file path
 ##          : $recipe_files_tracker    => Track the number of parallel processes (e.g. recipe scripts for a module)
+##          : $job_reservation_name    => Allocate resources from named reservation
+##          : $sample_id               => Sample id
+##          : $sample_ids_ref          => Sample ids {REF}
 ##          : $submission_profile      => Submission profile
 
     my ($arg_href) = @_;
@@ -1735,10 +1736,11 @@ sub submit_recipe {
     my $job_dependency_type;
     my $log;
     my $parallel_chains_ref;
-    my $sample_id;
-    my $sample_ids_ref;
     my $recipe_file_path;
     my $recipe_files_tracker;
+    my $job_reservation_name;
+    my $sample_id;
+    my $sample_ids_ref;
 
     ## Default(s)
     my $base_command;
@@ -1798,6 +1800,10 @@ sub submit_recipe {
             store       => \$recipe_files_tracker,
             strict_type => 1,
         },
+        job_reservation_name => {
+            store       => \$job_reservation_name,
+            strict_type => 1,
+        },
         sample_id => {
             store       => \$sample_id,
             strict_type => 1,
@@ -1831,11 +1837,11 @@ sub submit_recipe {
             job_id_href             => $job_id_href,
             log                     => $log,
             parallel_chains_ref     => $parallel_chains_ref,
-            sample_id               => $sample_id,
-            sample_ids_ref          => $sample_ids_ref,
             recipe_file_path        => $recipe_file_path,
             recipe_files_tracker    => $recipe_files_tracker,
-
+            reservation_name        => $job_reservation_name,
+            sample_id               => $sample_id,
+            sample_ids_ref          => $sample_ids_ref,
         }
     );
     return 1;

--- a/lib/MIP/Processmanagement/Slurm_processes.pm
+++ b/lib/MIP/Processmanagement/Slurm_processes.pm
@@ -25,7 +25,7 @@ BEGIN {
     require Exporter;
 
     # Set the version for version checking
-    our $VERSION = 1.06;
+    our $VERSION = 1.07;
 
     # Functions and variables which can be optionally exported
     our @EXPORT_OK = qw{
@@ -58,6 +58,7 @@ sub slurm_submit_job_case_id_dependency_add_to_sample {
 ##          : $job_id_href             => The info on job ids hash {REF}
 ##          : $log                     => Log
 ##          : $path                    => Trunk or branch
+##          : $reservation_name        => Allocate resources from named reservation
 ##          : $sample_id               => Sample id
 ##          : $sbatch_file_name        => Sbatch file name
 
@@ -69,6 +70,7 @@ sub slurm_submit_job_case_id_dependency_add_to_sample {
     my $job_id_href;
     my $log;
     my $path;
+    my $reservation_name;
     my $sample_id;
     my $sbatch_file_name;
 
@@ -113,7 +115,11 @@ sub slurm_submit_job_case_id_dependency_add_to_sample {
             required => 1,
             store    => \$log,
         },
-        path      => { defined => 1, required => 1, store => \$path, strict_type => 1, },
+        path => { defined => 1, required => 1, store => \$path, strict_type => 1, },
+        reservation_name => {
+            store       => \$reservation_name,
+            strict_type => 1,
+        },
         sample_id => {
             defined     => 1,
             required    => 1,
@@ -191,6 +197,7 @@ sub slurm_submit_job_case_id_dependency_add_to_sample {
             job_dependency_type => $job_dependency_type,
             job_ids_string      => $job_ids_string,
             log                 => $log,
+            reservation_name    => $reservation_name,
             sbatch_file_name    => $sbatch_file_name,
         }
     );
@@ -245,6 +252,7 @@ sub slurm_submit_job_no_dependency_dead_end {
 ## Arguments: $base_command     => Sbatch
 ##          : $log              => Log object
 ##          : $job_id_href      => The info on job ids hash {REF}
+##          : $reservation_name => Allocate resources from named reservation
 ##          : $sbatch_file_name => Sbatch file name
 
     my ($arg_href) = @_;
@@ -252,6 +260,7 @@ sub slurm_submit_job_no_dependency_dead_end {
     ## Flatten argument(s)
     my $log;
     my $job_id_href;
+    my $reservation_name;
     my $sbatch_file_name;
 
     ## Default(s)
@@ -275,6 +284,10 @@ sub slurm_submit_job_no_dependency_dead_end {
             store       => \$job_id_href,
             strict_type => 1,
         },
+        reservation_name => {
+            store       => \$reservation_name,
+            strict_type => 1,
+        },
         sbatch_file_name => {
             defined     => 1,
             required    => 1,
@@ -294,6 +307,7 @@ sub slurm_submit_job_no_dependency_dead_end {
         {
             base_command     => $base_command,
             log              => $log,
+            reservation_name => $reservation_name,
             sbatch_file_name => $sbatch_file_name,
         }
     );
@@ -325,6 +339,7 @@ sub slurm_submit_job_no_dependency_add_to_sample {
 ##          : $job_id_href      => The info on job ids hash {REF}
 ##          : $log              => Log
 ##          : $path             => Trunk or branch
+##          : $reservation_name => Allocate resources from named reservation
 ##          : $sample_id        => Sample id
 ##          : $sbatch_file_name => Sbatch file name
 
@@ -335,6 +350,7 @@ sub slurm_submit_job_no_dependency_add_to_sample {
     my $job_id_href;
     my $log;
     my $path;
+    my $reservation_name;
     my $sample_id;
     my $sbatch_file_name;
 
@@ -365,7 +381,11 @@ sub slurm_submit_job_no_dependency_add_to_sample {
             required => 1,
             store    => \$log,
         },
-        path      => { defined => 1, required => 1, store => \$path, strict_type => 1, },
+        path => { defined => 1, required => 1, store => \$path, strict_type => 1, },
+        reservation_name => {
+            store       => \$reservation_name,
+            strict_type => 1,
+        },
         sample_id => {
             defined     => 1,
             required    => 1,
@@ -399,6 +419,7 @@ sub slurm_submit_job_no_dependency_add_to_sample {
         {
             base_command     => $base_command,
             log              => $log,
+            reservation_name => $reservation_name,
             sbatch_file_name => $sbatch_file_name,
         }
     );
@@ -439,6 +460,7 @@ sub slurm_submit_job_no_dependency_add_to_samples {
 ##          : $job_id_href      => Info on job id dependencies hash {REF}
 ##          : $log              => Log
 ##          : $path             => Trunk or branch
+##          : $reservation_name => Allocate resources from named reservation
 ##          : $sample_ids_ref   => Sample ids {REF}
 ##          : $sbatch_file_name => Sbatch file name
 
@@ -449,6 +471,7 @@ sub slurm_submit_job_no_dependency_add_to_samples {
     my $job_id_href;
     my $log;
     my $path;
+    my $reservation_name;
     my $sample_ids_ref;
     my $sbatch_file_name;
 
@@ -480,6 +503,10 @@ sub slurm_submit_job_no_dependency_add_to_samples {
             store    => \$log,
         },
         path => { defined => 1, required => 1, store => \$path, strict_type => 1, },
+        reservation_name => {
+            store       => \$reservation_name,
+            strict_type => 1,
+        },
         sample_ids_ref => {
             default     => [],
             defined     => 1,
@@ -510,6 +537,7 @@ sub slurm_submit_job_no_dependency_add_to_samples {
         {
             base_command     => $base_command,
             log              => $log,
+            reservation_name => $reservation_name,
             sbatch_file_name => $sbatch_file_name,
         }
     );
@@ -562,6 +590,7 @@ sub slurm_submit_job_sample_id_dependency_dead_end {
 ##          : $job_dependency_type     => SLURM job dependency type
 ##          : $log                     => Log
 ##          : $path                    => Trunk or branch
+##          : $reservation_name        => Allocate resources from named reservation
 ##          : $sample_id               => Sample id
 ##          : $sbatch_file_name        => Sbatch file name
 
@@ -573,6 +602,7 @@ sub slurm_submit_job_sample_id_dependency_dead_end {
     my $job_id_href;
     my $log;
     my $path;
+    my $reservation_name;
     my $sample_id;
     my $sbatch_file_name;
 
@@ -617,7 +647,11 @@ sub slurm_submit_job_sample_id_dependency_dead_end {
             required => 1,
             store    => \$log,
         },
-        path      => { defined => 1, required => 1, store => \$path, strict_type => 1, },
+        path => { defined => 1, required => 1, store => \$path, strict_type => 1, },
+        reservation_name => {
+            store       => \$reservation_name,
+            strict_type => 1,
+        },
         sample_id => {
             store       => \$sample_id,
             strict_type => 1,
@@ -694,6 +728,7 @@ sub slurm_submit_job_sample_id_dependency_dead_end {
             job_dependency_type => $job_dependency_type,
             job_ids_string      => $job_ids_string,
             log                 => $log,
+            reservation_name    => $reservation_name,
             sbatch_file_name    => $sbatch_file_name,
         }
     );
@@ -770,6 +805,7 @@ sub slurm_submit_job_sample_id_dependency_add_to_sample {
 ##          : $job_id_href             => The info on job ids hash {REF}
 ##          : $log                     => Log
 ##          : $path                    => Trunk or branch
+##          : $reservation_name        => Allocate resources from named reservation
 ##          : $sample_id               => Sample id
 ##          : $sbatch_file_name        => Sbatch file name
 
@@ -781,6 +817,7 @@ sub slurm_submit_job_sample_id_dependency_add_to_sample {
     my $job_id_href;
     my $log;
     my $path;
+    my $reservation_name;
     my $sample_id;
     my $sbatch_file_name;
 
@@ -825,7 +862,11 @@ sub slurm_submit_job_sample_id_dependency_add_to_sample {
             required => 1,
             store    => \$log,
         },
-        path      => { defined => 1, required => 1, store => \$path, strict_type => 1, },
+        path => { defined => 1, required => 1, store => \$path, strict_type => 1, },
+        reservation_name => {
+            store       => \$reservation_name,
+            strict_type => 1,
+        },
         sample_id => {
             store       => \$sample_id,
             strict_type => 1,
@@ -902,6 +943,7 @@ sub slurm_submit_job_sample_id_dependency_add_to_sample {
             job_dependency_type => $job_dependency_type,
             job_ids_string      => $job_ids_string,
             log                 => $log,
+            reservation_name    => $reservation_name,
             sbatch_file_name    => $sbatch_file_name,
         }
     );
@@ -989,6 +1031,7 @@ sub slurm_submit_job_sample_id_dependency_add_to_case {
 ##          : $log                     => Log
 ##          : $parallel_chains_ref     => Info on parallel chains array {REF}
 ##          : $path                    => Trunk or branch
+##          : $reservation_name        => Allocate resources from named reservation
 ##          : $sample_ids_ref          => Sample ids {REF}
 ##          : $sbatch_file_name        => Sbatch file name
 
@@ -1001,6 +1044,7 @@ sub slurm_submit_job_sample_id_dependency_add_to_case {
     my $log;
     my $parallel_chains_ref;
     my $path;
+    my $reservation_name;
     my $sample_ids_ref;
     my $sbatch_file_name;
 
@@ -1051,6 +1095,10 @@ sub slurm_submit_job_sample_id_dependency_add_to_case {
             strict_type => 1,
         },
         path => { defined => 1, required => 1, store => \$path, strict_type => 1, },
+        reservation_name => {
+            store       => \$reservation_name,
+            strict_type => 1,
+        },
         sample_ids_ref => {
             default     => [],
             defined     => 1,
@@ -1120,6 +1168,7 @@ sub slurm_submit_job_sample_id_dependency_add_to_case {
             job_dependency_type => $job_dependency_type,
             job_ids_string      => $job_ids_string,
             log                 => $log,
+            reservation_name    => $reservation_name,
             sbatch_file_name    => $sbatch_file_name,
         }
     );
@@ -1187,6 +1236,7 @@ sub slurm_submit_job_sample_id_dependency_case_dead_end {
 ##          : $log                     => Log
 ##          : $parallel_chains_ref     => Info on parallel chains array {REF}
 ##          : $path                    => Trunk or branch
+##          : $reservation_name        => Allocate resources from named reservation
 ##          : $sample_ids_ref          => Sample ids {REF}
 ##          : $sbatch_file_name        => Sbatch file name
 
@@ -1199,6 +1249,7 @@ sub slurm_submit_job_sample_id_dependency_case_dead_end {
     my $log;
     my $parallel_chains_ref;
     my $path;
+    my $reservation_name;
     my $sample_ids_ref;
     my $sbatch_file_name;
 
@@ -1249,6 +1300,10 @@ sub slurm_submit_job_sample_id_dependency_case_dead_end {
             strict_type => 1,
         },
         path => { defined => 1, required => 1, store => \$path, strict_type => 1, },
+        reservation_name => {
+            store       => \$reservation_name,
+            strict_type => 1,
+        },
         sample_ids_ref => {
             default     => [],
             defined     => 1,
@@ -1318,6 +1373,7 @@ sub slurm_submit_job_sample_id_dependency_case_dead_end {
             job_dependency_type => $job_dependency_type,
             job_ids_string      => $job_ids_string,
             log                 => $log,
+            reservation_name    => $reservation_name,
             sbatch_file_name    => $sbatch_file_name,
         }
     );
@@ -1376,6 +1432,7 @@ sub slurm_submit_job_sample_id_dependency_step_in_parallel_to_case {
 ##          : $log                     => Log
 ##          : $parallel_chains_ref     => Info on parallel chains array {REF}
 ##          : $path                    => Trunk or branch
+##          : $reservation_name        => Allocate resources from named reservation
 ##          : $sample_ids_ref          => Sample ids {REF}
 ##          : $sbatch_file_name        => Sbatch file name
 ##          : $sbatch_script_tracker   => Track the number of parallel processes (e.g. sbatch scripts for a module)
@@ -1389,6 +1446,7 @@ sub slurm_submit_job_sample_id_dependency_step_in_parallel_to_case {
     my $log;
     my $parallel_chains_ref;
     my $path;
+    my $reservation_name;
     my $sample_ids_ref;
     my $sbatch_file_name;
     my $sbatch_script_tracker;
@@ -1438,6 +1496,10 @@ sub slurm_submit_job_sample_id_dependency_step_in_parallel_to_case {
         parallel_chains_ref => {
             default     => [],
             store       => \$parallel_chains_ref,
+            strict_type => 1,
+        },
+        reservation_name => {
+            store       => \$reservation_name,
             strict_type => 1,
         },
         sample_ids_ref => {
@@ -1501,6 +1563,7 @@ sub slurm_submit_job_sample_id_dependency_step_in_parallel_to_case {
             job_dependency_type => $job_dependency_type,
             job_ids_string      => $job_ids_string,
             log                 => $log,
+            reservation_name    => $reservation_name,
             sbatch_file_name    => $sbatch_file_name,
         }
     );
@@ -1562,6 +1625,7 @@ sub slurm_submit_job_sample_id_dependency_step_in_parallel {
 ##          : $job_id_href             => The info on job ids hash {REF}
 ##          : $log                     => Log
 ##          : $path                    => Trunk or branch
+##          : $reservation_name        => Allocate resources from named reservation
 ##          : $sample_id               => Sample id
 ##          : $sbatch_file_name        => Sbatch file name
 ##          : $sbatch_script_tracker   => Track the number of parallel processes (e.g. sbatch scripts for a module)
@@ -1574,6 +1638,7 @@ sub slurm_submit_job_sample_id_dependency_step_in_parallel {
     my $job_id_href;
     my $log;
     my $path;
+    my $reservation_name;
     my $sample_id;
     my $sbatch_file_name;
     my $sbatch_script_tracker;
@@ -1619,7 +1684,11 @@ sub slurm_submit_job_sample_id_dependency_step_in_parallel {
             required => 1,
             store    => \$log,
         },
-        path      => { defined => 1, required => 1, store => \$path, strict_type => 1, },
+        path => { defined => 1, required => 1, store => \$path, strict_type => 1, },
+        reservation_name => {
+            store       => \$reservation_name,
+            strict_type => 1,
+        },
         sample_id => {
             store       => \$sample_id,
             strict_type => 1,
@@ -1726,6 +1795,7 @@ sub slurm_submit_job_sample_id_dependency_step_in_parallel {
             job_dependency_type => $job_dependency_type,
             job_ids_string      => $job_ids_string,
             log                 => $log,
+            reservation_name    => $reservation_name,
             sbatch_file_name    => $sbatch_file_name,
         }
     );
@@ -1783,6 +1853,7 @@ sub slurm_submit_chain_job_ids_dependency_add_to_path {
 ##          : $job_id_href         => The info on job ids hash {REF}
 ##          : $log                 => Log
 ##          : $path                => Trunk or branch
+##          : $reservation_name    => Allocate resources from named reservation
 ##          : $sbatch_file_name    => Sbatch file name
 
     my ($arg_href) = @_;
@@ -1791,6 +1862,7 @@ sub slurm_submit_chain_job_ids_dependency_add_to_path {
     my $job_id_href;
     my $log;
     my $path;
+    my $reservation_name;
     my $sbatch_file_name;
 
     ## Default(s)
@@ -1822,6 +1894,10 @@ sub slurm_submit_chain_job_ids_dependency_add_to_path {
             store    => \$log,
         },
         path => { defined => 1, required => 1, store => \$path, strict_type => 1, },
+        reservation_name => {
+            store       => \$reservation_name,
+            strict_type => 1,
+        },
         sbatch_file_name => {
             defined     => 1,
             required    => 1,
@@ -1862,6 +1938,7 @@ sub slurm_submit_chain_job_ids_dependency_add_to_path {
             job_dependency_type => $job_dependency_type,
             job_ids_string      => $job_ids_string,
             log                 => $log,
+            reservation_name    => $reservation_name,
             sbatch_file_name    => $sbatch_file_name,
         }
     );
@@ -1908,6 +1985,7 @@ sub submit_jobs_to_sbatch {
 ##          : $job_dependency_type => Job dependency type
 ##          : $job_ids_string      => Job ids string
 ##          : $log                 => Log
+##          : $reservation_name    => Allocate resources from named reservation
 ##          : $sbatch_file_name    => Sbatch file to submit
 
     my ($arg_href) = @_;
@@ -1916,6 +1994,7 @@ sub submit_jobs_to_sbatch {
     my $job_dependency_type;
     my $job_ids_string;
     my $log;
+    my $reservation_name;
     my $sbatch_file_name;
 
     ## Default(s)
@@ -1934,6 +2013,10 @@ sub submit_jobs_to_sbatch {
             required => 1,
             store    => \$log,
         },
+        reservation_name => {
+            store       => \$reservation_name,
+            strict_type => 1,
+        },
         sbatch_file_name => {
             defined     => 1,
             required    => 1,
@@ -1944,16 +2027,17 @@ sub submit_jobs_to_sbatch {
 
     check( $tmpl, $arg_href, 1 ) or croak q{Could not parse arguments!};
 
-    use MIP::Workloadmanager::Slurm qw{slurm_sbatch};
+    use MIP::Workloadmanager::Slurm qw{ slurm_sbatch };
     use MIP::Unix::System qw{ system_cmd_call };
 
     ## Supply with potential dependency of previous jobs that this one is dependent on
     my @commands = slurm_sbatch(
         {
-            base_command    => $base_command,
-            dependency_type => $job_dependency_type,
-            infile_path     => $sbatch_file_name,
-            job_ids_string  => $job_ids_string,
+            base_command     => $base_command,
+            dependency_type  => $job_dependency_type,
+            infile_path      => $sbatch_file_name,
+            job_ids_string   => $job_ids_string,
+            reservation_name => $reservation_name,
         }
     );
 
@@ -2038,10 +2122,11 @@ sub submit_slurm_recipe {
 ##          : $job_dependency_type     => SLURM job dependency type
 ##          : $log                     => Log
 ##          : $parallel_chains_ref     => Info on parallel chains array {REF}
-##          : $sample_id               => Sample id
-##          : $sample_ids_ref          => Sample ids {REF}
 ##          : $recipe_file_path        => Sbatch file path
 ##          : $recipe_files_tracker    => Track the number of parallel processes (e.g. sbatch scripts for a module)
+##          : $reservation_name        => Allocate resources from named reservation
+##          : $sample_id               => Sample id
+##          : $sample_ids_ref          => Sample ids {REF}
 
     my ($arg_href) = @_;
 
@@ -2054,10 +2139,11 @@ sub submit_slurm_recipe {
     my $job_id_href;
     my $log;
     my $parallel_chains_ref;
-    my $sample_id;
-    my $sample_ids_ref;
+    my $reservation_name;
     my $recipe_file_path;
     my $recipe_files_tracker;
+    my $sample_id;
+    my $sample_ids_ref;
 
     ## Default(s)
     my $base_command;
@@ -2128,6 +2214,10 @@ sub submit_slurm_recipe {
             store       => \$recipe_file_path,
             strict_type => 1,
         },
+        reservation_name => {
+            store       => \$reservation_name,
+            strict_type => 1,
+        },
         sample_id => {
             store       => \$sample_id,
             strict_type => 1,
@@ -2154,6 +2244,7 @@ sub submit_slurm_recipe {
                 job_dependency_type => $job_dependency_type,
                 log                 => $log,
                 path                => $job_id_chain,
+                reservation_name    => $reservation_name,
                 sbatch_file_name    => $recipe_file_path,
             }
         );
@@ -2170,6 +2261,7 @@ sub submit_slurm_recipe {
                 job_id_href             => $job_id_href,
                 log                     => $log,
                 path                    => $job_id_chain,
+                reservation_name        => $reservation_name,
                 sample_ids_ref          => $sample_ids_ref,
                 sbatch_file_name        => $recipe_file_path,
             }
@@ -2184,6 +2276,7 @@ sub submit_slurm_recipe {
                 base_command     => $base_command,
                 job_id_href      => $job_id_href,
                 log              => $log,
+                reservation_name => $reservation_name,
                 sbatch_file_name => $recipe_file_path,
             }
         );
@@ -2198,6 +2291,7 @@ sub submit_slurm_recipe {
                 job_id_href      => $job_id_href,
                 log              => $log,
                 path             => $job_id_chain,
+                reservation_name => $reservation_name,
                 sample_id        => $sample_id,
                 sbatch_file_name => $recipe_file_path
             }
@@ -2213,6 +2307,7 @@ sub submit_slurm_recipe {
                 job_id_href      => $job_id_href,
                 log              => $log,
                 path             => $job_id_chain,
+                reservation_name => $reservation_name,
                 sample_ids_ref   => $sample_ids_ref,
                 sbatch_file_name => $recipe_file_path,
             }
@@ -2229,6 +2324,7 @@ sub submit_slurm_recipe {
                 job_id_href             => $job_id_href,
                 log                     => $log,
                 path                    => $job_id_chain,
+                reservation_name        => $reservation_name,
                 sample_id               => $sample_id,
                 sbatch_file_name        => $recipe_file_path,
             }
@@ -2246,6 +2342,7 @@ sub submit_slurm_recipe {
                 log                     => $log,
                 path                    => $job_id_chain,
                 parallel_chains_ref     => $parallel_chains_ref,
+                reservation_name        => $reservation_name,
                 sample_ids_ref          => $sample_ids_ref,
                 sbatch_file_name        => $recipe_file_path,
             }
@@ -2262,6 +2359,7 @@ sub submit_slurm_recipe {
                 job_id_href             => $job_id_href,
                 log                     => $log,
                 path                    => $job_id_chain,
+                reservation_name        => $reservation_name,
                 sample_ids_ref          => $sample_ids_ref,
                 sbatch_file_name        => $recipe_file_path,
                 sbatch_script_tracker   => $recipe_files_tracker,
@@ -2279,6 +2377,7 @@ sub submit_slurm_recipe {
                 job_id_href             => $job_id_href,
                 log                     => $log,
                 path                    => $job_id_chain,
+                reservation_name        => $reservation_name,
                 sample_id               => $sample_id,
                 sbatch_file_name        => $recipe_file_path,
             }
@@ -2295,6 +2394,7 @@ sub submit_slurm_recipe {
                 job_id_href             => $job_id_href,
                 log                     => $log,
                 path                    => $job_id_chain,
+                reservation_name        => $reservation_name,
                 sample_id               => $sample_id,
                 sbatch_file_name        => $recipe_file_path,
                 sbatch_script_tracker   => $recipe_files_tracker,
@@ -2313,6 +2413,7 @@ sub submit_slurm_recipe {
             job_id_href             => $job_id_href,
             log                     => $log,
             path                    => $job_id_chain,
+            reservation_name        => $reservation_name,
             sample_id               => $sample_id,
             sbatch_file_name        => $recipe_file_path,
         }

--- a/lib/MIP/Recipes/Analysis/Analysisrunstatus.pm
+++ b/lib/MIP/Recipes/Analysis/Analysisrunstatus.pm
@@ -26,7 +26,7 @@ BEGIN {
     use base qw{ Exporter };
 
     # Set the version for version checking
-    our $VERSION = 1.07;
+    our $VERSION = 1.08;
 
     # Functions and variables which can be optionally exported
     our @EXPORT_OK = qw{ analysis_analysisrunstatus };
@@ -250,14 +250,15 @@ sub analysis_analysisrunstatus {
 
         submit_recipe(
             {
-                base_command        => $profile_base_command,
-                dependency_method   => q{add_to_all},
-                job_dependency_type => q{afterok},
-                job_id_chain        => $job_id_chain,
-                job_id_href         => $job_id_href,
-                log                 => $log,
-                recipe_file_path    => $recipe_file_path,
-                submission_profile  => $active_parameter_href->{submission_profile},
+                base_command         => $profile_base_command,
+                dependency_method    => q{add_to_all},
+                job_dependency_type  => q{afterok},
+                job_id_chain         => $job_id_chain,
+                job_id_href          => $job_id_href,
+                job_reservation_name => $active_parameter_href->{job_reservation_name},
+                log                  => $log,
+                recipe_file_path     => $recipe_file_path,
+                submission_profile   => $active_parameter_href->{submission_profile},
             }
         );
     }

--- a/lib/MIP/Recipes/Analysis/Bcftools_merge.pm
+++ b/lib/MIP/Recipes/Analysis/Bcftools_merge.pm
@@ -27,7 +27,7 @@ BEGIN {
     use base qw{ Exporter };
 
     # Set the version for version checking
-    our $VERSION = 1.05;
+    our $VERSION = 1.06;
 
     # Functions and variables which can be optionally exported
     our @EXPORT_OK = qw{ analysis_bcftools_merge };
@@ -287,6 +287,7 @@ sub analysis_bcftools_merge {
                 infile_lane_prefix_href => $infile_lane_prefix_href,
                 job_id_chain            => $job_id_chain,
                 job_id_href             => $job_id_href,
+                job_reservation_name    => $active_parameter_href->{job_reservation_name},
                 log                     => $log,
                 recipe_file_path        => $recipe_file_path,
                 sample_ids_ref          => \@{ $active_parameter_href->{sample_ids} },

--- a/lib/MIP/Recipes/Analysis/Bcftools_mpileup.pm
+++ b/lib/MIP/Recipes/Analysis/Bcftools_mpileup.pm
@@ -25,7 +25,7 @@ BEGIN {
     use base qw{ Exporter };
 
     # Set the version for version checking
-    our $VERSION = 1.12;
+    our $VERSION = 1.13;
 
     # Functions and variables which can be optionally exported
     our @EXPORT_OK = qw{ analysis_bcftools_mpileup };
@@ -449,6 +449,7 @@ sub analysis_bcftools_mpileup {
                 infile_lane_prefix_href => $infile_lane_prefix_href,
                 job_id_chain            => $job_id_chain,
                 job_id_href             => $job_id_href,
+                job_reservation_name    => $active_parameter_href->{job_reservation_name},
                 log                     => $log,
                 recipe_file_path        => $recipe_file_path,
                 sample_ids_ref          => \@{ $active_parameter_href->{sample_ids} },

--- a/lib/MIP/Recipes/Analysis/Blobfish.pm
+++ b/lib/MIP/Recipes/Analysis/Blobfish.pm
@@ -27,7 +27,7 @@ BEGIN {
     use base qw{ Exporter };
 
     # Set the version for version checking
-    our $VERSION = 1.04;
+    our $VERSION = 1.05;
 
     # Functions and variables which can be optionally exported
     our @EXPORT_OK = qw{ analysis_blobfish };
@@ -256,6 +256,7 @@ sub analysis_blobfish {
                 infile_lane_prefix_href => $infile_lane_prefix_href,
                 job_id_chain            => $job_id_chain,
                 job_id_href             => $job_id_href,
+                job_reservation_name    => $active_parameter_href->{job_reservation_name},
                 log                     => $log,
                 recipe_file_path        => $recipe_file_path,
                 sample_ids_ref          => \@{ $active_parameter_href->{sample_ids} },

--- a/lib/MIP/Recipes/Analysis/BootstrapAnn.pm
+++ b/lib/MIP/Recipes/Analysis/BootstrapAnn.pm
@@ -26,7 +26,7 @@ BEGIN {
     use base qw{ Exporter };
 
     # Set the version for version checking
-    our $VERSION = 1.07;
+    our $VERSION = 1.08;
 
     # Functions and variables which can be optionally exported
     our @EXPORT_OK = qw{ analysis_bootstrapann };
@@ -280,6 +280,7 @@ sub analysis_bootstrapann {
                 infile_lane_prefix_href => $infile_lane_prefix_href,
                 job_id_chain            => $job_id_chain,
                 job_id_href             => $job_id_href,
+                job_reservation_name    => $active_parameter_href->{job_reservation_name},
                 log                     => $log,
                 recipe_file_path        => $recipe_file_path,
                 sample_id               => $sample_id,

--- a/lib/MIP/Recipes/Analysis/Bwa_mem.pm
+++ b/lib/MIP/Recipes/Analysis/Bwa_mem.pm
@@ -487,8 +487,6 @@ sub analysis_bwa_mem {
                     log                  => $log,
                     recipe_file_path     => $recipe_file_path,
                     recipe_files_tracker => $infile_index,
-                    job_reservation_name =>
-                      $active_parameter_href->{job_reservation_name},
                     sample_id          => $sample_id,
                     submission_profile => $active_parameter_href->{submission_profile},
                 }

--- a/lib/MIP/Recipes/Analysis/Bwa_mem.pm
+++ b/lib/MIP/Recipes/Analysis/Bwa_mem.pm
@@ -27,7 +27,7 @@ BEGIN {
     use base qw{ Exporter };
 
     # Set the version for version checking
-    our $VERSION = 1.18;
+    our $VERSION = 1.19;
 
     # Functions and variables which can be optionally exported
     our @EXPORT_OK = qw{ analysis_bwa_mem analysis_run_bwa_mem };
@@ -482,10 +482,14 @@ sub analysis_bwa_mem {
                     infile_lane_prefix_href => $infile_lane_prefix_href,
                     job_id_chain            => $job_id_chain,
                     job_id_href             => $job_id_href,
-                    log                     => $log,
-                    recipe_file_path        => $recipe_file_path,
-                    recipe_files_tracker    => $infile_index,
-                    sample_id               => $sample_id,
+                    job_reservation_name =>
+                      $active_parameter_href->{job_reservation_name},
+                    log                  => $log,
+                    recipe_file_path     => $recipe_file_path,
+                    recipe_files_tracker => $infile_index,
+                    job_reservation_name =>
+                      $active_parameter_href->{job_reservation_name},
+                    sample_id          => $sample_id,
                     submission_profile => $active_parameter_href->{submission_profile},
                 }
             );
@@ -921,11 +925,13 @@ sub analysis_run_bwa_mem {
                     infile_lane_prefix_href => $infile_lane_prefix_href,
                     job_id_chain            => $job_id_chain,
                     job_id_href             => $job_id_href,
-                    log                     => $log,
-                    recipe_file_path        => $recipe_file_path,
-                    recipe_files_tracker    => $infile_index,
-                    sample_id               => $sample_id,
-                    submission_profile => $active_parameter_href->{submission_profile},
+                    job_reservation_name =>
+                      $active_parameter_href->{job_reservation_name},
+                    log                  => $log,
+                    recipe_file_path     => $recipe_file_path,
+                    recipe_files_tracker => $infile_index,
+                    sample_id            => $sample_id,
+                    submission_profile   => $active_parameter_href->{submission_profile},
                 }
             );
         }

--- a/lib/MIP/Recipes/Analysis/Cadd.pm
+++ b/lib/MIP/Recipes/Analysis/Cadd.pm
@@ -27,7 +27,7 @@ BEGIN {
     use base qw{ Exporter };
 
     # Set the version for version checking
-    our $VERSION = 1.03;
+    our $VERSION = 1.04;
 
     # Functions and variables which can be optionally exported
     our @EXPORT_OK = qw{ analysis_cadd analysis_cadd_gb_38 };
@@ -404,6 +404,7 @@ sub analysis_cadd {
                 infile_lane_prefix_href => $infile_lane_prefix_href,
                 job_id_chain            => $job_id_chain,
                 job_id_href             => $job_id_href,
+                job_reservation_name    => $active_parameter_href->{job_reservation_name},
                 log                     => $log,
                 recipe_file_path        => $recipe_file_path,
                 sample_ids_ref          => \@{ $active_parameter_href->{sample_ids} },
@@ -840,9 +841,10 @@ sub analysis_cadd_gb_38 {
                 dependency_method       => q{sample_to_case},
                 case_id                 => $case_id,
                 infile_lane_prefix_href => $infile_lane_prefix_href,
-                job_id_href             => $job_id_href,
-                log                     => $log,
                 job_id_chain            => $job_id_chain,
+                job_id_href             => $job_id_href,
+                job_reservation_name    => $active_parameter_href->{job_reservation_name},
+                log                     => $log,
                 recipe_file_path        => $recipe_file_path,
                 sample_ids_ref          => \@{ $active_parameter_href->{sample_ids} },
                 submission_profile      => $active_parameter_href->{submission_profile},

--- a/lib/MIP/Recipes/Analysis/Chanjo_sex_check.pm
+++ b/lib/MIP/Recipes/Analysis/Chanjo_sex_check.pm
@@ -26,7 +26,7 @@ BEGIN {
     use base qw{ Exporter };
 
     # Set the version for version checking
-    our $VERSION = 1.12;
+    our $VERSION = 1.13;
 
     # Functions and variables which can be optionally exported
     our @EXPORT_OK = qw{ analysis_chanjo_sex_check };
@@ -279,6 +279,7 @@ sub analysis_chanjo_sex_check {
                 infile_lane_prefix_href => $infile_lane_prefix_href,
                 job_id_chain            => $job_id_chain,
                 job_id_href             => $job_id_href,
+                job_reservation_name    => $active_parameter_href->{job_reservation_name},
                 log                     => $log,
                 recipe_file_path        => $recipe_file_path,
                 sample_id               => $sample_id,

--- a/lib/MIP/Recipes/Analysis/Chromograph.pm
+++ b/lib/MIP/Recipes/Analysis/Chromograph.pm
@@ -25,7 +25,7 @@ BEGIN {
     use base qw{ Exporter };
 
     # Set the version for version checking
-    our $VERSION = 1.03;
+    our $VERSION = 1.04;
 
     # Functions and variables which can be optionally exported
     our @EXPORT_OK = qw{ analysis_chromograph analysis_chromograph_proband };
@@ -264,6 +264,7 @@ sub analysis_chromograph {
                 infile_lane_prefix_href => $infile_lane_prefix_href,
                 job_id_chain            => $job_id_chain,
                 job_id_href             => $job_id_href,
+                job_reservation_name    => $active_parameter_href->{job_reservation_name},
                 log                     => $log,
                 recipe_file_path        => $recipe_file_path,
                 sample_id               => $sample_id,

--- a/lib/MIP/Recipes/Analysis/Cnvnator.pm
+++ b/lib/MIP/Recipes/Analysis/Cnvnator.pm
@@ -27,7 +27,7 @@ BEGIN {
     use base qw{ Exporter };
 
     # Set the version for version checking
-    our $VERSION = 1.12;
+    our $VERSION = 1.13;
 
     # Functions and variables which can be optionally exported
     our @EXPORT_OK = qw{ analysis_cnvnator };
@@ -507,6 +507,7 @@ sub analysis_cnvnator {
                 job_id_href             => $job_id_href,
                 log                     => $log,
                 recipe_file_path        => $recipe_file_path,
+                job_reservation_name    => $active_parameter_href->{job_reservation_name},
                 sample_id               => $sample_id,
                 submission_profile      => $active_parameter_href->{submission_profile},
             }

--- a/lib/MIP/Recipes/Analysis/Delly_call.pm
+++ b/lib/MIP/Recipes/Analysis/Delly_call.pm
@@ -24,7 +24,7 @@ BEGIN {
     use base qw{ Exporter };
 
     # Set the version for version checking
-    our $VERSION = 1.09;
+    our $VERSION = 1.10;
 
     # Functions and variables which can be optionally exported
     our @EXPORT_OK = qw{ analysis_delly_call };
@@ -268,6 +268,7 @@ sub analysis_delly_call {
                 infile_lane_prefix_href => $infile_lane_prefix_href,
                 job_id_chain            => $job_id_chain,
                 job_id_href             => $job_id_href,
+                job_reservation_name    => $active_parameter_href->{job_reservation_name},
                 log                     => $log,
                 recipe_file_path        => $recipe_file_path,
                 sample_id               => $sample_id,

--- a/lib/MIP/Recipes/Analysis/Delly_reformat.pm
+++ b/lib/MIP/Recipes/Analysis/Delly_reformat.pm
@@ -25,7 +25,7 @@ BEGIN {
     use base qw{ Exporter };
 
     # Set the version for version checking
-    our $VERSION = 1.08;
+    our $VERSION = 1.09;
 
     # Functions and variables which can be optionally exported
     our @EXPORT_OK = qw{ analysis_delly_reformat };
@@ -448,6 +448,7 @@ q{## Reformat bcf infile to match outfile from regenotyping with multiple sample
                 job_id_href             => $job_id_href,
                 log                     => $log,
                 job_id_chain            => $job_id_chain,
+                job_reservation_name    => $active_parameter_href->{job_reservation_name},
                 recipe_file_path        => $recipe_file_path,
                 sample_ids_ref          => \@{ $active_parameter_href->{sample_ids} },
                 submission_profile      => $active_parameter_href->{submission_profile},

--- a/lib/MIP/Recipes/Analysis/Dragen_dna.pm
+++ b/lib/MIP/Recipes/Analysis/Dragen_dna.pm
@@ -26,7 +26,7 @@ BEGIN {
     use base qw{ Exporter };
 
     # Set the version for version checking
-    our $VERSION = 1.00;
+    our $VERSION = 1.01;
 
     # Functions and variables which can be optionally exported
     our @EXPORT_OK = qw{ analysis_dragen_dna_align_vc analysis_dragen_dna_joint_calling };
@@ -365,6 +365,7 @@ sub analysis_dragen_dna_align_vc {
                 infile_lane_prefix_href => $infile_lane_prefix_href,
                 job_id_chain            => $job_id_chain,
                 job_id_href             => $job_id_href,
+                job_reservation_name    => $active_parameter_href->{job_reservation_name},
                 log                     => $log,
                 recipe_file_path        => $recipe_file_path,
                 sample_id               => $sample_id,

--- a/lib/MIP/Recipes/Analysis/Endvariantannotationblock.pm
+++ b/lib/MIP/Recipes/Analysis/Endvariantannotationblock.pm
@@ -25,7 +25,7 @@ BEGIN {
     use base qw{ Exporter };
 
     # Set the version for version checking
-    our $VERSION = 1.06;
+    our $VERSION = 1.07;
 
     # Functions and variables which can be optionally exported
     our @EXPORT_OK = qw{ analysis_endvariantannotationblock };
@@ -378,6 +378,7 @@ sub analysis_endvariantannotationblock {
                 infile_lane_prefix_href => $infile_lane_prefix_href,
                 job_id_chain            => $job_id_chain,
                 job_id_href             => $job_id_href,
+                job_reservation_name    => $active_parameter_href->{job_reservation_name},
                 log                     => $log,
                 recipe_file_path        => $recipe_file_path,
                 sample_ids_ref          => \@{ $active_parameter_href->{sample_ids} },

--- a/lib/MIP/Recipes/Analysis/Expansionhunter.pm
+++ b/lib/MIP/Recipes/Analysis/Expansionhunter.pm
@@ -24,7 +24,7 @@ BEGIN {
     use base qw{ Exporter };
 
     # Set the version for version checking
-    our $VERSION = 1.19;
+    our $VERSION = 1.20;
 
     # Functions and variables which can be optionally exported
     our @EXPORT_OK = qw{ analysis_expansionhunter };
@@ -402,6 +402,7 @@ sub analysis_expansionhunter {
                 infile_lane_prefix_href => $infile_lane_prefix_href,
                 job_id_chain            => $job_id_chain,
                 job_id_href             => $job_id_href,
+                job_reservation_name    => $active_parameter_href->{job_reservation_name},
                 log                     => $log,
                 recipe_file_path        => $recipe_file_path,
                 sample_ids_ref          => \@{ $active_parameter_href->{sample_ids} },

--- a/lib/MIP/Recipes/Analysis/Fastqc.pm
+++ b/lib/MIP/Recipes/Analysis/Fastqc.pm
@@ -26,7 +26,7 @@ BEGIN {
     use base qw{Exporter};
 
     # Set the version for version checking
-    our $VERSION = 1.14;
+    our $VERSION = 1.15;
 
     # Functions and variables which can be optionally exported
     our @EXPORT_OK = qw{ analysis_fastqc };
@@ -333,9 +333,10 @@ sub analysis_fastqc {
                 dependency_method       => q{sample_to_island},
                 case_id                 => $case_id,
                 infile_lane_prefix_href => $infile_lane_prefix_href,
-                job_id_href             => $job_id_href,
-                log                     => $log,
                 job_id_chain            => $job_id_chain,
+                job_id_href             => $job_id_href,
+                job_reservation_name    => $active_parameter_href->{job_reservation_name},
+                log                     => $log,
                 recipe_file_path        => $recipe_file_path,
                 sample_id               => $sample_id,
                 submission_profile      => $active_parameter_href->{submission_profile},

--- a/lib/MIP/Recipes/Analysis/Frequency_annotation.pm
+++ b/lib/MIP/Recipes/Analysis/Frequency_annotation.pm
@@ -26,7 +26,7 @@ BEGIN {
     use base qw{ Exporter };
 
     # Set the version for version checking
-    our $VERSION = 1.00;
+    our $VERSION = 1.01;
 
     # Functions and variables which can be optionally exported
     our @EXPORT_OK = qw{ analysis_frequency_annotation };
@@ -339,6 +339,7 @@ sub analysis_frequency_annotation {
                 infile_lane_prefix_href => $infile_lane_prefix_href,
                 job_id_chain            => $job_id_chain,
                 job_id_href             => $job_id_href,
+                job_reservation_name    => $active_parameter_href->{job_reservation_name},
                 log                     => $log,
                 recipe_file_path        => $recipe_file_path,
                 sample_ids_ref          => \@{ $active_parameter_href->{sample_ids} },

--- a/lib/MIP/Recipes/Analysis/Frequency_filter.pm
+++ b/lib/MIP/Recipes/Analysis/Frequency_filter.pm
@@ -27,7 +27,7 @@ BEGIN {
     use base qw{ Exporter };
 
     # Set the version for version checking
-    our $VERSION = 1.08;
+    our $VERSION = 1.09;
 
     # Functions and variables which can be optionally exported
     our @EXPORT_OK = qw{ analysis_frequency_filter };
@@ -303,6 +303,7 @@ sub analysis_frequency_filter {
                 infile_lane_prefix_href => $infile_lane_prefix_href,
                 job_id_chain            => $job_id_chain,
                 job_id_href             => $job_id_href,
+                job_reservation_name    => $active_parameter_href->{job_reservation_name},
                 log                     => $log,
                 recipe_file_path        => $recipe_file_path,
                 sample_ids_ref          => \@{ $active_parameter_href->{sample_ids} },

--- a/lib/MIP/Recipes/Analysis/Gatk_asereadcounter.pm
+++ b/lib/MIP/Recipes/Analysis/Gatk_asereadcounter.pm
@@ -26,7 +26,7 @@ BEGIN {
     use base qw{ Exporter };
 
     # Set the version for version checking
-    our $VERSION = 1.13;
+    our $VERSION = 1.14;
 
     # Functions and variables which can be optionally exported
     our @EXPORT_OK = qw{ analysis_gatk_asereadcounter };
@@ -320,6 +320,7 @@ sub analysis_gatk_asereadcounter {
                 infile_lane_prefix_href => $infile_lane_prefix_href,
                 job_id_chain            => $job_id_chain,
                 job_id_href             => $job_id_href,
+                job_reservation_name    => $active_parameter_href->{job_reservation_name},
                 log                     => $log,
                 recipe_file_path        => $recipe_file_path,
                 sample_id               => $sample_id,

--- a/lib/MIP/Recipes/Analysis/Gatk_baserecalibration.pm
+++ b/lib/MIP/Recipes/Analysis/Gatk_baserecalibration.pm
@@ -26,7 +26,7 @@ BEGIN {
     use base qw{ Exporter };
 
     # Set the version for version checking
-    our $VERSION = 1.16;
+    our $VERSION = 1.17;
 
     # Functions and variables which can be optionally exported
     our @EXPORT_OK = qw{ analysis_gatk_baserecalibration };
@@ -483,6 +483,7 @@ sub analysis_gatk_baserecalibration {
                 infile_lane_prefix_href => $infile_lane_prefix_href,
                 job_id_chain            => $job_id_chain,
                 job_id_href             => $job_id_href,
+                job_reservation_name    => $active_parameter_href->{job_reservation_name},
                 log                     => $log,
                 recipe_file_path        => $recipe_file_path,
                 sample_id               => $sample_id,

--- a/lib/MIP/Recipes/Analysis/Gatk_cnnscorevariants.pm
+++ b/lib/MIP/Recipes/Analysis/Gatk_cnnscorevariants.pm
@@ -26,7 +26,7 @@ BEGIN {
     use base qw{ Exporter };
 
     # Set the version for version checking
-    our $VERSION = 1.03;
+    our $VERSION = 1.04;
 
     # Functions and variables which can be optionally exported
     our @EXPORT_OK = qw{ analysis_gatk_cnnscorevariants };
@@ -357,6 +357,7 @@ sub analysis_gatk_cnnscorevariants {
                 infile_lane_prefix_href => $infile_lane_prefix_href,
                 job_id_chain            => $job_id_chain,
                 job_id_href             => $job_id_href,
+                job_reservation_name    => $active_parameter_href->{job_reservation_name},
                 log                     => $log,
                 recipe_file_path        => $recipe_file_path,
                 sample_ids_ref          => \@{ $active_parameter_href->{sample_ids} },

--- a/lib/MIP/Recipes/Analysis/Gatk_combinevariantcallsets.pm
+++ b/lib/MIP/Recipes/Analysis/Gatk_combinevariantcallsets.pm
@@ -25,7 +25,7 @@ BEGIN {
     use base qw{ Exporter };
 
     # Set the version for version checking
-    our $VERSION = 1.11;
+    our $VERSION = 1.12;
 
     # Functions and variables which can be optionally exported
     our @EXPORT_OK = qw{ analysis_gatk_combinevariantcallsets };
@@ -358,6 +358,7 @@ sub analysis_gatk_combinevariantcallsets {
                 infile_lane_prefix_href => $infile_lane_prefix_href,
                 job_id_chain            => $job_id_chain,
                 job_id_href             => $job_id_href,
+                job_reservation_name    => $active_parameter_href->{job_reservation_name},
                 log                     => $log,
                 parallel_chains_ref     => \@parallel_chains,
                 recipe_file_path        => $recipe_file_path,

--- a/lib/MIP/Recipes/Analysis/Gatk_gathervcfs.pm
+++ b/lib/MIP/Recipes/Analysis/Gatk_gathervcfs.pm
@@ -24,7 +24,7 @@ BEGIN {
     use base qw{ Exporter };
 
     # Set the version for version checking
-    our $VERSION = 1.06;
+    our $VERSION = 1.07;
 
     # Functions and variables which can be optionally exported
     our @EXPORT_OK = qw{ analysis_gatk_gathervcfs };
@@ -319,6 +319,7 @@ sub analysis_gatk_gathervcfs {
                 infile_lane_prefix_href => $infile_lane_prefix_href,
                 job_id_chain            => $job_id_chain,
                 job_id_href             => $job_id_href,
+                job_reservation_name    => $active_parameter_href->{job_reservation_name},
                 log                     => $log,
                 recipe_file_path        => $recipe_file_path,
                 sample_ids_ref          => \@{ $active_parameter_href->{sample_ids} },

--- a/lib/MIP/Recipes/Analysis/Gatk_genotypegvcfs.pm
+++ b/lib/MIP/Recipes/Analysis/Gatk_genotypegvcfs.pm
@@ -25,7 +25,7 @@ BEGIN {
     use base qw{ Exporter };
 
     # Set the version for version checking
-    our $VERSION = 1.17;
+    our $VERSION = 1.18;
 
     # Functions and variables which can be optionally exported
     our @EXPORT_OK = qw{ analysis_gatk_genotypegvcfs };
@@ -362,11 +362,13 @@ sub analysis_gatk_genotypegvcfs {
                     infile_lane_prefix_href => $infile_lane_prefix_href,
                     job_id_chain            => $job_id_chain,
                     job_id_href             => $job_id_href,
-                    log                     => $log,
-                    recipe_file_path        => $recipe_file_path,
-                    recipe_files_tracker    => $recipe_files_tracker,
-                    sample_ids_ref          => \@{ $active_parameter_href->{sample_ids} },
-                    submission_profile => $active_parameter_href->{submission_profile},
+                    job_reservation_name =>
+                      $active_parameter_href->{job_reservation_name},
+                    log                  => $log,
+                    recipe_file_path     => $recipe_file_path,
+                    recipe_files_tracker => $recipe_files_tracker,
+                    sample_ids_ref       => \@{ $active_parameter_href->{sample_ids} },
+                    submission_profile   => $active_parameter_href->{submission_profile},
                 }
             );
         }

--- a/lib/MIP/Recipes/Analysis/Gatk_haplotypecaller.pm
+++ b/lib/MIP/Recipes/Analysis/Gatk_haplotypecaller.pm
@@ -27,7 +27,7 @@ BEGIN {
     use base qw{ Exporter };
 
     # Set the version for version checking
-    our $VERSION = 1.20;
+    our $VERSION = 1.21;
 
     # Functions and variables which can be optionally exported
     our @EXPORT_OK = qw{ analysis_gatk_haplotypecaller };
@@ -424,6 +424,7 @@ sub analysis_gatk_haplotypecaller {
                 infile_lane_prefix_href => $infile_lane_prefix_href,
                 job_id_chain            => $job_id_chain,
                 job_id_href             => $job_id_href,
+                job_reservation_name    => $active_parameter_href->{job_reservation_name},
                 log                     => $log,
                 recipe_file_path        => $recipe_file_path,
                 sample_id               => $sample_id,

--- a/lib/MIP/Recipes/Analysis/Gatk_splitncigarreads.pm
+++ b/lib/MIP/Recipes/Analysis/Gatk_splitncigarreads.pm
@@ -27,7 +27,7 @@ BEGIN {
     use base qw{ Exporter };
 
     # Set the version for version checking
-    our $VERSION = 1.14;
+    our $VERSION = 1.15;
 
     # Functions and variables which can be optionally exported
     our @EXPORT_OK = qw{ analysis_gatk_splitncigarreads };
@@ -338,6 +338,7 @@ sub analysis_gatk_splitncigarreads {
                 infile_lane_prefix_href => $infile_lane_prefix_href,
                 job_id_chain            => $job_id_chain,
                 job_id_href             => $job_id_href,
+                job_reservation_name    => $active_parameter_href->{job_reservation_name},
                 log                     => $log,
                 recipe_file_path        => $recipe_file_path,
                 sample_id               => $sample_id,

--- a/lib/MIP/Recipes/Analysis/Gatk_variantevalall.pm
+++ b/lib/MIP/Recipes/Analysis/Gatk_variantevalall.pm
@@ -25,7 +25,7 @@ BEGIN {
     use base qw{ Exporter };
 
     # Set the version for version checking
-    our $VERSION = 1.10;
+    our $VERSION = 1.11;
 
     # Functions and variables which can be optionally exported
     our @EXPORT_OK = qw{ analysis_gatk_variantevalall };
@@ -295,6 +295,7 @@ sub analysis_gatk_variantevalall {
                 infile_lane_prefix_href => $infile_lane_prefix_href,
                 job_id_chain            => $job_id_chain,
                 job_id_href             => $job_id_href,
+                job_reservation_name    => $active_parameter_href->{job_reservation_name},
                 log                     => $log,
                 recipe_file_path        => $recipe_file_path,
                 sample_ids_ref          => \@{ $active_parameter_href->{sample_ids} },

--- a/lib/MIP/Recipes/Analysis/Gatk_variantevalexome.pm
+++ b/lib/MIP/Recipes/Analysis/Gatk_variantevalexome.pm
@@ -25,7 +25,7 @@ BEGIN {
     use base qw{ Exporter };
 
     # Set the version for version checking
-    our $VERSION = 1.10;
+    our $VERSION = 1.11;
 
     # Functions and variables which can be optionally exported
     our @EXPORT_OK = qw{ analysis_gatk_variantevalexome };
@@ -297,6 +297,7 @@ sub analysis_gatk_variantevalexome {
                 infile_lane_prefix_href => $infile_lane_prefix_href,
                 job_id_chain            => $job_id_chain,
                 job_id_href             => $job_id_href,
+                job_reservation_name    => $active_parameter_href->{job_reservation_name},
                 log                     => $log,
                 recipe_file_path        => $recipe_file_path,
                 sample_ids_ref          => \@{ $active_parameter_href->{sample_ids} },

--- a/lib/MIP/Recipes/Analysis/Gatk_variantfiltration.pm
+++ b/lib/MIP/Recipes/Analysis/Gatk_variantfiltration.pm
@@ -26,7 +26,7 @@ BEGIN {
     use base qw{ Exporter };
 
     # Set the version for version checking
-    our $VERSION = 1.08;
+    our $VERSION = 1.09;
 
     # Functions and variables which can be optionally exported
     our @EXPORT_OK = qw{ analysis_gatk_variantfiltration };
@@ -277,6 +277,7 @@ sub analysis_gatk_variantfiltration {
                 infile_lane_prefix_href => $infile_lane_prefix_href,
                 job_id_chain            => $job_id_chain,
                 job_id_href             => $job_id_href,
+                job_reservation_name    => $active_parameter_href->{job_reservation_name},
                 log                     => $log,
                 recipe_file_path        => $recipe_file_path,
                 sample_id               => $sample_id,

--- a/lib/MIP/Recipes/Analysis/Gatk_variantrecalibration.pm
+++ b/lib/MIP/Recipes/Analysis/Gatk_variantrecalibration.pm
@@ -27,7 +27,7 @@ BEGIN {
     use base qw{ Exporter };
 
     # Set the version for version checking
-    our $VERSION = 1.16;
+    our $VERSION = 1.17;
 
     # Functions and variables which can be optionally exported
     our @EXPORT_OK =
@@ -505,6 +505,7 @@ sub analysis_gatk_variantrecalibration_wes {
                 infile_lane_prefix_href => $infile_lane_prefix_href,
                 job_id_chain            => $job_id_chain,
                 job_id_href             => $job_id_href,
+                job_reservation_name    => $active_parameter_href->{job_reservation_name},
                 log                     => $log,
                 recipe_file_path        => $recipe_file_path,
                 sample_ids_ref          => \@{ $active_parameter_href->{sample_ids} },
@@ -995,6 +996,7 @@ sub analysis_gatk_variantrecalibration_wgs {
                 infile_lane_prefix_href => $infile_lane_prefix_href,
                 job_id_chain            => $job_id_chain,
                 job_id_href             => $job_id_href,
+                job_reservation_name    => $active_parameter_href->{job_reservation_name},
                 log                     => $log,
                 recipe_file_path        => $recipe_file_path,
                 sample_ids_ref          => \@{ $active_parameter_href->{sample_ids} },

--- a/lib/MIP/Recipes/Analysis/Genebody_coverage.pm
+++ b/lib/MIP/Recipes/Analysis/Genebody_coverage.pm
@@ -25,7 +25,7 @@ BEGIN {
     use base qw{ Exporter };
 
     # Set the version for version checking
-    our $VERSION = 1.04;
+    our $VERSION = 1.05;
 
     # Functions and variables which can be optionally exported
     our @EXPORT_OK = qw{ analysis_genebody_coverage };
@@ -305,6 +305,7 @@ sub analysis_genebody_coverage {
                 infile_lane_prefix_href => $infile_lane_prefix_href,
                 job_id_chain            => $job_id_chain,
                 job_id_href             => $job_id_href,
+                job_reservation_name    => $active_parameter_href->{job_reservation_name},
                 log                     => $log,
                 recipe_file_path        => $recipe_file_path,
                 sample_id               => $sample_id,

--- a/lib/MIP/Recipes/Analysis/Gffcompare.pm
+++ b/lib/MIP/Recipes/Analysis/Gffcompare.pm
@@ -25,7 +25,7 @@ BEGIN {
     use base qw{ Exporter };
 
     # Set the version for version checking
-    our $VERSION = 1.07;
+    our $VERSION = 1.08;
 
     # Functions and variables which can be optionally exported
     our @EXPORT_OK = qw{ analysis_gffcompare };
@@ -307,6 +307,7 @@ sub analysis_gffcompare {
                 infile_lane_prefix_href => $infile_lane_prefix_href,
                 job_id_chain            => $job_id_chain,
                 job_id_href             => $job_id_href,
+                job_reservation_name    => $active_parameter_href->{job_reservation_name},
                 log                     => $log,
                 recipe_file_path        => $recipe_file_path,
                 sample_id               => $sample_id,

--- a/lib/MIP/Recipes/Analysis/Gzip_fastq.pm
+++ b/lib/MIP/Recipes/Analysis/Gzip_fastq.pm
@@ -25,7 +25,7 @@ BEGIN {
     use base qw{ Exporter };
 
     # Set the version for version checking
-    our $VERSION = 1.08;
+    our $VERSION = 1.09;
 
     # Functions and variables which can be optionally exported
     our @EXPORT_OK = qw{ analysis_gzip_fastq };
@@ -286,15 +286,16 @@ sub analysis_gzip_fastq {
 
         submit_recipe(
             {
-                base_command       => $profile_base_command,
-                case_id            => $case_id,
-                dependency_method  => q{island_to_sample},
-                job_id_chain       => $job_id_chain,
-                job_id_href        => $job_id_href,
-                log                => $log,
-                recipe_file_path   => $recipe_file_path,
-                sample_id          => $sample_id,
-                submission_profile => $active_parameter_href->{submission_profile},
+                base_command         => $profile_base_command,
+                case_id              => $case_id,
+                dependency_method    => q{island_to_sample},
+                job_id_chain         => $job_id_chain,
+                job_id_href          => $job_id_href,
+                job_reservation_name => $active_parameter_href->{job_reservation_name},
+                log                  => $log,
+                recipe_file_path     => $recipe_file_path,
+                sample_id            => $sample_id,
+                submission_profile   => $active_parameter_href->{submission_profile},
             }
         );
     }

--- a/lib/MIP/Recipes/Analysis/Manta.pm
+++ b/lib/MIP/Recipes/Analysis/Manta.pm
@@ -25,7 +25,7 @@ BEGIN {
     use base qw{ Exporter };
 
     # Set the version for version checking
-    our $VERSION = 1.14;
+    our $VERSION = 1.15;
 
     # Functions and variables which can be optionally exported
     our @EXPORT_OK = qw{ analysis_manta };
@@ -317,6 +317,7 @@ sub analysis_manta {
                 infile_lane_prefix_href => $infile_lane_prefix_href,
                 job_id_chain            => $job_id_chain,
                 job_id_href             => $job_id_href,
+                job_reservation_name    => $active_parameter_href->{job_reservation_name},
                 log                     => $log,
                 recipe_file_path        => $recipe_file_path,
                 sample_ids_ref          => \@{ $active_parameter_href->{sample_ids} },

--- a/lib/MIP/Recipes/Analysis/Markduplicates.pm
+++ b/lib/MIP/Recipes/Analysis/Markduplicates.pm
@@ -27,7 +27,7 @@ BEGIN {
     use base qw{ Exporter };
 
     # Set the version for version checking
-    our $VERSION = 1.18;
+    our $VERSION = 1.19;
 
     # Functions and variables which can be optionally exported
     our @EXPORT_OK = qw{ analysis_markduplicates };
@@ -492,6 +492,7 @@ sub analysis_markduplicates {
                 infile_lane_prefix_href => $infile_lane_prefix_href,
                 job_id_chain            => $job_id_chain,
                 job_id_href             => $job_id_href,
+                job_reservation_name    => $active_parameter_href->{job_reservation_name},
                 log                     => $log,
                 recipe_file_path        => $recipe_file_path,
                 sample_id               => $sample_id,

--- a/lib/MIP/Recipes/Analysis/Mip_qccollect.pm
+++ b/lib/MIP/Recipes/Analysis/Mip_qccollect.pm
@@ -25,7 +25,7 @@ BEGIN {
     use base qw{ Exporter };
 
     # Set the version for version checking
-    our $VERSION = 1.07;
+    our $VERSION = 1.08;
 
     # Functions and variables which can be optionally exported
     our @EXPORT_OK = qw{ analysis_mip_qccollect };
@@ -224,14 +224,15 @@ sub analysis_mip_qccollect {
 
         submit_recipe(
             {
-                base_command        => $profile_base_command,
-                dependency_method   => q{add_to_all},
-                job_dependency_type => q{afterok},
-                job_id_chain        => $job_id_chain,
-                job_id_href         => $job_id_href,
-                log                 => $log,
-                recipe_file_path    => $recipe_file_path,
-                submission_profile  => $active_parameter_href->{submission_profile},
+                base_command         => $profile_base_command,
+                dependency_method    => q{add_to_all},
+                job_dependency_type  => q{afterok},
+                job_id_chain         => $job_id_chain,
+                job_id_href          => $job_id_href,
+                job_reservation_name => $active_parameter_href->{job_reservation_name},
+                log                  => $log,
+                recipe_file_path     => $recipe_file_path,
+                submission_profile   => $active_parameter_href->{submission_profile},
             }
         );
     }

--- a/lib/MIP/Recipes/Analysis/Mip_vcfparser.pm
+++ b/lib/MIP/Recipes/Analysis/Mip_vcfparser.pm
@@ -26,7 +26,7 @@ BEGIN {
     use base qw{ Exporter };
 
     # Set the version for version checking
-    our $VERSION = 1.18;
+    our $VERSION = 1.19;
 
     # Functions and variables which can be optionally exported
     our @EXPORT_OK =
@@ -439,6 +439,7 @@ sub analysis_mip_vcfparser {
                 infile_lane_prefix_href => $infile_lane_prefix_href,
                 job_id_chain            => $job_id_chain,
                 job_id_href             => $job_id_href,
+                job_reservation_name    => $active_parameter_href->{job_reservation_name},
                 log                     => $log,
                 recipe_file_path        => $recipe_file_path,
                 sample_ids_ref          => \@{ $active_parameter_href->{sample_ids} },
@@ -764,6 +765,7 @@ sub analysis_mip_vcfparser_sv_wes {
                 infile_lane_prefix_href => $infile_lane_prefix_href,
                 job_id_chain            => $job_id_chain,
                 job_id_href             => $job_id_href,
+                job_reservation_name    => $active_parameter_href->{job_reservation_name},
                 log                     => $log,
                 recipe_file_path        => $recipe_file_path,
                 sample_ids_ref          => \@{ $active_parameter_href->{sample_ids} },
@@ -1179,6 +1181,7 @@ sub analysis_mip_vcfparser_sv_wgs {
                 infile_lane_prefix_href => $infile_lane_prefix_href,
                 job_id_chain            => $job_id_chain,
                 job_id_href             => $job_id_href,
+                job_reservation_name    => $active_parameter_href->{job_reservation_name},
                 log                     => $log,
                 recipe_file_path        => $recipe_file_path,
                 sample_ids_ref          => \@{ $active_parameter_href->{sample_ids} },

--- a/lib/MIP/Recipes/Analysis/Mip_vercollect.pm
+++ b/lib/MIP/Recipes/Analysis/Mip_vercollect.pm
@@ -25,7 +25,7 @@ BEGIN {
     use base qw{ Exporter };
 
     # Set the version for version checking
-    our $VERSION = 1.01;
+    our $VERSION = 1.02;
 
     # Functions and variables which can be optionally exported
     our @EXPORT_OK = qw{ analysis_mip_vercollect };
@@ -235,14 +235,15 @@ sub analysis_mip_vercollect {
 
         submit_recipe(
             {
-                base_command        => $profile_base_command,
-                dependency_method   => q{add_to_all},
-                job_dependency_type => q{afterok},
-                job_id_chain        => $job_id_chain,
-                job_id_href         => $job_id_href,
-                log                 => $log,
-                recipe_file_path    => $recipe_file_path,
-                submission_profile  => $active_parameter_href->{submission_profile},
+                base_command         => $profile_base_command,
+                dependency_method    => q{add_to_all},
+                job_dependency_type  => q{afterok},
+                job_id_chain         => $job_id_chain,
+                job_id_href          => $job_id_href,
+                job_reservation_name => $active_parameter_href->{job_reservation_name},
+                log                  => $log,
+                recipe_file_path     => $recipe_file_path,
+                submission_profile   => $active_parameter_href->{submission_profile},
             }
         );
     }

--- a/lib/MIP/Recipes/Analysis/Multiqc.pm
+++ b/lib/MIP/Recipes/Analysis/Multiqc.pm
@@ -25,7 +25,7 @@ BEGIN {
     use base qw{ Exporter };
 
     # Set the version for version checking
-    our $VERSION = 1.10;
+    our $VERSION = 1.11;
 
     # Functions and variables which can be optionally exported
     our @EXPORT_OK = qw{ analysis_multiqc };
@@ -240,14 +240,15 @@ sub analysis_multiqc {
 
         submit_recipe(
             {
-                base_command        => $profile_base_command,
-                dependency_method   => q{add_to_all},
-                job_dependency_type => q{afterok},
-                job_id_chain        => $job_id_chain,
-                job_id_href         => $job_id_href,
-                log                 => $log,
-                recipe_file_path    => $recipe_file_path,
-                submission_profile  => $active_parameter_href->{submission_profile},
+                base_command         => $profile_base_command,
+                dependency_method    => q{add_to_all},
+                job_dependency_type  => q{afterok},
+                job_id_chain         => $job_id_chain,
+                job_id_href          => $job_id_href,
+                job_reservation_name => $active_parameter_href->{job_reservation_name},
+                log                  => $log,
+                recipe_file_path     => $recipe_file_path,
+                submission_profile   => $active_parameter_href->{submission_profile},
             }
         );
     }

--- a/lib/MIP/Recipes/Analysis/Peddy.pm
+++ b/lib/MIP/Recipes/Analysis/Peddy.pm
@@ -25,7 +25,7 @@ BEGIN {
     use base qw{ Exporter };
 
     # Set the version for version checking
-    our $VERSION = 1.11;
+    our $VERSION = 1.12;
 
     # Functions and variables which can be optionally exported
     our @EXPORT_OK = qw{ analysis_peddy };
@@ -300,6 +300,7 @@ sub analysis_peddy {
                 infile_lane_prefix_href => $infile_lane_prefix_href,
                 job_id_chain            => $job_id_chain,
                 job_id_href             => $job_id_href,
+                job_reservation_name    => $active_parameter_href->{job_reservation_name},
                 log                     => $log,
                 recipe_file_path        => $recipe_file_path,
                 sample_ids_ref          => \@{ $active_parameter_href->{sample_ids} },

--- a/lib/MIP/Recipes/Analysis/Picardtools_collecthsmetrics.pm
+++ b/lib/MIP/Recipes/Analysis/Picardtools_collecthsmetrics.pm
@@ -25,7 +25,7 @@ BEGIN {
     use base qw{ Exporter };
 
     # Set the version for version checking
-    our $VERSION = 1.10;
+    our $VERSION = 1.11;
 
     # Functions and variables which can be optionally exported
     our @EXPORT_OK = qw{ analysis_picardtools_collecthsmetrics };
@@ -289,6 +289,7 @@ sub analysis_picardtools_collecthsmetrics {
                 infile_lane_prefix_href => $infile_lane_prefix_href,
                 job_id_chain            => $job_id_chain,
                 job_id_href             => $job_id_href,
+                job_reservation_name    => $active_parameter_href->{job_reservation_name},
                 log                     => $log,
                 recipe_file_path        => $recipe_file_path,
                 sample_id               => $sample_id,

--- a/lib/MIP/Recipes/Analysis/Picardtools_collectmultiplemetrics.pm
+++ b/lib/MIP/Recipes/Analysis/Picardtools_collectmultiplemetrics.pm
@@ -25,7 +25,7 @@ BEGIN {
     use base qw{ Exporter };
 
     # Set the version for version checking
-    our $VERSION = 1.09;
+    our $VERSION = 1.10;
 
     # Functions and variables which can be optionally exported
     our @EXPORT_OK = qw{ analysis_picardtools_collectmultiplemetrics };
@@ -282,6 +282,7 @@ sub analysis_picardtools_collectmultiplemetrics {
                 infile_lane_prefix_href => $infile_lane_prefix_href,
                 job_id_chain            => $job_id_chain,
                 job_id_href             => $job_id_href,
+                job_reservation_name    => $active_parameter_href->{job_reservation_name},
                 log                     => $log,
                 recipe_file_path        => $recipe_file_path,
                 sample_id               => $sample_id,

--- a/lib/MIP/Recipes/Analysis/Picardtools_mergesamfiles.pm
+++ b/lib/MIP/Recipes/Analysis/Picardtools_mergesamfiles.pm
@@ -28,7 +28,7 @@ BEGIN {
     use base qw{ Exporter };
 
     # Set the version for version checking
-    our $VERSION = 1.18;
+    our $VERSION = 1.19;
 
     # Functions and variables which can be optionally exported
     our @EXPORT_OK = qw{ analysis_picardtools_mergesamfiles };
@@ -493,6 +493,7 @@ q{## Renaming sample instead of merge to streamline handling of filenames downst
                 infile_lane_prefix_href => $infile_lane_prefix_href,
                 job_id_chain            => $job_id_chain,
                 job_id_href             => $job_id_href,
+                job_reservation_name    => $active_parameter_href->{job_reservation_name},
                 log                     => $log,
                 recipe_file_path        => $recipe_file_path,
                 sample_id               => $sample_id,

--- a/lib/MIP/Recipes/Analysis/Plink.pm
+++ b/lib/MIP/Recipes/Analysis/Plink.pm
@@ -25,7 +25,7 @@ BEGIN {
     use base qw{ Exporter };
 
     # Set the version for version checking
-    our $VERSION = 1.13;
+    our $VERSION = 1.14;
 
     # Functions and variables which can be optionally exported
     our @EXPORT_OK = qw{ analysis_plink };
@@ -513,6 +513,7 @@ sub analysis_plink {
                 infile_lane_prefix_href => $infile_lane_prefix_href,
                 job_id_chain            => $job_id_chain,
                 job_id_href             => $job_id_href,
+                job_reservation_name    => $active_parameter_href->{job_reservation_name},
                 log                     => $log,
                 recipe_file_path        => $recipe_file_path,
                 sample_ids_ref          => \@{ $active_parameter_href->{sample_ids} },

--- a/lib/MIP/Recipes/Analysis/Prepareforvariantannotationblock.pm
+++ b/lib/MIP/Recipes/Analysis/Prepareforvariantannotationblock.pm
@@ -25,7 +25,7 @@ BEGIN {
     use base qw{ Exporter };
 
     # Set the version for version checking
-    our $VERSION = 1.06;
+    our $VERSION = 1.07;
 
     # Functions and variables which can be optionally exported
     our @EXPORT_OK = qw{ analysis_prepareforvariantannotationblock };
@@ -336,6 +336,7 @@ sub analysis_prepareforvariantannotationblock {
                 infile_lane_prefix_href => $infile_lane_prefix_href,
                 job_id_chain            => $job_id_chain,
                 job_id_href             => $job_id_href,
+                job_reservation_name    => $active_parameter_href->{job_reservation_name},
                 log                     => $log,
                 recipe_file_path        => $recipe_file_path,
                 sample_ids_ref          => \@{ $active_parameter_href->{sample_ids} },

--- a/lib/MIP/Recipes/Analysis/Preseq.pm
+++ b/lib/MIP/Recipes/Analysis/Preseq.pm
@@ -25,7 +25,7 @@ BEGIN {
     use base qw{ Exporter };
 
     # Set the version for version checking
-    our $VERSION = 1.03;
+    our $VERSION = 1.04;
 
     # Functions and variables which can be optionally exported
     our @EXPORT_OK = qw{ analysis_preseq };
@@ -255,6 +255,7 @@ sub analysis_preseq {
                 infile_lane_prefix_href => $infile_lane_prefix_href,
                 job_id_chain            => $job_id_chain,
                 job_id_href             => $job_id_href,
+                job_reservation_name    => $active_parameter_href->{job_reservation_name},
                 log                     => $log,
                 recipe_file_path        => $recipe_file_path,
                 sample_id               => $sample_id,

--- a/lib/MIP/Recipes/Analysis/Rankvariant.pm
+++ b/lib/MIP/Recipes/Analysis/Rankvariant.pm
@@ -27,7 +27,7 @@ BEGIN {
     use base qw{ Exporter };
 
     # Set the version for version checking
-    our $VERSION = 1.12;
+    our $VERSION = 1.13;
 
     # Functions and variables which can be optionally exported
     our @EXPORT_OK =
@@ -447,6 +447,7 @@ sub analysis_rankvariant {
                 infile_lane_prefix_href => $infile_lane_prefix_href,
                 job_id_chain            => $job_id_chain,
                 job_id_href             => $job_id_href,
+                job_reservation_name    => $active_parameter_href->{job_reservation_name},
                 log                     => $log,
                 recipe_file_path        => $recipe_file_path,
                 sample_ids_ref          => \@{ $active_parameter_href->{sample_ids} },
@@ -788,6 +789,7 @@ sub analysis_rankvariant_unaffected {
                 infile_lane_prefix_href => $infile_lane_prefix_href,
                 job_id_chain            => $job_id_chain,
                 job_id_href             => $job_id_href,
+                job_reservation_name    => $active_parameter_href->{job_reservation_name},
                 log                     => $log,
                 recipe_file_path        => $recipe_file_path,
                 sample_ids_ref          => \@{ $active_parameter_href->{sample_ids} },
@@ -1183,6 +1185,7 @@ sub analysis_rankvariant_sv {
                 infile_lane_prefix_href => $infile_lane_prefix_href,
                 job_id_chain            => $job_id_chain,
                 job_id_href             => $job_id_href,
+                job_reservation_name    => $active_parameter_href->{job_reservation_name},
                 log                     => $log,
                 recipe_file_path        => $recipe_file_path,
                 sample_ids_ref          => \@{ $active_parameter_href->{sample_ids} },
@@ -1470,6 +1473,7 @@ sub analysis_rankvariant_sv_unaffected {
                 infile_lane_prefix_href => $infile_lane_prefix_href,
                 job_id_chain            => $job_id_chain,
                 job_id_href             => $job_id_href,
+                job_reservation_name    => $active_parameter_href->{job_reservation_name},
                 log                     => $log,
                 recipe_file_path        => $recipe_file_path,
                 sample_ids_ref          => \@{ $active_parameter_href->{sample_ids} },

--- a/lib/MIP/Recipes/Analysis/Rhocall.pm
+++ b/lib/MIP/Recipes/Analysis/Rhocall.pm
@@ -25,7 +25,7 @@ BEGIN {
     use base qw{ Exporter };
 
     # Set the version for version checking
-    our $VERSION = 1.08;
+    our $VERSION = 1.09;
 
     # Functions and variables which can be optionally exported
     our @EXPORT_OK = qw{ analysis_rhocall_annotate analysis_rhocall_viz };
@@ -318,6 +318,7 @@ sub analysis_rhocall_annotate {
                 infile_lane_prefix_href => $infile_lane_prefix_href,
                 job_id_chain            => $job_id_chain,
                 job_id_href             => $job_id_href,
+                job_reservation_name    => $active_parameter_href->{job_reservation_name},
                 log                     => $log,
                 recipe_file_path        => $recipe_file_path,
                 sample_ids_ref          => \@{ $active_parameter_href->{sample_ids} },
@@ -600,6 +601,7 @@ sub analysis_rhocall_viz {
                 infile_lane_prefix_href => $infile_lane_prefix_href,
                 job_id_chain            => $job_id_chain,
                 job_id_href             => $job_id_href,
+                job_reservation_name    => $active_parameter_href->{job_reservation_name},
                 log                     => $log,
                 recipe_file_path        => $recipe_file_path,
                 sample_id               => $sample_id,

--- a/lib/MIP/Recipes/Analysis/Rseqc.pm
+++ b/lib/MIP/Recipes/Analysis/Rseqc.pm
@@ -27,7 +27,7 @@ BEGIN {
     use base qw{ Exporter };
 
     # Set the version for version checking
-    our $VERSION = 1.06;
+    our $VERSION = 1.07;
 
     # Functions and variables which can be optionally exported
     our @EXPORT_OK = qw{ analysis_rseqc };
@@ -341,6 +341,7 @@ sub analysis_rseqc {
                 infile_lane_prefix_href => $infile_lane_prefix_href,
                 job_id_chain            => $job_id_chain,
                 job_id_href             => $job_id_href,
+                job_reservation_name    => $active_parameter_href->{job_reservation_name},
                 log                     => $log,
                 recipe_file_path        => $recipe_file_path,
                 sample_id               => $sample_id,

--- a/lib/MIP/Recipes/Analysis/Rtg_vcfeval.pm
+++ b/lib/MIP/Recipes/Analysis/Rtg_vcfeval.pm
@@ -25,7 +25,7 @@ BEGIN {
     use base qw{ Exporter };
 
     # Set the version for version checking
-    our $VERSION = 1.13;
+    our $VERSION = 1.14;
 
     # Functions and variables which can be optionally exported
     our @EXPORT_OK = qw{ analysis_rtg_vcfeval };
@@ -397,6 +397,7 @@ sub analysis_rtg_vcfeval {
                 infile_lane_prefix_href => $infile_lane_prefix_href,
                 job_id_chain            => $job_id_chain,
                 job_id_href             => $job_id_href,
+                job_reservation_name    => $active_parameter_href->{job_reservation_name},
                 log                     => $log,
                 recipe_file_path        => $recipe_file_path,
                 sample_ids_ref          => \@{ $active_parameter_href->{sample_ids} },

--- a/lib/MIP/Recipes/Analysis/Sacct.pm
+++ b/lib/MIP/Recipes/Analysis/Sacct.pm
@@ -25,7 +25,7 @@ BEGIN {
     use base qw{ Exporter };
 
     # Set the version for version checking
-    our $VERSION = 1.05;
+    our $VERSION = 1.06;
 
     # Functions and variables which can be optionally exported
     our @EXPORT_OK = qw{ analysis_sacct };
@@ -187,14 +187,15 @@ sub analysis_sacct {
 
         submit_recipe(
             {
-                base_command        => $profile_base_command,
-                dependency_method   => q{add_to_all},
-                job_dependency_type => q{afterany},
-                job_id_chain        => $job_id_chain,
-                job_id_href         => $job_id_href,
-                log                 => $log,
-                recipe_file_path    => $recipe_file_path,
-                submission_profile  => $active_parameter_href->{submission_profile},
+                base_command         => $profile_base_command,
+                dependency_method    => q{add_to_all},
+                job_dependency_type  => q{afterany},
+                job_id_chain         => $job_id_chain,
+                job_id_href          => $job_id_href,
+                job_reservation_name => $active_parameter_href->{job_reservation_name},
+                log                  => $log,
+                recipe_file_path     => $recipe_file_path,
+                submission_profile   => $active_parameter_href->{submission_profile},
             }
         );
     }

--- a/lib/MIP/Recipes/Analysis/Salmon_quant.pm
+++ b/lib/MIP/Recipes/Analysis/Salmon_quant.pm
@@ -26,7 +26,7 @@ BEGIN {
     use base qw{ Exporter };
 
     # Set the version for version checking
-    our $VERSION = 1.12;
+    our $VERSION = 1.13;
 
     # Functions and variables which can be optionally exported
     our @EXPORT_OK = qw{ analysis_salmon_quant };
@@ -310,6 +310,7 @@ sub analysis_salmon_quant {
                 infile_lane_prefix_href => $infile_lane_prefix_href,
                 job_id_chain            => $job_id_chain,
                 job_id_href             => $job_id_href,
+                job_reservation_name    => $active_parameter_href->{job_reservation_name},
                 log                     => $log,
                 recipe_file_path        => $recipe_file_path,
                 sample_id               => $sample_id,

--- a/lib/MIP/Recipes/Analysis/Sambamba_depth.pm
+++ b/lib/MIP/Recipes/Analysis/Sambamba_depth.pm
@@ -24,7 +24,7 @@ BEGIN {
     use base qw{ Exporter };
 
     # Set the version for version checking
-    our $VERSION = 1.10;
+    our $VERSION = 1.11;
 
     # Functions and variables which can be optionally exported
     our @EXPORT_OK = qw{ analysis_sambamba_depth };
@@ -286,6 +286,7 @@ sub analysis_sambamba_depth {
                 infile_lane_prefix_href => $infile_lane_prefix_href,
                 job_id_chain            => $job_id_chain,
                 job_id_href             => $job_id_href,
+                job_reservation_name    => $active_parameter_href->{job_reservation_name},
                 log                     => $log,
                 recipe_file_path        => $recipe_file_path,
                 sample_id               => $sample_id,

--- a/lib/MIP/Recipes/Analysis/Samtools_subsample_mt.pm
+++ b/lib/MIP/Recipes/Analysis/Samtools_subsample_mt.pm
@@ -26,7 +26,7 @@ BEGIN {
     use base qw{ Exporter };
 
     # Set the version for version checking
-    our $VERSION = 1.12;
+    our $VERSION = 1.13;
 
     # Functions and variables which can be optionally exported
     our @EXPORT_OK = qw{ analysis_samtools_subsample_mt };
@@ -333,9 +333,10 @@ sub analysis_samtools_subsample_mt {
                 infile_lane_prefix_href => $infile_lane_prefix_href,
                 job_id_chain            => $job_id_chain,
                 job_id_href             => $job_id_href,
+                job_reservation_name    => $active_parameter_href->{job_reservation_name},
                 log                     => $log,
-                sample_id               => $sample_id,
                 recipe_file_path        => $recipe_file_path,
+                sample_id               => $sample_id,
                 submission_profile      => $active_parameter_href->{submission_profile},
             }
         );

--- a/lib/MIP/Recipes/Analysis/Split_fastq_file.pm
+++ b/lib/MIP/Recipes/Analysis/Split_fastq_file.pm
@@ -26,7 +26,7 @@ BEGIN {
     use base qw{ Exporter };
 
     # Set the version for version checking
-    our $VERSION = 1.07;
+    our $VERSION = 1.08;
 
     # Functions and variables which can be optionally exported
     our @EXPORT_OK = qw{ analysis_split_fastq_file };
@@ -347,9 +347,11 @@ sub analysis_split_fastq_file {
                     infile_lane_prefix_href => $infile_lane_prefix_href,
                     job_id_chain            => $job_id_chain,
                     job_id_href             => $job_id_href,
-                    log                     => $log,
-                    recipe_file_path        => $recipe_file_path,
-                    sample_id               => $sample_id,
+                    job_reservation_name =>
+                      $active_parameter_href->{job_reservation_name},
+                    log                => $log,
+                    recipe_file_path   => $recipe_file_path,
+                    sample_id          => $sample_id,
                     submission_profile => $active_parameter_href->{submission_profile},
                 }
             );

--- a/lib/MIP/Recipes/Analysis/Star_aln.pm
+++ b/lib/MIP/Recipes/Analysis/Star_aln.pm
@@ -25,7 +25,7 @@ BEGIN {
     use base qw{ Exporter };
 
     # Set the version for version checking
-    our $VERSION = 1.13;
+    our $VERSION = 1.14;
 
     # Functions and variables which can be optionally exported
     our @EXPORT_OK = qw{ analysis_star_aln };
@@ -372,11 +372,13 @@ sub analysis_star_aln {
                     infile_lane_prefix_href => $infile_lane_prefix_href,
                     job_id_chain            => $job_id_chain,
                     job_id_href             => $job_id_href,
-                    log                     => $log,
-                    recipe_file_path        => $recipe_file_path,
-                    recipe_files_tracker    => $infile_index,
-                    sample_id               => $sample_id,
-                    submission_profile => $active_parameter_href->{submission_profile},
+                    job_reservation_name =>
+                      $active_parameter_href->{job_reservation_name},
+                    log                  => $log,
+                    recipe_file_path     => $recipe_file_path,
+                    recipe_files_tracker => $infile_index,
+                    sample_id            => $sample_id,
+                    submission_profile   => $active_parameter_href->{submission_profile},
                 }
             );
         }

--- a/lib/MIP/Recipes/Analysis/Star_fusion.pm
+++ b/lib/MIP/Recipes/Analysis/Star_fusion.pm
@@ -25,7 +25,7 @@ BEGIN {
     use base qw{ Exporter };
 
     # Set the version for version checking
-    our $VERSION = 1.14;
+    our $VERSION = 1.15;
 
     # Functions and variables which can be optionally exported
     our @EXPORT_OK = qw{ analysis_star_fusion };
@@ -280,6 +280,7 @@ sub analysis_star_fusion {
                 infile_lane_prefix_href => $infile_lane_prefix_href,
                 job_id_chain            => $recipe_attribute{chain},
                 job_id_href             => $job_id_href,
+                job_reservation_name    => $active_parameter_href->{job_reservation_name},
                 log                     => $log,
                 recipe_file_path        => $recipe_file_path,
                 sample_id               => $sample_id,

--- a/lib/MIP/Recipes/Analysis/Stringtie.pm
+++ b/lib/MIP/Recipes/Analysis/Stringtie.pm
@@ -25,7 +25,7 @@ BEGIN {
     use base qw{ Exporter };
 
     # Set the version for version checking
-    our $VERSION = 1.07;
+    our $VERSION = 1.08;
 
     # Functions and variables which can be optionally exported
     our @EXPORT_OK = qw{ analysis_stringtie };
@@ -284,6 +284,7 @@ sub analysis_stringtie {
                 infile_lane_prefix_href => $infile_lane_prefix_href,
                 job_id_chain            => $job_id_chain,
                 job_id_href             => $job_id_href,
+                job_reservation_name    => $active_parameter_href->{job_reservation_name},
                 log                     => $log,
                 recipe_file_path        => $recipe_file_path,
                 sample_id               => $sample_id,

--- a/lib/MIP/Recipes/Analysis/Sv_annotate.pm
+++ b/lib/MIP/Recipes/Analysis/Sv_annotate.pm
@@ -27,7 +27,7 @@ BEGIN {
     use base qw{ Exporter };
 
     # Set the version for version checking
-    our $VERSION = 1.16;
+    our $VERSION = 1.17;
 
     # Functions and variables which can be optionally exported
     our @EXPORT_OK = qw{ analysis_sv_annotate };
@@ -467,6 +467,7 @@ sub analysis_sv_annotate {
                 infile_lane_prefix_href => $infile_lane_prefix_href,
                 job_id_chain            => $job_id_chain,
                 job_id_href             => $job_id_href,
+                job_reservation_name    => $active_parameter_href->{job_reservation_name},
                 log                     => $log,
                 recipe_file_path        => $recipe_file_path,
                 sample_ids_ref          => \@{ $active_parameter_href->{sample_ids} },

--- a/lib/MIP/Recipes/Analysis/Sv_combinevariantcallsets.pm
+++ b/lib/MIP/Recipes/Analysis/Sv_combinevariantcallsets.pm
@@ -27,7 +27,7 @@ BEGIN {
     use base qw{ Exporter };
 
     # Set the version for version checking
-    our $VERSION = 1.14;
+    our $VERSION = 1.15;
 
     # Functions and variables which can be optionally exported
     our @EXPORT_OK = qw{ analysis_sv_combinevariantcallsets };
@@ -391,6 +391,7 @@ sub analysis_sv_combinevariantcallsets {
                 infile_lane_prefix_href => $infile_lane_prefix_href,
                 job_id_chain            => $job_id_chain,
                 job_id_href             => $job_id_href,
+                job_reservation_name    => $active_parameter_href->{job_reservation_name},
                 log                     => $log,
                 parallel_chains_ref     => \@parallel_chains,
                 recipe_file_path        => $recipe_file_path,

--- a/lib/MIP/Recipes/Analysis/Sv_reformat.pm
+++ b/lib/MIP/Recipes/Analysis/Sv_reformat.pm
@@ -25,7 +25,7 @@ BEGIN {
     use base qw{ Exporter };
 
     # Set the version for version checking
-    our $VERSION = 1.11;
+    our $VERSION = 1.12;
 
     # Functions and variables which can be optionally exported
     our @EXPORT_OK = qw{ analysis_reformat_sv };
@@ -389,6 +389,7 @@ sub analysis_reformat_sv {
                 infile_lane_prefix_href => $infile_lane_prefix_href,
                 job_id_chain            => $job_id_chain,
                 job_id_href             => $job_id_href,
+                job_reservation_name    => $active_parameter_href->{job_reservation_name},
                 log                     => $log,
                 recipe_file_path        => $recipe_file_path,
                 sample_ids_ref          => \@{ $active_parameter_href->{sample_ids} },

--- a/lib/MIP/Recipes/Analysis/Tiddit.pm
+++ b/lib/MIP/Recipes/Analysis/Tiddit.pm
@@ -24,7 +24,7 @@ BEGIN {
     use base qw{ Exporter };
 
     # Set the version for version checking
-    our $VERSION = 1.09;
+    our $VERSION = 1.10;
 
     # Functions and variables which can be optionally exported
     our @EXPORT_OK = qw{ analysis_tiddit };
@@ -339,6 +339,7 @@ sub analysis_tiddit {
                 infile_lane_prefix_href => $infile_lane_prefix_href,
                 job_id_chain            => $job_id_chain,
                 job_id_href             => $job_id_href,
+                job_reservation_name    => $active_parameter_href->{job_reservation_name},
                 log                     => $log,
                 recipe_file_path        => $recipe_file_path,
                 sample_ids_ref          => \@{ $active_parameter_href->{sample_ids} },

--- a/lib/MIP/Recipes/Analysis/Tiddit_coverage.pm
+++ b/lib/MIP/Recipes/Analysis/Tiddit_coverage.pm
@@ -26,7 +26,7 @@ BEGIN {
     use base qw{ Exporter };
 
     # Set the version for version checking
-    our $VERSION = 1.04;
+    our $VERSION = 1.05;
 
     # Functions and variables which can be optionally exported
     our @EXPORT_OK = qw{ analysis_tiddit_coverage };
@@ -255,6 +255,7 @@ sub analysis_tiddit_coverage {
                 infile_lane_prefix_href => $infile_lane_prefix_href,
                 job_id_chain            => $job_id_chain,
                 job_id_href             => $job_id_href,
+                job_reservation_name    => $active_parameter_href->{job_reservation_name},
                 log                     => $log,
                 recipe_file_path        => $recipe_file_path,
                 sample_id               => $sample_id,

--- a/lib/MIP/Recipes/Analysis/Trim_galore.pm
+++ b/lib/MIP/Recipes/Analysis/Trim_galore.pm
@@ -26,7 +26,7 @@ BEGIN {
     use base qw{ Exporter };
 
     # Set the version for version checking
-    our $VERSION = 1.04;
+    our $VERSION = 1.05;
 
     # Functions and variables which can be optionally exported
     our @EXPORT_OK = qw{ analysis_trim_galore };
@@ -327,6 +327,7 @@ sub analysis_trim_galore {
                 infile_lane_prefix_href => $infile_lane_prefix_href,
                 job_id_chain            => $job_id_chain,
                 job_id_href             => $job_id_href,
+                job_reservation_name    => $active_parameter_href->{job_reservation_name},
                 log                     => $log,
                 recipe_file_path        => $recipe_file_path,
                 sample_id               => $sample_id,

--- a/lib/MIP/Recipes/Analysis/Upd.pm
+++ b/lib/MIP/Recipes/Analysis/Upd.pm
@@ -26,7 +26,7 @@ BEGIN {
     use base qw{ Exporter };
 
     # Set the version for version checking
-    our $VERSION = 1.02;
+    our $VERSION = 1.03;
 
     # Functions and variables which can be optionally exported
     our @EXPORT_OK = qw{ analysis_upd };
@@ -277,6 +277,7 @@ sub analysis_upd {
                 infile_lane_prefix_href => $infile_lane_prefix_href,
                 job_id_chain            => $job_id_chain,
                 job_id_href             => $job_id_href,
+                job_reservation_name    => $active_parameter_href->{job_reservation_name},
                 log                     => $log,
                 recipe_file_path        => $recipe_file_path,
                 sample_id               => $sample_id,

--- a/lib/MIP/Recipes/Analysis/Varg.pm
+++ b/lib/MIP/Recipes/Analysis/Varg.pm
@@ -26,7 +26,7 @@ BEGIN {
     use base qw{ Exporter };
 
     # Set the version for version checking
-    our $VERSION = 1.00;
+    our $VERSION = 1.01;
 
     # Functions and variables which can be optionally exported
     our @EXPORT_OK = qw{ analysis_varg };
@@ -269,6 +269,7 @@ sub analysis_varg {
                 infile_lane_prefix_href => $infile_lane_prefix_href,
                 job_id_chain            => $job_id_chain,
                 job_id_href             => $job_id_href,
+                job_reservation_name    => $active_parameter_href->{job_reservation_name},
                 log                     => $log,
                 recipe_file_path        => $recipe_file_path,
                 sample_ids_ref          => \@{ $active_parameter_href->{sample_ids} },

--- a/lib/MIP/Recipes/Analysis/Variant_integrity.pm
+++ b/lib/MIP/Recipes/Analysis/Variant_integrity.pm
@@ -25,7 +25,7 @@ BEGIN {
     use base qw{ Exporter };
 
     # Set the version for version checking
-    our $VERSION = 1.13;
+    our $VERSION = 1.14;
 
     # Functions and variables which can be optionally exported
     our @EXPORT_OK = qw{ analysis_variant_integrity };
@@ -332,6 +332,7 @@ sub analysis_variant_integrity {
                 infile_lane_prefix_href => $infile_lane_prefix_href,
                 job_id_chain            => $job_id_chain,
                 job_id_href             => $job_id_href,
+                job_reservation_name    => $active_parameter_href->{job_reservation_name},
                 log                     => $log,
                 recipe_file_path        => $recipe_file_path,
                 sample_ids_ref          => \@{ $active_parameter_href->{sample_ids} },

--- a/lib/MIP/Recipes/Analysis/Vcf2cytosure.pm
+++ b/lib/MIP/Recipes/Analysis/Vcf2cytosure.pm
@@ -25,7 +25,7 @@ BEGIN {
     use base qw{ Exporter };
 
     # Set the version for version checking
-    our $VERSION = 1.13;
+    our $VERSION = 1.14;
 
     # Functions and variables which can be optionally exported
     our @EXPORT_OK = qw{ analysis_vcf2cytosure };
@@ -400,6 +400,7 @@ sub analysis_vcf2cytosure {
                 infile_lane_prefix_href => $infile_lane_prefix_href,
                 job_id_chain            => $job_id_chain,
                 job_id_href             => $job_id_href,
+                job_reservation_name    => $active_parameter_href->{job_reservation_name},
                 log                     => $log,
                 recipe_file_path        => $recipe_file_path,
                 sample_ids_ref          => \@{ $active_parameter_href->{sample_ids} },

--- a/lib/MIP/Recipes/Analysis/Vcf_rerun_reformat.pm
+++ b/lib/MIP/Recipes/Analysis/Vcf_rerun_reformat.pm
@@ -26,7 +26,7 @@ BEGIN {
     use base qw{ Exporter };
 
     # Set the version for version checking
-    our $VERSION = 1.05;
+    our $VERSION = 1.06;
 
     # Functions and variables which can be optionally exported
     our @EXPORT_OK = qw{ analysis_vcf_rerun_reformat_sv analysis_vcf_rerun_reformat };
@@ -257,6 +257,7 @@ sub analysis_vcf_rerun_reformat_sv {
                 infile_lane_prefix_href => $infile_lane_prefix_href,
                 job_id_chain            => $job_id_chain,
                 job_id_href             => $job_id_href,
+                job_reservation_name    => $active_parameter_href->{job_reservation_name},
                 log                     => $log,
                 recipe_file_path        => $recipe_file_path,
                 sample_ids_ref          => \@{ $active_parameter_href->{sample_ids} },
@@ -490,6 +491,7 @@ sub analysis_vcf_rerun_reformat {
                 infile_lane_prefix_href => $infile_lane_prefix_href,
                 job_id_chain            => $job_id_chain,
                 job_id_href             => $job_id_href,
+                job_reservation_name    => $active_parameter_href->{job_reservation_name},
                 log                     => $log,
                 recipe_file_path        => $recipe_file_path,
                 sample_ids_ref          => \@{ $active_parameter_href->{sample_ids} },

--- a/lib/MIP/Recipes/Analysis/Vep.pm
+++ b/lib/MIP/Recipes/Analysis/Vep.pm
@@ -29,7 +29,7 @@ BEGIN {
     use base qw{ Exporter };
 
     # Set the version for version checking
-    our $VERSION = 1.22;
+    our $VERSION = 1.23;
 
     # Functions and variables which can be optionally exported
     our @EXPORT_OK =
@@ -409,6 +409,7 @@ sub analysis_vep {
                 infile_lane_prefix_href => $infile_lane_prefix_href,
                 job_id_chain            => $job_id_chain,
                 job_id_href             => $job_id_href,
+                job_reservation_name    => $active_parameter_href->{job_reservation_name},
                 log                     => $log,
                 recipe_file_path        => $recipe_file_path,
                 sample_ids_ref          => \@{ $active_parameter_href->{sample_ids} },
@@ -748,6 +749,7 @@ sub analysis_vep_sv_wes {
                 infile_lane_prefix_href => $infile_lane_prefix_href,
                 job_id_chain            => $job_id_chain,
                 job_id_href             => $job_id_href,
+                job_reservation_name    => $active_parameter_href->{job_reservation_name},
                 log                     => $log,
                 recipe_file_path        => $recipe_file_path,
                 sample_ids_ref          => \@{ $active_parameter_href->{sample_ids} },
@@ -1158,6 +1160,7 @@ sub analysis_vep_sv_wgs {
                 infile_lane_prefix_href => $infile_lane_prefix_href,
                 job_id_chain            => $job_id_chain,
                 job_id_href             => $job_id_href,
+                job_reservation_name    => $active_parameter_href->{job_reservation_name},
                 log                     => $log,
                 recipe_file_path        => $recipe_file_path,
                 sample_ids_ref          => \@{ $active_parameter_href->{sample_ids} },
@@ -1424,6 +1427,7 @@ sub analysis_vep_rna {
                 infile_lane_prefix_href => $infile_lane_prefix_href,
                 job_id_chain            => $job_id_chain,
                 job_id_href             => $job_id_href,
+                job_reservation_name    => $active_parameter_href->{job_reservation_name},
                 log                     => $log,
                 recipe_file_path        => $recipe_file_path,
                 sample_ids_ref          => \@{ $active_parameter_href->{sample_ids} },

--- a/lib/MIP/Recipes/Analysis/Vt.pm
+++ b/lib/MIP/Recipes/Analysis/Vt.pm
@@ -27,7 +27,7 @@ BEGIN {
     use base qw{ Exporter };
 
     # Set the version for version checking
-    our $VERSION = 1.07;
+    our $VERSION = 1.08;
 
     # Functions and variables which can be optionally exported
     our @EXPORT_OK = qw{ analysis_vt };
@@ -347,6 +347,7 @@ q{## vt - Decompose (split multi allelic records into single records) and/or nor
                 infile_lane_prefix_href => $infile_lane_prefix_href,
                 job_id_chain            => $job_id_chain,
                 job_id_href             => $job_id_href,
+                job_reservation_name    => $active_parameter_href->{job_reservation_name},
                 log                     => $log,
                 recipe_file_path        => $recipe_file_path,
                 sample_ids_ref          => \@{ $active_parameter_href->{sample_ids} },

--- a/lib/MIP/Recipes/Analysis/Vt_core.pm
+++ b/lib/MIP/Recipes/Analysis/Vt_core.pm
@@ -24,7 +24,7 @@ BEGIN {
     use base qw{ Exporter };
 
     # Set the version for version checking
-    our $VERSION = 1.06;
+    our $VERSION = 1.07;
 
     # Functions and variables which can be optionally exported
     our @EXPORT_OK = qw{ analysis_vt_core analysis_vt_core_rio };
@@ -412,15 +412,16 @@ sub analysis_vt_core {
 
         submit_recipe(
             {
-                base_command       => $profile_base_command,
-                dependency_method  => q{island_to_samples},
-                case_id            => $case_id,
-                job_id_href        => $job_id_href,
-                log                => $log,
-                job_id_chain       => q{MAIN},
-                recipe_file_path   => $recipe_file_path,
-                sample_ids_ref     => \@{ $active_parameter_href->{sample_ids} },
-                submission_profile => $active_parameter_href->{submission_profile},
+                base_command         => $profile_base_command,
+                dependency_method    => q{island_to_samples},
+                case_id              => $case_id,
+                job_id_href          => $job_id_href,
+                job_reservation_name => $active_parameter_href->{job_reservation_name},
+                log                  => $log,
+                job_id_chain         => q{MAIN},
+                recipe_file_path     => $recipe_file_path,
+                sample_ids_ref       => \@{ $active_parameter_href->{sample_ids} },
+                submission_profile   => $active_parameter_href->{submission_profile},
             }
         );
     }

--- a/t/slurm_sbatch.t
+++ b/t/slurm_sbatch.t
@@ -1,138 +1,119 @@
 #!/usr/bin/env perl
 
-#### Copyright 2017 Henrik Stranneheim
-
-use Modern::Perl qw{ 2018 };
-use warnings qw(FATAL utf8);
-use autodie;
-use 5.026;    #Require at least perl 5.18
-use utf8;
-use open qw( :encoding(UTF-8) :std );
-use charnames qw( :full :short );
+use 5.026;
 use Carp;
-use English qw(-no_match_vars);
-use Params::Check qw(check allow last_error);
-
-use FindBin qw($Bin);    #Find directory of script
-use File::Basename qw(dirname basename);
-use File::Spec::Functions qw(catdir);
-use Getopt::Long;
+use charnames qw{ :full :short };
+use English qw{ -no_match_vars };
+use File::Basename qw{ dirname };
+use File::Spec::Functions qw{ catdir };
+use FindBin qw{ $Bin };
+use open qw{ :encoding(UTF-8) :std };
+use Params::Check qw{ allow check last_error };
 use Test::More;
+use utf8;
+use warnings qw{ FATAL utf8 };
+
+## CPANM
+use autodie qw{ :all };
+use Modern::Perl qw{ 2018 };
+use Readonly;
 
 ## MIPs lib/
-use lib catdir( dirname($Bin), 'lib' );
-use MIP::Script::Utils qw(help);
-
-our $USAGE = build_usage( {} );
+use lib catdir( dirname($Bin), q{lib} );
+use MIP::Constants qw{ $COMMA $SPACE };
+use MIP::Test::Commands qw{ test_function };
+use MIP::Test::Fixtures qw{ test_standard_cli };
 
 my $VERBOSE = 1;
-our $VERSION = '0.0.0';
+our $VERSION = 1.01;
 
-###User Options
-GetOptions(
-    'h|help' => sub {
-        done_testing();
-        print {*STDOUT} $USAGE, "\n";
-        exit;
-    },    #Display help text
-    'v|version' => sub {
-        done_testing();
-        print {*STDOUT} "\n" . basename($PROGRAM_NAME) . q{  } . $VERSION, "\n\n";
-        exit;
-    },    #Display version number
-    'vb|verbose' => $VERBOSE,
-  )
-  or (
-    done_testing(),
-    help(
-        {
-            USAGE     => $USAGE,
-            exit_code => 1,
-        }
-    )
-  );
+$VERBOSE = test_standard_cli(
+    {
+        verbose => $VERBOSE,
+        version => $VERSION,
+    }
+);
 
 BEGIN {
 
+    use MIP::Test::Fixtures qw{ test_import };
+
 ### Check all internal dependency modules and imports
-##Modules with import
-    my %perl_module;
+## Modules with import
+    my %perl_module = (
+        q{MIP::Workloadmanager::Slurm} => [qw{ slurm_sbatch }],
+        q{MIP::Test::Fixtures}         => [qw{ test_standard_cli }],
+    );
 
-    $perl_module{'MIP::Script::Utils'} = [qw(help)];
-
-    while ( my ( $module, $module_import ) = each %perl_module ) {
-
-        use_ok( $module, @{$module_import} )
-          or BAIL_OUT 'Cannot load ' . $module;
-    }
-
-##Modules
-    my @modules = ('MIP::Workloadmanager::Slurm');
-
-    for my $module (@modules) {
-
-        require_ok($module) or BAIL_OUT 'Cannot load ' . $module;
-    }
+    test_import( { perl_module_href => \%perl_module, } );
 }
 
-use MIP::Workloadmanager::Slurm qw(slurm_sbatch);
-use MIP::Test::Commands qw(test_function);
+use MIP::Workloadmanager::Slurm qw{ slurm_sbatch };
 
-diag(
-    "Test slurm_sbatch $MIP::Workloadmanager::Slurm::VERSION, Perl $^V, $EXECUTABLE_NAME"
-);
+diag(   q{Test slurm_sbatch from SLURM.pm v}
+      . $MIP::Workloadmanager::Slurm::VERSION
+      . $COMMA
+      . $SPACE . q{Perl}
+      . $SPACE
+      . $PERL_VERSION
+      . $SPACE
+      . $EXECUTABLE_NAME );
 
 ## Base arguments
-my @function_base_commands = 'sbatch';
+my @function_base_commands = qw{ sbatch };
 
 my %base_argument = (
-    stdoutfile_path => {
-        input           => 'outfile.test',
-        expected_output => '1> outfile.test',
-    },
-    stderrfile_path => {
-        input           => 'stderrfile.test',
-        expected_output => '2> stderrfile.test',
-    },
-    stderrfile_path_append => {
-        input           => 'stderrfile.test',
-        expected_output => '2>> stderrfile.test',
-    },
     filehandle => {
         input           => undef,
         expected_output => \@function_base_commands,
+    },
+    stderrfile_path => {
+        input           => q{stderrfile.test},
+        expected_output => q{2> stderrfile.test},
+    },
+    stderrfile_path_append => {
+        input           => q{stderrfile.test},
+        expected_output => q{2>> stderrfile.test},
+    },
+    stdoutfile_path => {
+        input           => q{outfile.test},
+        expected_output => q{1> outfile.test},
     },
 );
 
 ## Can be duplicated with %base and/or %specific to enable testing of each individual argument
 my %required_argument = (
-    infile_path => {
-        input           => 'infile.test',
-        expected_output => 'infile.test',
-    },
     dependency_type => {
-        input           => 'afterok',
-        expected_output => '--dependency=afterok',
+        input           => q{afterok},
+        expected_output => q{--dependency=afterok},
+    },
+    infile_path => {
+        input           => q{infile.test},
+        expected_output => q{infile.test},
     },
     job_ids_string => {
-        input           => ':123:124',
-        expected_output => ':123:124',
+        input           => q{:123:124},
+        expected_output => q{:123:124},
     },
 );
 
 ## Specific arguments
 my %specific_argument = (
-    infile_path => {
-        input           => 'infile.test',
-        expected_output => 'infile.test',
-    },
     dependency_type => {
-        input           => 'afterok',
-        expected_output => '--dependency=afterok:123:124',
+        input           => q{afterok},
+        expected_output => q{--dependency=afterok:123:124},
+    },
+    infile_path => {
+        input           => q{infile.test},
+        expected_output => q{infile.test},
     },
     job_ids_string => {
-        input           => ':123:124',
-        expected_output => '--dependency=afterok:123:124',
+        input           => q{:123:124},
+        expected_output => q{--dependency=afterok:123:124},
+    },
+    reservation_name => {
+        input           => q{development},
+        expected_output => q{--reservation=development},
     },
 );
 
@@ -142,52 +123,17 @@ my $module_function_cref = \&slurm_sbatch;
 ## Test both base and function specific arguments
 my @arguments = ( \%base_argument, \%specific_argument );
 
+ARGUMENT_HASH_REF:
 foreach my $argument_href (@arguments) {
 
     my @commands = test_function(
         {
             argument_href              => $argument_href,
-            required_argument_href     => \%required_argument,
-            module_function_cref       => $module_function_cref,
             function_base_commands_ref => \@function_base_commands,
+            module_function_cref       => $module_function_cref,
+            required_argument_href     => \%required_argument,
         }
     );
 }
 
 done_testing();
-
-######################
-####SubRoutines#######
-######################
-
-sub build_usage {
-
-##build_usage
-
-##Function : Build the USAGE instructions
-##Returns  : ""
-##Arguments: $program_name
-##         : $program_name => Name of the script
-
-    my ($arg_href) = @_;
-
-    ## Default(s)
-    my $program_name;
-
-    my $tmpl = {
-        program_name => {
-            default     => basename($PROGRAM_NAME),
-            strict_type => 1,
-            store       => \$program_name,
-        },
-    };
-
-    check( $tmpl, $arg_href, 1 ) or croak qw(Could not parse arguments!);
-
-    return <<"END_USAGE";
- $program_name [options]
-    -vb/--verbose Verbose
-    -h/--help Display this help message
-    -v/--version Display version
-END_USAGE
-}

--- a/templates/code/recipe_analysis_case.pm
+++ b/templates/code/recipe_analysis_case.pm
@@ -241,6 +241,7 @@ sub analysis_RECIPE_NAME {
                 infile_lane_prefix_href => $infile_lane_prefix_href,
                 job_id_chain            => $job_id_chain,
                 job_id_href             => $job_id_href,
+                job_reservation_name    => $active_parameter_href->{job_reservation_name},
                 log                     => $log,
                 recipe_file_path        => $recipe_file_path,
                 sample_ids_ref          => \@{ $active_parameter_href->{sample_ids} },

--- a/templates/code/recipe_analysis_sample.pm
+++ b/templates/code/recipe_analysis_sample.pm
@@ -263,6 +263,7 @@ sub analysis_RECIPE_NAME {
                 infile_lane_prefix_href => $infile_lane_prefix_href,
                 job_id_chain            => $job_id_chain,
                 job_id_href             => $job_id_href,
+                job_reservation_name    => $active_parameter_href->{job_reservation_name},
                 log                     => $log,
                 recipe_file_path        => $recipe_file_path,
                 sample_id               => $sample_id,


### PR DESCRIPTION
- Use this in all analysis recipes
- Add "job_reservation_name: [reservation_name]" to MIP config or on cmd to
  enable use of cluster specific reserved node allocations. Hasta
"job_reservation_name: development"

### This PR fixes:

- See above

### How to test:

- Automatic and continuous test pass

### Expected outcome:
- Installation, unit and integration tests pass

### Review:
- [ ] Code review
- [ ] New code is executed and covered by tests
- [ ] Tests pass
