### PR TITLE
hotfix(vcfparser_counter): Use the snv/indel counter instead of sv

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 All notable changes to this project will be documented in this file.
 This project adheres to [Semantic Versioning](http://semver.org/).
 
+## [7.1.11]
+- Fixed bug that will casue select vcf files for snv/indel to not be produced if you turn off all SV programs
+ 
 ## [7.1.10]
 - Added BAM contigs set to allow for single ladies to get a proper check sex (no pun intended:). Actually it is for all female only analyses.
 

--- a/lib/MIP/Constants.pm
+++ b/lib/MIP/Constants.pm
@@ -20,7 +20,7 @@ BEGIN {
     use base qw{ Exporter };
 
     # Set the version for version checking
-    our $VERSION = 1.06;
+    our $VERSION = 1.07;
 
     # Functions and variables which can be optionally exported
 
@@ -60,7 +60,7 @@ BEGIN {
 ## Constants
 ## Set MIP version
 ## Constants
-Readonly our $MIP_VERSION => q{v7.1.10};
+Readonly our $MIP_VERSION => q{v7.1.11};
 
 ## Cli
 Readonly our $MOOSEX_APP_SCEEN_WIDTH => 160;

--- a/lib/MIP/Recipes/Analysis/Endvariantannotationblock.pm
+++ b/lib/MIP/Recipes/Analysis/Endvariantannotationblock.pm
@@ -25,7 +25,7 @@ BEGIN {
     use base qw{ Exporter };
 
     # Set the version for version checking
-    our $VERSION = 1.05;
+    our $VERSION = 1.06;
 
     # Functions and variables which can be optionally exported
     our @EXPORT_OK = qw{ analysis_endvariantannotationblock };
@@ -199,8 +199,7 @@ sub analysis_endvariantannotationblock {
 
     my @vcfparser_analysis_types = get_vcf_parser_analysis_suffix(
         {
-            vcfparser_outfile_count =>
-              $active_parameter_href->{sv_vcfparser_outfile_count},
+            vcfparser_outfile_count => $active_parameter_href->{vcfparser_outfile_count},
         }
     );
 


### PR DESCRIPTION
counter in recipe. Otherwise we will lose the select vcf when turning
off all sv modules

### This PR fixes:

- See above

### How to test:

- Automatic and continuous test pass

### Expected outcome:
- Installation, unit and integration tests pass

### Review:
- [x] Code review
- [x] New code is executed and covered by tests
- [x] Tests pass
