### PR TITLE
bug(expansionhunter): switches vt svdb order

### DIFF
--- a/definitions/rd_rna_parameters.yaml
+++ b/definitions/rd_rna_parameters.yaml
@@ -328,7 +328,7 @@ chim_out_type:
   associated_recipe:
     - star_aln
   data_type: SCALAR
-  default: WithinBAM SoftClip
+  default: WithinBAM
   type: recipe_argument
 pe_overlap_nbases_min:
   associated_recipe:

--- a/definitions/rd_rna_parameters.yaml
+++ b/definitions/rd_rna_parameters.yaml
@@ -328,7 +328,7 @@ chim_out_type:
   associated_recipe:
     - star_aln
   data_type: SCALAR
-  default: WithinBAM
+  default: WithinBAM SoftClip
   type: recipe_argument
 pe_overlap_nbases_min:
   associated_recipe:

--- a/lib/MIP/Recipes/Analysis/Expansionhunter.pm
+++ b/lib/MIP/Recipes/Analysis/Expansionhunter.pm
@@ -15,6 +15,7 @@ use warnings qw{ FATAL utf8 };
 
 ## CPANM
 use autodie qw{ :all };
+use List::MoreUtils qw{ each_array };
 use MIP::Constants qw{ $AMPERSAND $ASTERISK $DOT $LOG_NAME $NEWLINE $UNDERSCORE };
 use Readonly;
 
@@ -24,7 +25,7 @@ BEGIN {
     use base qw{ Exporter };
 
     # Set the version for version checking
-    our $VERSION = 1.20;
+    our $VERSION = 1.21;
 
     # Functions and variables which can be optionally exported
     our @EXPORT_OK = qw{ analysis_expansionhunter };
@@ -275,7 +276,8 @@ sub analysis_expansionhunter {
 
     ## Expansion hunter calling per sample id
     # Expansionhunter sample infiles needs to be lexiographically sorted for svdb merge
-    my @svdb_infile_paths;
+    my @vt_infile_paths;
+    my @vt_outfile_paths;
 
   SAMPLE_ID:
     while ( my ( $sample_id_index, $sample_id ) =
@@ -320,36 +322,46 @@ sub analysis_expansionhunter {
             }
         );
         say {$filehandle} $AMPERSAND, $NEWLINE;
-        push @svdb_infile_paths, $sample_outfile_path_prefix . $outfile_suffix,;
+        push @vt_infile_paths, $sample_outfile_path_prefix . $outfile_suffix;
+        push @vt_outfile_paths,
+            $outfile_path_prefix
+          . $UNDERSCORE . q{vt}
+          . $UNDERSCORE
+          . $sample_id
+          . $outfile_suffix;
 
     }
     say {$filehandle} q{wait}, $NEWLINE;
 
+    ## Split multiallelic variants
+    say {$filehandle} q{## Split multiallelic variants};
+    my $vt_file_paths = each_array( @vt_infile_paths, @vt_outfile_paths );
+
+  VT_SAMPLE_FILES:
+    while ( my ( $vt_infile_path, $vt_outfile_path ) = $vt_file_paths->() ) {
+
+        vt_decompose(
+            {
+                filehandle          => $filehandle,
+                infile_path         => $vt_infile_path,
+                outfile_path        => $vt_outfile_path,
+                smart_decomposition => 1,
+            }
+        );
+        say {$filehandle} $NEWLINE;
+    }
+
     ## Get parameters
     ## Expansionhunter sample infiles needs to be lexiographically sorted for svdb merge
     my $svdb_outfile_path =
-      $outfile_path_prefix . $UNDERSCORE . q{svdbmerge} . $outfile_suffix;
+      $outfile_path_prefix . $UNDERSCORE . q{vt_svdbmerge} . $outfile_suffix;
 
     svdb_merge(
         {
             filehandle       => $filehandle,
-            infile_paths_ref => \@svdb_infile_paths,
+            infile_paths_ref => \@vt_outfile_paths,
             notag            => 1,
             stdoutfile_path  => $svdb_outfile_path,
-        }
-    );
-    say {$filehandle} $NEWLINE;
-
-    ## Split multiallelic variants
-    say {$filehandle} q{## Split multiallelic variants};
-    my $vt_outfile_path =
-      $outfile_path_prefix . $UNDERSCORE . q{svdbmerg_vt} . $outfile_suffix;
-    vt_decompose(
-        {
-            filehandle          => $filehandle,
-            infile_path         => $svdb_outfile_path,
-            outfile_path        => $vt_outfile_path,
-            smart_decomposition => 1,
         }
     );
     say {$filehandle} $NEWLINE;
@@ -357,11 +369,11 @@ sub analysis_expansionhunter {
     say {$filehandle} q{## Stranger annotation};
 
     my $stranger_outfile_path =
-      $outfile_path_prefix . $UNDERSCORE . q{svdbmerg_vt_ann} . $outfile_suffix;
+      $outfile_path_prefix . $UNDERSCORE . q{vt_svdbmerge_ann} . $outfile_suffix;
     stranger(
         {
             filehandle      => $filehandle,
-            infile_path     => $vt_outfile_path,
+            infile_path     => $svdb_outfile_path,
             stdoutfile_path => $stranger_outfile_path,
         }
     );

--- a/lib/MIP/Recipes/Analysis/Expansionhunter.pm
+++ b/lib/MIP/Recipes/Analysis/Expansionhunter.pm
@@ -335,10 +335,11 @@ sub analysis_expansionhunter {
 
     ## Split multiallelic variants
     say {$filehandle} q{## Split multiallelic variants};
-    my $vt_file_paths = each_array( @vt_infile_paths, @vt_outfile_paths );
+    ## Create iterator object
+    my $vt_file_paths_iter = each_array( @vt_infile_paths, @vt_outfile_paths );
 
-  VT_SAMPLE_FILES:
-    while ( my ( $vt_infile_path, $vt_outfile_path ) = $vt_file_paths->() ) {
+  VT_FILES_ITER:
+    while ( my ( $vt_infile_path, $vt_outfile_path ) = $vt_file_paths_iter->() ) {
 
         vt_decompose(
             {


### PR DESCRIPTION
### This PR fixes:
- fixes representation of multiallelic str calls
- resolves #1169 

### How to test:

- Automatic and continuous test pass

### Expected outcome:
- Installation, unit and integration tests pass

### Review:
- [x] Code review
- [x] New code is executed and covered by tests
- [x] Tests pass
