### PR TITLE
bug(vcfparser_count): Use the snv/indel counter instead of sv counter in

### DIFF
--- a/lib/MIP/Recipes/Analysis/Endvariantannotationblock.pm
+++ b/lib/MIP/Recipes/Analysis/Endvariantannotationblock.pm
@@ -25,7 +25,7 @@ BEGIN {
     use base qw{ Exporter };
 
     # Set the version for version checking
-    our $VERSION = 1.08;
+    our $VERSION = 1.09;
 
     # Functions and variables which can be optionally exported
     our @EXPORT_OK = qw{ analysis_endvariantannotationblock };
@@ -199,8 +199,7 @@ sub analysis_endvariantannotationblock {
 
     my @vcfparser_analysis_types = get_vcf_parser_analysis_suffix(
         {
-            vcfparser_outfile_count =>
-              $active_parameter_href->{sv_vcfparser_outfile_count},
+            vcfparser_outfile_count => $active_parameter_href->{vcfparser_outfile_count},
         }
     );
 


### PR DESCRIPTION
recipe. Otherwise we will lose the select vcf

### This PR fixes:

- See above

### How to test:

- Automatic and continuous test pass

### Expected outcome:
- Installation, unit and integration tests pass

### Review:
- [ ] Code review
- [ ] New code is executed and covered by tests
- [ ] Tests pass
