### PR TITLE
feat(rtg_docker): Use official rtg docker image uri in mip install

### DIFF
--- a/templates/mip_install_rd_dna_config_-1.0-.yaml
+++ b/templates/mip_install_rd_dna_config_-1.0-.yaml
@@ -106,7 +106,7 @@ singularity:
   rtg-tools:
     executable:
       rtg:
-    uri: shub://Clinical-Genomics/MIP:rtg-tools-3.10.1
+    uri: docker://realtimegenomics/rtg-tools:3.10.1
   sambamba:
     executable:
       sambamba:


### PR DESCRIPTION
### This PR fixes:

- Use docker for rtg-tools

### How to test:

- Automatic and continuous test pass

### Expected outcome:
- Installation, unit and integration tests pass

### Review:
- [ ] Code review
- [ ] New code is executed and covered by tests
- [ ] Tests pass
