### PR TITLE
Feature/mip docker base

### DIFF
--- a/containers/Dockerfile
+++ b/containers/Dockerfile
@@ -1,0 +1,66 @@
+# Base image
+FROM ubuntu:16.04
+
+################## METADATA ######################
+
+LABEL base_image="ubuntu:16.04"
+LABEL version="1"
+LABEL software="mip"
+LABEL software.version="7.1.4"
+LABEL about.summary="Base image for MIP"
+LABEL about.home="https://github.com/Clinical-Genomics/MIP"
+LABEL about.documentation="https://clinical-genomics.gitbook.io/project-mip/"
+LABEL about.license_file="https://github.com/Clinical-Genomics/MIP/blob/master/LICENSE"
+LABEL about.license="MIT License (MIT)"
+LABEL about.tags="Clinical,variants,analysis,pipeline"
+
+################## MAINTAINER ######################
+MAINTAINER Henrik Stranneheim <henrik.stranneheim@scilifelab.se>
+
+ENV DEBIAN_FRONTEND noninteractive
+
+RUN mv /etc/apt/sources.list /etc/apt/sources.list.bkp && \
+    bash -c 'echo -e "deb mirror://mirrors.ubuntu.com/mirrors.txt xenial main restricted universe multiverse\n\
+deb mirror://mirrors.ubuntu.com/mirrors.txt xenial-updates main restricted universe multiverse\n\
+deb mirror://mirrors.ubuntu.com/mirrors.txt xenial-backports main restricted universe multiverse\n\
+deb mirror://mirrors.ubuntu.com/mirrors.txt xenial-security main restricted universe multiverse\n\n" > /etc/apt/sources.list' && \
+    cat /etc/apt/sources.list.bkp >> /etc/apt/sources.list && \
+    cat /etc/apt/sources.list
+
+RUN apt-get clean all && \
+    apt-get update && \
+    apt-get upgrade -y && \
+    apt-get install -y  \
+        curl            \
+        grep            \
+        sed             \
+        dpkg            \
+        fuse            \
+        git             \
+        wget            \
+        zip             \
+        build-essential \
+        pkg-config      \
+        bzip2           \
+        ca-certificates && \
+        apt-get clean && \
+        apt-get purge && \
+        rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
+
+# Install conda and give write permissions to conda folder
+RUN echo 'export PATH=/opt/conda/bin:$PATH' > /etc/profile.d/conda.sh && \
+    wget --quiet https://repo.continuum.io/miniconda/Miniconda3-4.7.10-Linux-x86_64.sh -O ~/miniconda.sh && \
+    /bin/bash ~/miniconda.sh -b -p /opt/conda && \
+    rm ~/miniconda.sh
+
+RUN mkdir /data /config
+
+ENV PATH=$PATH:/opt/conda/bin
+
+RUN conda config --add channels defaults
+RUN conda config --add channels conda-forge
+RUN conda config --add channels bioconda
+
+VOLUME ["/data", "/config"]
+
+WORKDIR /data

--- a/containers/Dockerfile
+++ b/containers/Dockerfile
@@ -7,7 +7,7 @@ LABEL base_image="ubuntu:16.04"
 LABEL version="1"
 LABEL software="mip"
 LABEL software.version="7.1.4"
-LABEL about.summary="Base image for MIP"
+LABEL about.summary="Base image for MIP's dependency tools"
 LABEL about.home="https://github.com/Clinical-Genomics/MIP"
 LABEL about.documentation="https://clinical-genomics.gitbook.io/project-mip/"
 LABEL about.license_file="https://github.com/Clinical-Genomics/MIP/blob/master/LICENSE"
@@ -16,6 +16,7 @@ LABEL about.tags="Clinical,variants,analysis,pipeline"
 
 ################## MAINTAINER ######################
 MAINTAINER Henrik Stranneheim <henrik.stranneheim@scilifelab.se>
+MAINTAINER Anders Jemt <anders.jemt@scilifelab.se>
 
 ENV DEBIAN_FRONTEND noninteractive
 

--- a/containers/Dockerfile
+++ b/containers/Dockerfile
@@ -59,8 +59,8 @@ RUN mkdir /data /config
 ENV PATH=$PATH:/opt/conda/bin
 
 RUN conda config --add channels defaults
-RUN conda config --add channels conda-forge
 RUN conda config --add channels bioconda
+RUN conda config --add channels conda-forge
 
 VOLUME ["/data", "/config"]
 

--- a/containers/bedtools/Dockerfile
+++ b/containers/bedtools/Dockerfile
@@ -1,0 +1,8 @@
+################## BASE IMAGE ######################
+
+FROM clinicalgenomics/mip:latest
+
+RUN conda install bedtools=2.29.0
+
+WORKDIR /data/
+

--- a/containers/bedtools/Dockerfile
+++ b/containers/bedtools/Dockerfile
@@ -2,6 +2,17 @@
 
 FROM clinicalgenomics/mip:latest
 
+################## METADATA ######################
+
+LABEL base_image="clinicalgenomics/mip:latest"
+LABEL version="1"
+LABEL software="bedtools"
+LABEL software.version="2.29.0"
+LABEL extra.binaries="bedtools"
+
+################## MAINTAINER ######################
+MAINTAINER Clinical-Genomics/MIP
+
 RUN conda install bedtools=2.29.0
 
 WORKDIR /data/


### PR DESCRIPTION
### This PR fixes:

- Adds a MIP docker base image and bedtools docker imagine using mip base image

### How to test:

- Automatic and continuous test pass
- Tested building bedtools docker via singularity on hasta and it works

### Expected outcome:
- Installation, unit and integration tests pass

### Review:
- [ ] Code review
- [ ] New code is executed and covered by tests
- [ ] Tests pass
