### PR TITLE
feat(get_order_of_parameters): Added new sub to get order of parameters

### DIFF
--- a/lib/MIP/Cli/Mip/Analyse/Dragen_rd_dna.pm
+++ b/lib/MIP/Cli/Mip/Analyse/Dragen_rd_dna.pm
@@ -20,7 +20,7 @@ use Moose::Util::TypeConstraints;
 ## MIPs lib
 use MIP::Main::Analyse qw{ mip_analyse };
 
-our $VERSION = 1.08;
+our $VERSION = 1.09;
 
 extends(qw{ MIP::Cli::Mip::Analyse });
 
@@ -42,15 +42,14 @@ sub run {
     ## Input from Cli
     my %active_parameter = %{$arg_href};
 
-
-    use MIP::Definition
-      qw{ get_dependency_tree_from_definition_file
+    use MIP::Definition qw{ get_dependency_tree_from_definition_file
       get_first_level_keys_order_from_definition_file
       get_parameter_definition_file_paths
       get_parameter_from_definition_files };
     use MIP::File::Format::Yaml qw{ load_yaml };
     use MIP::Get::Analysis
       qw{ get_dependency_tree_chain get_dependency_tree_order print_recipe };
+    use MIP::Parameter qw{ get_order_of_parameters };
 
     ## %parameter holds all defined parameters for MIP analyse dragen_rd_dna
     ## CLI commands inheritance
@@ -60,13 +59,18 @@ sub run {
     my @dragen_rd_dna_definition_file_paths =
       get_parameter_definition_file_paths( { level => $level, } );
 
+    ### To write parameters and their values to log in logical order
+    ## Adds the order of first level keys from definition files to array
+    my @order_parameters = get_order_of_parameters(
+        { define_parameters_files_ref => \@dragen_rd_dna_definition_file_paths, } );
+
     ## Print recipes if requested and exit
     print_recipe(
         {
-            define_parameters_files_ref => \@dragen_rd_dna_definition_file_paths,
-            parameter_href              => \%parameter,
-            print_recipe                => $active_parameter{print_recipe},
-            print_recipe_mode           => $active_parameter{print_recipe_mode},
+            order_parameters_ref => \@order_parameters,
+            parameter_href       => \%parameter,
+            print_recipe         => $active_parameter{print_recipe},
+            print_recipe_mode    => $active_parameter{print_recipe_mode},
         }
     );
 
@@ -89,21 +93,6 @@ sub run {
             recipes_ref          => \@{ $parameter{cache}{order_recipes_ref} },
         }
     );
-
-    ### To write parameters and their values to log in logical order
-    ### Actual order of parameters in definition parameters file(s) does not matter
-    ## Adds the order of first level keys from definition files to array
-    my @order_parameters;
-  DEFINITION_FILE:
-    foreach my $define_parameters_file (@dragen_rd_dna_definition_file_paths) {
-
-        push @order_parameters,
-          get_first_level_keys_order_from_definition_file(
-            {
-                file_path => $define_parameters_file,
-            }
-          );
-    }
 
     ## File info hash
     my %file_info = (

--- a/lib/MIP/Cli/Mip/Analyse/Rd_dna.pm
+++ b/lib/MIP/Cli/Mip/Analyse/Rd_dna.pm
@@ -20,7 +20,7 @@ use Moose::Util::TypeConstraints;
 ## MIPs lib
 use MIP::Main::Analyse qw{ mip_analyse };
 
-our $VERSION = 1.38;
+our $VERSION = 1.39;
 
 extends(qw{ MIP::Cli::Mip::Analyse });
 
@@ -42,14 +42,14 @@ sub run {
     ## Input from Cli
     my %active_parameter = %{$arg_href};
 
-    use MIP::Definition
-      qw{ get_dependency_tree_from_definition_file
+    use MIP::Definition qw{ get_dependency_tree_from_definition_file
       get_first_level_keys_order_from_definition_file
       get_parameter_definition_file_paths
       get_parameter_from_definition_files };
     use MIP::File::Format::Yaml qw{ load_yaml };
     use MIP::Get::Analysis
       qw{ get_dependency_tree_chain get_dependency_tree_order print_recipe };
+    use MIP::Parameter qw{ get_order_of_parameters };
 
     ## %parameter holds all defined parameters for MIP analyse rd_dna
     ## CLI commands inheritance level
@@ -60,13 +60,18 @@ sub run {
     my @rd_dna_definition_file_paths =
       get_parameter_definition_file_paths( { level => $level, } );
 
+    ### To write parameters and their values to log in logical order
+    ## Adds the order of first level keys from definition files to array
+    my @order_parameters = get_order_of_parameters(
+        { define_parameters_files_ref => \@rd_dna_definition_file_paths, } );
+
     ## Print recipes if requested and exit
     print_recipe(
         {
-            define_parameters_files_ref => \@rd_dna_definition_file_paths,
-            parameter_href              => \%parameter,
-            print_recipe                => $active_parameter{print_recipe},
-            print_recipe_mode           => $active_parameter{print_recipe_mode},
+            order_parameters_ref => \@order_parameters,
+            parameter_href       => \%parameter,
+            print_recipe         => $active_parameter{print_recipe},
+            print_recipe_mode    => $active_parameter{print_recipe_mode},
         }
     );
 
@@ -89,22 +94,6 @@ sub run {
             recipes_ref          => \@{ $parameter{cache}{order_recipes_ref} },
         }
     );
-
-    ### To write parameters and their values to log in logical order
-    ### Actual order of parameters in definition parameters file(s) does not matter
-    ## Adds the order of first level keys from definition files to array
-    my @order_parameters;
-
-  DEFINITION_FILE:
-    foreach my $define_parameters_file (@rd_dna_definition_file_paths) {
-
-        push @order_parameters,
-          get_first_level_keys_order_from_definition_file(
-            {
-                file_path => $define_parameters_file,
-            }
-          );
-    }
 
     ## File info hash
     my %file_info = (

--- a/lib/MIP/Cli/Mip/Analyse/Rd_rna.pm
+++ b/lib/MIP/Cli/Mip/Analyse/Rd_rna.pm
@@ -19,7 +19,7 @@ use Moose::Util::TypeConstraints;
 ## MIPs lib
 use MIP::Main::Analyse qw{ mip_analyse };
 
-our $VERSION = 1.24;
+our $VERSION = 1.26;
 
 extends(qw{ MIP::Cli::Mip::Analyse });
 
@@ -41,14 +41,14 @@ sub run {
     ## Input from Cli
     my %active_parameter = %{$arg_href};
 
-    use MIP::Definition
-      qw{ get_dependency_tree_from_definition_file
+    use MIP::Definition qw{ get_dependency_tree_from_definition_file
       get_first_level_keys_order_from_definition_file
       get_parameter_definition_file_paths
       get_parameter_from_definition_files };
     use MIP::File::Format::Yaml qw{ load_yaml };
     use MIP::Get::Analysis
       qw{ get_dependency_tree_chain get_dependency_tree_order print_recipe };
+    use MIP::Parameter qw{ get_order_of_parameters };
 
     ## %parameter holds all defined parameters for MIP analyse rd_rna
     ## CLI commands inheritance
@@ -58,13 +58,18 @@ sub run {
     my @rd_rna_definition_file_paths =
       get_parameter_definition_file_paths( { level => $level, } );
 
+    ### To write parameters and their values to log in logical order
+    ## Adds the order of first level keys from definition files to array
+    my @order_parameters = get_order_of_parameters(
+        { define_parameters_files_ref => \@rd_rna_definition_file_paths, } );
+
     ## Print recipes if requested and exit
     print_recipe(
         {
-            define_parameters_files_ref => \@rd_rna_definition_file_paths,
-            parameter_href              => \%parameter,
-            print_recipe                => $active_parameter{print_recipe},
-            print_recipe_mode           => $active_parameter{print_recipe_mode},
+            order_parameters_ref => \@order_parameters,
+            parameter_href       => \%parameter,
+            print_recipe         => $active_parameter{print_recipe},
+            print_recipe_mode    => $active_parameter{print_recipe_mode},
         }
     );
 
@@ -87,21 +92,6 @@ sub run {
             recipes_ref          => \@{ $parameter{cache}{order_recipes_ref} },
         }
     );
-
-### To write parameters and their values to log in logical order
-### Actual order of parameters in definition parameters file(s) does not matter
-## Adds the order of first level keys from definition files to array
-    my @order_parameters;
-  DEFINITION_FILE:
-    foreach my $define_parameters_file (@rd_rna_definition_file_paths) {
-
-        push @order_parameters,
-          get_first_level_keys_order_from_definition_file(
-            {
-                file_path => $define_parameters_file,
-            }
-          );
-    }
 
 ## File info hash
     my %file_info = (

--- a/lib/MIP/Get/Analysis.pm
+++ b/lib/MIP/Get/Analysis.pm
@@ -28,7 +28,7 @@ BEGIN {
     use base qw{ Exporter };
 
     # Set the version for version checking
-    our $VERSION = 1.13;
+    our $VERSION = 1.14;
 
     # Functions and variables which can be optionally exported
     our @EXPORT_OK = qw{
@@ -485,25 +485,27 @@ sub print_recipe {
 
 ## Function : Print all supported recipes in '-prm' mode if requested and then exit
 ## Returns  :
-## Arguments: $define_parameters_files_ref => MIPs define parameters file
-##          : $parameter_href              => Parameter hash {REF}
-##          : $print_recipe                => Print recipes switch
-##          : $print_recipe_mode           => Mode to run recipes in
+## Arguments: $order_parameters_ref => Order of addition to parameter array {REF}
+##          : $parameter_href       => Parameter hash {REF}
+##          : $print_recipe         => Print recipes switch
+##          : $print_recipe_mode    => Mode to run recipes in
 
     my ($arg_href) = @_;
 
     ## Flatten argument(s)
+    my $order_parameters_ref;
     my $parameter_href;
     my $print_recipe;
 
     ## Default(s)
-    my $define_parameters_files_ref;
     my $print_recipe_mode;
 
     my $tmpl = {
-        define_parameters_files_ref => {
+        order_parameters_ref => {
             default     => [],
-            store       => \$define_parameters_files_ref,
+            defined     => 1,
+            required    => 1,
+            store       => \$order_parameters_ref,
             strict_type => 1,
         },
         parameter_href => {
@@ -529,7 +531,6 @@ sub print_recipe {
 
     check( $tmpl, $arg_href, 1 ) or croak q{Could not parse arguments!};
 
-    use MIP::Definition qw{ get_first_level_keys_order_from_definition_file };
     use MIP::Set::Parameter qw{ set_cache };
 
     ## Do not print
@@ -542,20 +543,8 @@ sub print_recipe {
         }
     );
 
-    ## Adds the order of first level keys from yaml file to array
-    my @order_parameters;
-    foreach my $define_parameters_file ( @{$define_parameters_files_ref} ) {
-
-        push @order_parameters,
-          get_first_level_keys_order_from_definition_file(
-            {
-                file_path => $define_parameters_file,
-            }
-          );
-    }
-
   PARAMETER:
-    foreach my $parameter (@order_parameters) {
+    foreach my $parameter ( @{$order_parameters_ref} ) {
 
         ## Only process recipes
         if (

--- a/lib/MIP/Parameter.pm
+++ b/lib/MIP/Parameter.pm
@@ -24,10 +24,10 @@ BEGIN {
     use base qw{ Exporter };
 
     # Set the version for version checking
-    our $VERSION = 1.00;
+    our $VERSION = 1.01;
 
     # Functions and variables which can be optionally exported
-    our @EXPORT_OK = qw{ check_parameter_hash };
+    our @EXPORT_OK = qw{ check_parameter_hash get_order_of_parameters };
 }
 
 sub check_parameter_hash {
@@ -100,6 +100,44 @@ sub check_parameter_hash {
         );
     }
     return 1;
+}
+
+sub get_order_of_parameters {
+
+## Function : Get order of parameters as they appear in definition file(s)
+## Returns  : @order_of_parameters
+## Arguments: $define_parameters_files_ref => MIPs define parameters file(s)
+
+    my ($arg_href) = @_;
+
+    ## Flatten argument(s)
+    my $define_parameters_files_ref;
+
+    my $tmpl = {
+        define_parameters_files_ref => {
+            default     => [],
+            store       => \$define_parameters_files_ref,
+            strict_type => 1,
+        },
+    };
+
+    check( $tmpl, $arg_href, 1 ) or croak q{Could not parse arguments!};
+
+    use MIP::Definition qw{ get_first_level_keys_order_from_definition_file };
+
+    my @order_of_parameters;
+
+  DEFINITION_FILE:
+    foreach my $define_parameters_file ( @{$define_parameters_files_ref} ) {
+
+        push @order_of_parameters,
+          get_first_level_keys_order_from_definition_file(
+            {
+                file_path => $define_parameters_file,
+            }
+          );
+    }
+    return @order_of_parameters;
 }
 
 sub _check_parameter_mandatory_keys_exits {


### PR DESCRIPTION
- Modified print_recipes args to directly use order_parameters instead of definition file
- Added test

### This PR fixes:

- See above

### How to test:

- Automatic and continuous test pass

### Expected outcome:
- Installation, unit and integration tests pass

### Review:
- [ ] Code review
- [ ] New code is executed and covered by tests
- [ ] Tests pass
