### PR TITLE
Feature/star aln recipe split

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,9 +29,11 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 - Removed cramtools
 - Removes cutadapt 
 - Supply wgs variantcalls for ASE analysis
+- STAR aligns sample fastq files with the same sequnece mode (eg. single-end or paired-end) within one job
 
 **CLI**
 - Removes the noupdate option from the installation
+- New CLI option for picard markduplicates optical duplicate distance. Default: 2500
 
 **New references**
 - grch37_sv_frequency_vcfanno_filter_config_-v1.2-.toml

--- a/definitions/rd_dna_parameters.yaml
+++ b/definitions/rd_dna_parameters.yaml
@@ -448,6 +448,12 @@ markduplicates_picardtools_markduplicates:
   data_type: SCALAR
   default: 1
   type: recipe_argument
+markduplicates_picardtools_opt_dup_dist:
+  associated_recipe:
+   - markduplicates
+  data_type: SCALAR
+  default: 2500
+  type: recipe_argument
 markduplicates_sambamba_markdup:
   associated_recipe:
    - markduplicates

--- a/definitions/rd_rna_parameters.yaml
+++ b/definitions/rd_rna_parameters.yaml
@@ -117,7 +117,7 @@ recipe_time:
     genebody_coverage: 3
     gffcompare_ar: 1
     gzip_fastq: 2
-    markduplicates: 2
+    markduplicates: 8
     multiqc_ar: 1
     picardtools_mergesamfiles: 2
     preseq_ar: 2
@@ -395,7 +395,7 @@ star_fusion_reference_genome:
   mandatory: no
   reference: reference_dir
   type: path
-## Arriba 
+## Arriba
 arriba_ar:
   analysis_mode: sample
   associated_recipe:
@@ -410,17 +410,17 @@ arriba_ar:
     - sambamba
   type: recipe
 arriba_blacklist_path:
-  associated_recipe: 
+  associated_recipe:
     - arriba_ar
   data_type: SCALAR
   type: path
 arriba_cytoband_path:
-  associated_recipe: 
+  associated_recipe:
     - arriba_ar
   data_type: SCALAR
   type: path
-arriba_proteindomain_path: 
-  associated_recipe: 
+arriba_proteindomain_path:
+  associated_recipe:
     - arriba_ar
   data_type: SCALAR
   type: path
@@ -449,17 +449,17 @@ stringtie_ar:
     - stringtie
   type: recipe
 stringtie_junction_reads:
-    associated_recipe:
-      - stringtie_ar
-    data_type: SCALAR
-    default: 2
-    type: recipe_argument
+  associated_recipe:
+    - stringtie_ar
+  data_type: SCALAR
+  default: 2
+  type: recipe_argument
 stringtie_minimum_coverage:
-    associated_recipe:
-      - stringtie_ar
-    data_type: SCALAR
-    default: 5
-    type: recipe_argument
+  associated_recipe:
+    - stringtie_ar
+  data_type: SCALAR
+  default: 5
+  type: recipe_argument
 ## GffCompare
 gffcompare_ar:
   analysis_mode: sample
@@ -496,6 +496,12 @@ markduplicates_picardtools_markduplicates:
     - markduplicates
   data_type: SCALAR
   default: 1
+  type: recipe_argument
+markduplicates_picardtools_opt_dup_dist:
+  associated_recipe:
+    - markduplicates
+  data_type: SCALAR
+  default: 2500
   type: recipe_argument
 markduplicates_sambamba_markdup:
   associated_recipe:
@@ -547,7 +553,7 @@ gatk_baserecalibration:
   type: recipe
 gatk_baserecalibration_no_bam_to_cram:
   associated_recipe:
-   - gatk_baserecalibration
+    - gatk_baserecalibration
   data_type: SCALAR
   default: 1
   type: recipe_argument

--- a/lib/MIP/Cli/Mip/Analyse/Rd_dna.pm
+++ b/lib/MIP/Cli/Mip/Analyse/Rd_dna.pm
@@ -20,7 +20,7 @@ use Moose::Util::TypeConstraints;
 ## MIPs lib
 use MIP::Main::Analyse qw{ mip_analyse };
 
-our $VERSION = 1.39;
+our $VERSION = 1.40;
 
 extends(qw{ MIP::Cli::Mip::Analyse });
 
@@ -446,6 +446,17 @@ q{gatk_baserecalibration_known_sites, gatk_haplotypecaller_snp_known_set, gatk_v
             documentation => q{Markduplicates using Picardtools markduplicates},
             is            => q{rw},
             isa           => Bool,
+        )
+    );
+
+    option(
+        q{markduplicates_picardtools_opt_dup_dist} => (
+            cmd_aliases   => [qw{ mdpodd }],
+            cmd_flag      => q{picard_mdup_odd},
+            cmd_tags      => [q{Default: 2500}],
+            documentation => q{Picardtools markduplicates optical duplicate distance},
+            is            => q{rw},
+            isa           => Int,
         )
     );
 

--- a/lib/MIP/Cli/Mip/Analyse/Rd_rna.pm
+++ b/lib/MIP/Cli/Mip/Analyse/Rd_rna.pm
@@ -19,7 +19,7 @@ use Moose::Util::TypeConstraints;
 ## MIPs lib
 use MIP::Main::Analyse qw{ mip_analyse };
 
-our $VERSION = 1.26;
+our $VERSION = 1.27;
 
 extends(qw{ MIP::Cli::Mip::Analyse });
 
@@ -638,6 +638,17 @@ q{Default: BaseQualityRankSumTest, ChromosomeCounts, Coverage, DepthPerAlleleByS
             documentation => q{Markduplicates using Picardtools markduplicates},
             is            => q{rw},
             isa           => Bool,
+        )
+    );
+
+    option(
+        q{markduplicates_picardtools_opt_dup_dist} => (
+            cmd_aliases   => [qw{ mdpodd }],
+            cmd_flag      => q{picard_mdup_odd},
+            cmd_tags      => [q{Default: 2500}],
+            documentation => q{Picardtools markduplicates optical duplicate distance},
+            is            => q{rw},
+            isa           => Int,
         )
     );
 

--- a/lib/MIP/Program/Picardtools.pm
+++ b/lib/MIP/Program/Picardtools.pm
@@ -27,7 +27,7 @@ BEGIN {
     use base qw{ Exporter };
 
     # Set the version for version checking
-    our $VERSION = 1.05;
+    our $VERSION = 1.06;
 
     # Functions and variables which can be optionally exported
     our @EXPORT_OK = qw{
@@ -714,18 +714,19 @@ sub picardtools_markduplicates {
 
 ## Function : Perl wrapper for writing picardtools markduplicates recipe to $filehandle. Based on picardtools 2.20.7.
 ## Returns  : @commands
-## Arguments: $create_index           => Create index
-##          : $filehandle             => Sbatch filehandle to write to
-##          : $infile_paths_ref       => Infile paths {REF}
-##          : $java_jar               => Java jar
-##          : $java_use_large_pages   => Use java large pages
-##          : $memory_allocation      => Memory allocation for java
-##          : $metrics_file           => File to write duplication metrics to
-##          : $outfile_path           => Outfile path
-##          : $referencefile_path     => Genome reference file
-##          : $stderrfile_path        => Stderrfile path
-##          : $stderrfile_path_append => Append stderr info to file path
-##          : $temp_directory         => Redirect tmp files to java temp
+## Arguments: $create_index               => Create index
+##          : $filehandle                 => Sbatch filehandle to write to
+##          : $infile_paths_ref           => Infile paths {REF}
+##          : $java_jar                   => Java jar
+##          : $java_use_large_pages       => Use java large pages
+##          : $memory_allocation          => Memory allocation for java
+##          : $metrics_file               => File to write duplication metrics to
+##          : $optical_duplicate_distance => Max distance between optical duplicates
+##          : $outfile_path               => Outfile path
+##          : $referencefile_path         => Genome reference file
+##          : $stderrfile_path            => Stderrfile path
+##          : $stderrfile_path_append     => Append stderr info to file path
+##          : $temp_directory             => Redirect tmp files to java temp
 
     my ($arg_href) = @_;
 
@@ -735,6 +736,7 @@ sub picardtools_markduplicates {
     my $metrics_file;
     my $infile_paths_ref;
     my $java_jar;
+    my $optical_duplicate_distance;
     my $outfile_path;
     my $referencefile_path;
     my $stderrfile_path;
@@ -772,6 +774,11 @@ sub picardtools_markduplicates {
             defined     => 1,
             required    => 1,
             store       => \$metrics_file,
+            strict_type => 1,
+        },
+        optical_duplicate_distance => {
+            allow       => [ undef, qr/ \A \d+ \z /xms ],
+            store       => \$optical_duplicate_distance,
             strict_type => 1,
         },
         outfile_path => {
@@ -825,8 +832,12 @@ sub picardtools_markduplicates {
 
     if ($metrics_file) {
 
-        # File to write duplication metrics to
         push @commands, q{-METRICS_FILE} . $SPACE . $metrics_file;
+    }
+    if ($optical_duplicate_distance) {
+
+        push @commands,
+          q{-OPTICAL_DUPLICATE_PIXEL_DISTANCE} . $SPACE . $optical_duplicate_distance;
     }
 
     ## Infile

--- a/lib/MIP/Program/Star.pm
+++ b/lib/MIP/Program/Star.pm
@@ -25,7 +25,7 @@ BEGIN {
     use base qw{ Exporter };
 
     # Set the version for version checking
-    our $VERSION = 1.05;
+    our $VERSION = 1.06;
 
     # Functions and variables which can be optionally exported
     our @EXPORT_OK = qw{ star_aln star_genome_generate };
@@ -54,6 +54,7 @@ sub star_aln {
 ##           : $out_bam_compression           => Compression level of BAM file
 ##           : $out_filter_mismatch_nmax      => Max number of missmatches allowed in alignment
 ##           : $out_filter_multimap_nmax      => Max number of loci a read is allowed to map to
+##           : $out_sam_attr_rgline           => SAM/BAM read group line
 ##           : $out_sam_strand_field          => Cufflinks-like strand field flag
 ##           : $out_sam_type                  => Format of the output aligned reads
 ##           : $out_sam_unmapped              => Write unmapped reads to main BAM file
@@ -89,6 +90,7 @@ sub star_aln {
     my $out_bam_compression;
     my $out_filter_mismatch_nmax;
     my $out_filter_multimap_nmax;
+    my $out_sam_attr_rgline;
     my $out_sam_unmapped;
     my $pe_overlap_nbases_min;
     my $stderrfile_path;
@@ -211,6 +213,10 @@ sub star_aln {
         out_filter_multimap_nmax => {
             allow       => qr/ \A \d+ \z /xms,
             store       => \$out_filter_multimap_nmax,
+            strict_type => 1,
+        },
+        out_sam_attr_rgline => {
+            store       => \$out_sam_attr_rgline,
             strict_type => 1,
         },
         out_sam_strand_field => {
@@ -356,6 +362,10 @@ sub star_aln {
     if ($out_filter_multimap_nmax) {
 
         push @commands, q{--outFilterMultimapNmax} . $SPACE . $out_filter_multimap_nmax;
+    }
+    if ($out_sam_attr_rgline) {
+
+        push @commands, q{--outSAMattrRGline} . $SPACE . $out_sam_attr_rgline;
     }
     if ($out_sam_strand_field) {
 

--- a/lib/MIP/Recipes/Analysis/Markduplicates.pm
+++ b/lib/MIP/Recipes/Analysis/Markduplicates.pm
@@ -27,7 +27,7 @@ BEGIN {
     use base qw{ Exporter };
 
     # Set the version for version checking
-    our $VERSION = 1.22;
+    our $VERSION = 1.23;
 
     # Functions and variables which can be optionally exported
     our @EXPORT_OK = qw{ analysis_markduplicates };
@@ -336,8 +336,10 @@ sub analysis_markduplicates {
                     ),
                     java_use_large_pages =>
                       $active_parameter_href->{java_use_large_pages},
-                    memory_allocation  => q{Xmx} . $JAVA_MEMORY_ALLOCATION . q{g},
-                    metrics_file       => $metrics_file,
+                    memory_allocation => q{Xmx} . $JAVA_MEMORY_ALLOCATION . q{g},
+                    metrics_file      => $metrics_file,
+                    optical_duplicate_distance =>
+                      $active_parameter_href->{markduplicates_picardtools_opt_dup_dist},
                     outfile_path       => $outfile_path{$contig},
                     referencefile_path => $referencefile_path,
                     stderrfile_path    => $stderrfile_path,

--- a/lib/MIP/Recipes/Analysis/Star_aln.pm
+++ b/lib/MIP/Recipes/Analysis/Star_aln.pm
@@ -17,7 +17,8 @@ use autodie qw{ :all };
 use Readonly;
 
 ## MIPs lib/
-use MIP::Constants qw{ $ASTERISK $DOT $LOG_NAME $NEWLINE $UNDERSCORE };
+use MIP::Constants
+  qw{ $ASTERISK $COLON $COMMA $DOT $EMPTY_STR $LOG_NAME $NEWLINE $SPACE $UNDERSCORE };
 
 BEGIN {
 
@@ -25,10 +26,10 @@ BEGIN {
     use base qw{ Exporter };
 
     # Set the version for version checking
-    our $VERSION = 1.16;
+    our $VERSION = 1.17;
 
     # Functions and variables which can be optionally exported
-    our @EXPORT_OK = qw{ analysis_star_aln };
+    our @EXPORT_OK = qw{ analysis_star_aln analysis_star_aln_mixed };
 
 }
 
@@ -141,12 +142,383 @@ sub analysis_star_aln {
 
     use MIP::Get::File qw{ get_io_files };
     use MIP::Get::Parameter qw{ get_recipe_attributes get_recipe_resources };
+    use MIP::Gnu::Coreutils qw{ gnu_mv gnu_rm };
     use MIP::Parse::File qw{ parse_io_outfiles };
-    use MIP::Program::Picardtools qw{ picardtools_addorreplacereadgroups };
+    use MIP::Program::Samtools qw{ samtools_index };
     use MIP::Program::Star qw{ star_aln };
     use MIP::Processmanagement::Processes qw{ submit_recipe };
-    use MIP::Sample_info
-      qw{ get_read_group get_sequence_run_type set_recipe_outfile_in_sample_info set_recipe_metafile_in_sample_info set_processing_metafile_in_sample_info };
+    use MIP::Sample_info qw{
+      get_read_group
+      get_sequence_run_type
+      set_recipe_metafile_in_sample_info
+      set_recipe_outfile_in_sample_info };
+    use MIP::Script::Setup_script qw{ setup_script };
+
+    ## PREPROCESSING:
+
+    ## Retrieve logger object
+    my $log = Log::Log4perl->get_logger($LOG_NAME);
+
+    ## Unpack parameters
+    ## Get the io infiles per chain and id
+    my %io = get_io_files(
+        {
+            id             => $sample_id,
+            file_info_href => $file_info_href,
+            parameter_href => $parameter_href,
+            recipe_name    => $recipe_name,
+            stream         => q{in},
+        }
+    );
+    my @infile_paths = @{ $io{in}{file_paths} };
+
+    my $recipe_mode = $active_parameter_href->{$recipe_name};
+
+    ## Build outfile_paths
+    my %rec_atr = get_recipe_attributes(
+        {
+            parameter_href => $parameter_href,
+            recipe_name    => $recipe_name,
+        }
+    );
+    my $job_id_chain = $rec_atr{chain};
+    my $outsample_directory =
+      catdir( $active_parameter_href->{outdata_dir}, $sample_id, $recipe_name );
+    my $lanes_id            = join $EMPTY_STR, @{ $file_info_href->{$sample_id}{lanes} };
+    my $outfile_tag         = $file_info_href->{$sample_id}{$recipe_name}{file_tag};
+    my $outfile_suffix      = $rec_atr{outfile_suffix};
+    my $outfile_path_prefix = catfile( $outsample_directory,
+        $sample_id . $UNDERSCORE . q{lanes} . $UNDERSCORE . $lanes_id . $outfile_tag );
+
+    %io = (
+        %io,
+        parse_io_outfiles(
+            {
+                chain_id       => $job_id_chain,
+                id             => $sample_id,
+                file_info_href => $file_info_href,
+                file_paths_ref => [ $outfile_path_prefix . $outfile_suffix ],
+                parameter_href => $parameter_href,
+                recipe_name    => $recipe_name,
+            }
+        )
+    );
+    my $outfile_name = ${ $io{out}{file_names} }[0];
+    my $outfile_path = $io{out}{file_path};
+
+    my %recipe_resource = get_recipe_resources(
+        {
+            active_parameter_href => $active_parameter_href,
+            recipe_name           => $recipe_name,
+        }
+    );
+
+    ## Filehandles
+    # Create anonymous filehandle
+    my $filehandle = IO::Handle->new();
+
+    ## Creates recipe directories (info & data & script), recipe script filenames and writes sbatch header
+    my ( $recipe_file_path, $recipe_info_path ) = setup_script(
+        {
+            active_parameter_href           => $active_parameter_href,
+            core_number                     => $recipe_resource{core_number},
+            directory_id                    => $sample_id,
+            filehandle                      => $filehandle,
+            job_id_href                     => $job_id_href,
+            log                             => $log,
+            memory_allocation               => $recipe_resource{memory},
+            process_time                    => $recipe_resource{time},
+            recipe_directory                => $recipe_name,
+            recipe_name                     => $recipe_name,
+            source_environment_commands_ref => $recipe_resource{load_env_ref},
+            temp_directory                  => $temp_directory,
+            ulimit_n                        => $active_parameter_href->{star_ulimit_n},
+        }
+    );
+
+    ### SHELL:
+    say {$filehandle} q{## Performing fusion transcript detections using } . $recipe_name;
+
+    ## Get infiles
+    my $paired_end_tracker = 0;
+    my @forward_files;
+    my @reverse_files;
+    my @read_groups;
+
+    ## Perform per single-end or read pair
+  INFILE_PREFIX:
+    while ( my ( $infile_index, $infile_prefix ) =
+        each @{ $infile_lane_prefix_href->{$sample_id} } )
+    {
+
+        # Collect paired-end or single-end sequence run mode
+        my $sequence_run_mode =
+          $sample_info_href->{sample}{$sample_id}{file}{$infile_prefix}
+          {sequence_run_type};
+
+        ## Add read one to file index array
+        push @forward_files, $infile_paths[$paired_end_tracker];
+
+        # If second read direction is present
+        if ( $sequence_run_mode eq q{paired-end} ) {
+
+            # Increment to collect correct read 2 from infiles
+            $paired_end_tracker++;
+
+            ## Add read two file index array
+            push @reverse_files, $infile_paths[$paired_end_tracker];
+        }
+
+        ## Increment paired end tracker
+        $paired_end_tracker++;
+
+        ## Construct RG
+        my %rg = get_read_group(
+            {
+                infile_prefix    => $infile_prefix,
+                platform         => $active_parameter_href->{platform},
+                sample_id        => $sample_id,
+                sample_info_href => $sample_info_href,
+            }
+        );
+
+        ## Construct read group line;
+        my @rg_elements = map { uc $_ . $COLON . $rg{$_} } qw{ id lb pl pu sm };
+        push @read_groups, join $SPACE, @rg_elements;
+    }
+
+    my @fastq_files =
+      ( ( join $COMMA, @forward_files ), ( join $COMMA, @reverse_files ) );
+    my $out_sam_attr_rgline = join $SPACE . $COMMA . $SPACE, @read_groups;
+
+    my $referencefile_dir_path =
+        $active_parameter_href->{star_aln_reference_genome}
+      . $file_info_href->{star_aln_reference_genome}[0];
+
+    star_aln(
+        {
+            align_intron_max        => $active_parameter_href->{align_intron_max},
+            align_mates_gap_max     => $active_parameter_href->{align_mates_gap_max},
+            align_sjdb_overhang_min => $active_parameter_href->{align_sjdb_overhang_min},
+            chim_junction_overhang_min =>
+              $active_parameter_href->{chim_junction_overhang_min},
+            chim_out_type         => $active_parameter_href->{chim_out_type},
+            chim_segment_min      => $active_parameter_href->{chim_segment_min},
+            filehandle            => $filehandle,
+            genome_dir_path       => $referencefile_dir_path,
+            infile_paths_ref      => \@fastq_files,
+            out_sam_attr_rgline   => $out_sam_attr_rgline,
+            outfile_name_prefix   => $outfile_path_prefix . $DOT,
+            pe_overlap_nbases_min => $active_parameter_href->{pe_overlap_nbases_min},
+            thread_number         => $recipe_resource{core_number},
+            two_pass_mode         => $active_parameter_href->{two_pass_mode},
+        },
+    );
+    say {$filehandle} $NEWLINE;
+
+    ## Rename bam file
+    gnu_mv(
+        {
+            filehandle  => $filehandle,
+            infile_path => $outfile_path_prefix
+              . $DOT
+              . q{Aligned.sortedByCoord.out}
+              . $outfile_suffix,
+            outfile_path => $outfile_path,
+        }
+    );
+    say {$filehandle} $NEWLINE;
+
+    samtools_index(
+        {
+            filehandle  => $filehandle,
+            infile_path => $outfile_path,
+        }
+    );
+    say {$filehandle} $NEWLINE;
+
+    ## Remove intermediary files
+  FILE_TAG:
+    foreach my $file_tag (qw{ _STARgenome _STARpass1 }) {
+
+        gnu_rm(
+            {
+                filehandle  => $filehandle,
+                force       => 1,
+                infile_path => $outfile_path_prefix . $DOT . $file_tag,
+                recursive   => 1,
+            }
+        );
+        print {$filehandle} $NEWLINE;
+    }
+
+    ## Close filehandle
+    close $filehandle or $log->logcroak(q{Could not close filehandle});
+
+    if ( $recipe_mode == 1 ) {
+
+        ## Collect QC metadata info for later use
+        set_recipe_outfile_in_sample_info(
+            {
+                infile           => $outfile_name,
+                path             => $outfile_path,
+                recipe_name      => $recipe_name,
+                sample_id        => $sample_id,
+                sample_info_href => $sample_info_href,
+            }
+        );
+
+        my $star_aln_log = $outfile_path_prefix . $DOT . q{Log.final.out};
+        set_recipe_metafile_in_sample_info(
+            {
+                infile           => $outfile_name,
+                metafile_tag     => q{log},
+                path             => $star_aln_log,
+                recipe_name      => $recipe_name,
+                sample_id        => $sample_id,
+                sample_info_href => $sample_info_href,
+            }
+        );
+
+        submit_recipe(
+            {
+                base_command            => $profile_base_command,
+                case_id                 => $case_id,
+                dependency_method       => q{sample_to_sample},
+                infile_lane_prefix_href => $infile_lane_prefix_href,
+                job_id_chain            => $job_id_chain,
+                job_id_href             => $job_id_href,
+                job_reservation_name    => $active_parameter_href->{job_reservation_name},
+                log                     => $log,
+                recipe_file_path        => $recipe_file_path,
+                sample_id               => $sample_id,
+                submission_profile      => $active_parameter_href->{submission_profile},
+            }
+        );
+    }
+    return 1;
+}
+
+sub analysis_star_aln_mixed {
+
+## Function : Alignment of mixed single and paired end fastq files using star aln
+## Returns  :
+## Arguments: $active_parameter_href   => Active parameters for this analysis hash {REF}
+##          : $case_id                 => Family id
+##          : $file_info_href          => File_info hash {REF}
+##          : $infile_lane_prefix_href => Infile(s) without the ".ending" {REF}
+##          : $job_id_href             => Job id hash {REF}
+##          : $parameter_href          => Parameter hash {REF}
+##          : $profile_base_command    => Submission profile base command
+##          : $recipe_name             => Program name
+##          : $sample_id               => Sample id
+##          : $sample_info_href        => Info on samples and case hash {REF}
+##          : $temp_directory          => Temporary directory
+
+    my ($arg_href) = @_;
+
+    ## Flatten argument(s)
+    my $active_parameter_href;
+    my $file_info_href;
+    my $infile_lane_prefix_href;
+    my $job_id_href;
+    my $parameter_href;
+    my $recipe_name;
+    my $sample_id;
+    my $sample_info_href;
+
+    ## Default(s)
+    my $case_id;
+    my $profile_base_command;
+    my $temp_directory;
+
+    my $tmpl = {
+        active_parameter_href => {
+            default     => {},
+            defined     => 1,
+            required    => 1,
+            store       => \$active_parameter_href,
+            strict_type => 1,
+        },
+        case_id => {
+            default     => $arg_href->{active_parameter_href}{case_id},
+            store       => \$case_id,
+            strict_type => 1,
+        },
+        file_info_href => {
+            default     => {},
+            defined     => 1,
+            required    => 1,
+            store       => \$file_info_href,
+            strict_type => 1,
+        },
+        infile_lane_prefix_href => {
+            default     => {},
+            defined     => 1,
+            required    => 1,
+            store       => \$infile_lane_prefix_href,
+            strict_type => 1,
+        },
+        job_id_href => {
+            default     => {},
+            defined     => 1,
+            required    => 1,
+            store       => \$job_id_href,
+            strict_type => 1,
+        },
+        parameter_href => {
+            default     => {},
+            defined     => 1,
+            required    => 1,
+            store       => \$parameter_href,
+            strict_type => 1,
+        },
+        profile_base_command => {
+            default     => q{sbatch},
+            store       => \$profile_base_command,
+            strict_type => 1,
+        },
+        recipe_name => {
+            defined     => 1,
+            required    => 1,
+            store       => \$recipe_name,
+            strict_type => 1,
+        },
+        sample_id => {
+            defined     => 1,
+            required    => 1,
+            store       => \$sample_id,
+            strict_type => 1,
+        },
+        sample_info_href => {
+            default     => {},
+            defined     => 1,
+            required    => 1,
+            store       => \$sample_info_href,
+            strict_type => 1,
+        },
+        temp_directory => {
+            default     => $arg_href->{active_parameter_href}{temp_directory},
+            store       => \$temp_directory,
+            strict_type => 1,
+        },
+    };
+
+    check( $tmpl, $arg_href, 1 ) or croak q{Could not parse arguments!};
+
+    use MIP::Get::File qw{ get_io_files };
+    use MIP::Get::Parameter qw{ get_recipe_attributes get_recipe_resources };
+    use MIP::Gnu::Coreutils qw{ gnu_mv gnu_rm };
+    use MIP::Parse::File qw{ parse_io_outfiles };
+    use MIP::Program::Samtools qw{ samtools_index };
+    use MIP::Program::Star qw{ star_aln };
+    use MIP::Processmanagement::Processes qw{ submit_recipe };
+    use MIP::Sample_info qw{
+      get_read_group
+      get_sequence_run_type
+      set_recipe_outfile_in_sample_info
+      set_recipe_metafile_in_sample_info
+      set_processing_metafile_in_sample_info };
     use MIP::Script::Setup_script qw{ setup_script };
 
     ## PREPROCESSING:
@@ -271,6 +643,20 @@ sub analysis_star_aln {
             $active_parameter_href->{star_aln_reference_genome}
           . $file_info_href->{star_aln_reference_genome}[0];
 
+        ## Construct RG
+        my %rg = get_read_group(
+            {
+                infile_prefix    => $infile_prefix,
+                platform         => $active_parameter_href->{platform},
+                sample_id        => $sample_id,
+                sample_info_href => $sample_info_href,
+            }
+        );
+
+        ## Construct read group line;
+        my @rg_elements         = map { uc $_ . $COLON . $rg{$_} } qw{ id lb pl pu sm };
+        my $out_sam_attr_rgline = join $SPACE, @rg_elements;
+
         star_aln(
             {
                 filehandle          => $filehandle,
@@ -284,6 +670,7 @@ sub analysis_star_aln {
                 chim_segment_min      => $active_parameter_href->{chim_segment_min},
                 genome_dir_path       => $referencefile_dir_path,
                 infile_paths_ref      => \@fastq_files,
+                out_sam_attr_rgline   => $out_sam_attr_rgline,
                 outfile_name_prefix   => $outfile_path_prefix . $DOT,
                 pe_overlap_nbases_min => $active_parameter_href->{pe_overlap_nbases_min},
                 thread_number         => $recipe_resource{core_number},
@@ -295,39 +682,43 @@ sub analysis_star_aln {
         ## Increment paired end tracker
         $paired_end_tracker++;
 
-        my %read_group = get_read_group(
+        ## Rename bam file
+        gnu_mv(
             {
-                infile_prefix    => $infile_prefix,
-                platform         => $active_parameter_href->{platform},
-                sample_id        => $sample_id,
-                sample_info_href => $sample_info_href,
-            }
-        );
-
-        picardtools_addorreplacereadgroups(
-            {
-                create_index => q{true},
-                filehandle   => $filehandle,
-                infile_path  => $outfile_path_prefix
+                filehandle  => $filehandle,
+                infile_path => $outfile_path_prefix
                   . $DOT
                   . q{Aligned.sortedByCoord.out}
                   . $outfile_suffix,
-                java_jar =>
-                  catfile( $active_parameter_href->{picardtools_path}, q{picard.jar} ),
-                java_use_large_pages    => $active_parameter_href->{java_use_large_pages},
-                memory_allocation       => q{Xmx1g},
-                outfile_path            => $outfile_path,
-                readgroup_id            => $read_group{id},
-                readgroup_library       => $read_group{lb},
-                readgroup_platform      => $read_group{pl},
-                readgroup_platform_unit => $read_group{pu},
-                readgroup_sample        => $read_group{sm},
-            },
+                outfile_path => $outfile_path,
+            }
         );
-
         say {$filehandle} $NEWLINE;
 
-        ## Close filehandleS
+        samtools_index(
+            {
+                filehandle  => $filehandle,
+                infile_path => $outfile_path,
+            }
+        );
+        say {$filehandle} $NEWLINE;
+
+        ## Remove intermediary files
+      FILE_TAG:
+        foreach my $file_tag (qw{ _STARgenome _STARpass1 }) {
+
+            gnu_rm(
+                {
+                    filehandle  => $filehandle,
+                    force       => 1,
+                    infile_path => $outfile_path_prefix . $DOT . $file_tag,
+                    recursive   => 1,
+                }
+            );
+            print {$filehandle} $NEWLINE;
+        }
+
+        ## Close filehandles
         close $filehandle or $log->logcroak(q{Could not close filehandle});
 
         if ( $recipe_mode == 1 ) {
@@ -347,20 +738,9 @@ sub analysis_star_aln {
             set_recipe_metafile_in_sample_info(
                 {
                     infile           => $outfile_name_prefix,
+                    metafile_tag     => q{log},
                     path             => $star_aln_log,
                     recipe_name      => $recipe_name,
-                    metafile_tag     => q{log},
-                    sample_id        => $sample_id,
-                    sample_info_href => $sample_info_href,
-                }
-            );
-
-            my $most_complete_format_key =
-              q{most_complete} . $UNDERSCORE . substr $outfile_suffix, 1;
-            set_processing_metafile_in_sample_info(
-                {
-                    metafile_tag     => $most_complete_format_key,
-                    path             => $outfile_path,
                     sample_id        => $sample_id,
                     sample_info_href => $sample_info_href,
                 }

--- a/lib/MIP/Recipes/Pipeline/Analyse_rd_rna.pm
+++ b/lib/MIP/Recipes/Pipeline/Analyse_rd_rna.pm
@@ -23,7 +23,7 @@ BEGIN {
     use base qw{ Exporter };
 
     # Set the version for version checking
-    our $VERSION = 1.26;
+    our $VERSION = 1.27;
 
     # Functions and variables which can be optionally exported
     our @EXPORT_OK = qw{ pipeline_analyse_rd_rna };
@@ -171,13 +171,13 @@ sub pipeline_analyse_rd_rna {
     use MIP::Recipes::Analysis::Rseqc qw{ analysis_rseqc };
     use MIP::Recipes::Analysis::Sacct qw{ analysis_sacct };
     use MIP::Recipes::Analysis::Salmon_quant qw{ analysis_salmon_quant };
-    use MIP::Recipes::Analysis::Star_aln qw{ analysis_star_aln };
     use MIP::Recipes::Analysis::Star_fusion qw{ analysis_star_fusion };
     use MIP::Recipes::Analysis::Stringtie qw{ analysis_stringtie };
     use MIP::Recipes::Analysis::Trim_galore qw{ analysis_trim_galore };
     use MIP::Recipes::Analysis::Vcf_ase_reformat qw{ analysis_vcf_ase_reformat};
     use MIP::Recipes::Analysis::Vep qw{ analysis_vep_rna };
-    use MIP::Recipes::Build::Rd_rna qw{build_rd_rna_meta_files};
+    use MIP::Recipes::Build::Rd_rna qw{ build_rd_rna_meta_files };
+    use MIP::Set::Analysis qw{ set_recipe_star_aln };
 
     ### Pipeline specific checks
     check_rd_rna(
@@ -235,12 +235,21 @@ sub pipeline_analyse_rd_rna {
         rseqc                     => \&analysis_rseqc,
         sacct                     => \&analysis_sacct,
         salmon_quant              => \&analysis_salmon_quant,
-        star_aln                  => \&analysis_star_aln,
+        star_aln                  => undef,
         star_fusion               => \&analysis_star_fusion,
         stringtie_ar              => \&analysis_stringtie,
         trim_galore_ar            => \&analysis_trim_galore,
         varianteffectpredictor    => \&analysis_vep_rna,
         version_collect_ar        => \&analysis_mip_vercollect,
+    );
+
+    ## Update which star recipe to use depending on fastq infile mix
+    set_recipe_star_aln(
+        {
+            analysis_recipe_href    => \%analysis_recipe,
+            infile_lane_prefix_href => $infile_lane_prefix_href,
+            sample_info_href        => $sample_info_href,
+        }
     );
 
   RECIPE:

--- a/lib/MIP/Sample_info.pm
+++ b/lib/MIP/Sample_info.pm
@@ -207,9 +207,9 @@ sub get_read_group {
 
 sub get_rg_header_line {
 
-## Function : Builds hash with read group headers
-## Returns  : %read_group
-## Arguments: $infile_prefix    => Name of Fastq file minus read direction information
+## Function : Builds line using read group headers
+## Returns  : $rg_header_line
+## Arguments: $infile_prefix    => Name of fastq file minus read direction information
 ##          : $platform         => Sequencing platform
 ##          : $sample_id        => Sample ID
 ##          : $sample_info_href => Sample info hash {REF}

--- a/lib/MIP/Sample_info.pm
+++ b/lib/MIP/Sample_info.pm
@@ -19,7 +19,7 @@ use autodie qw{ :all };
 use Readonly;
 
 ## MIPs lib/
-use MIP::Constants qw{ $DOT $EMPTY_STR $NEWLINE $SPACE $UNDERSCORE };
+use MIP::Constants qw{ $COLON $DOT $EMPTY_STR $NEWLINE $SPACE $UNDERSCORE };
 
 BEGIN {
 
@@ -27,12 +27,13 @@ BEGIN {
     use base qw{Exporter};
 
     # Set the version for version checking
-    our $VERSION = 1.17;
+    our $VERSION = 1.18;
 
     # Functions and variables which can be optionally exported
     our @EXPORT_OK = qw{
       get_family_member_id
       get_read_group
+      get_rg_header_line
       get_sample_info_case_recipe_attributes
       get_sample_info_sample_recipe_attributes
       get_sequence_run_type
@@ -202,6 +203,77 @@ sub get_read_group {
     );
 
     return %rg;
+}
+
+sub get_rg_header_line {
+
+## Function : Builds hash with read group headers
+## Returns  : %read_group
+## Arguments: $infile_prefix    => Name of Fastq file minus read direction information
+##          : $platform         => Sequencing platform
+##          : $sample_id        => Sample ID
+##          : $sample_info_href => Sample info hash {REF}
+##          : $separator        => Separator of the read group elements
+
+    my ($arg_href) = @_;
+
+    ## Flatten argument(s)
+    my $infile_prefix;
+    my $platform;
+    my $sample_id;
+    my $sample_info_href;
+    my $separator;
+
+    my $tmpl = {
+        infile_prefix => {
+            defined     => 1,
+            required    => 1,
+            store       => \$infile_prefix,
+            strict_type => 1,
+        },
+        platform => {
+            defined     => 1,
+            required    => 1,
+            store       => \$platform,
+            strict_type => 1,
+        },
+        sample_id => {
+            defined     => 1,
+            required    => 1,
+            store       => \$sample_id,
+            strict_type => 1,
+        },
+        sample_info_href => {
+            default     => {},
+            defined     => 1,
+            required    => 1,
+            store       => \$sample_info_href,
+            strict_type => 1,
+        },
+        separator => {
+            defined     => 1,
+            required    => 1,
+            store       => \$separator,
+            strict_type => 1,
+        },
+    };
+
+    check( $tmpl, $arg_href, 1 ) or croak q{Could not parse arguments!};
+
+    my %rg = get_read_group(
+        {
+            infile_prefix    => $infile_prefix,
+            platform         => $platform,
+            sample_id        => $sample_id,
+            sample_info_href => $sample_info_href,
+        }
+    );
+
+    ## Construct read group line;
+    my @rg_elements    = map { uc($_) . $COLON . $rg{$_} } qw{ id lb pl pu sm };
+    my $rg_header_line = join $separator, @rg_elements;
+
+    return $rg_header_line;
 }
 
 sub get_sample_info_case_recipe_attributes {

--- a/lib/MIP/Set/Analysis.pm
+++ b/lib/MIP/Set/Analysis.pm
@@ -13,6 +13,7 @@ use warnings qw{ FATAL utf8 };
 
 ## CPANM
 use autodie qw{ :all };
+use List::MoreUtils qw { uniq };
 use Readonly;
 
 ## MIPs lib/
@@ -23,7 +24,7 @@ BEGIN {
     use base qw{ Exporter };
 
     # Set the version for version checking
-    our $VERSION = 1.10;
+    our $VERSION = 1.11;
 
     # Functions and variables which can be optionally exported
     our @EXPORT_OK = qw{
@@ -34,6 +35,7 @@ BEGIN {
       set_recipe_chromograph
       set_recipe_gatk_variantrecalibration
       set_recipe_on_analysis_type
+      set_recipe_star_aln
     };
 }
 
@@ -472,6 +474,75 @@ sub set_ase_chain_recipes {
         $active_parameter_href->{gatk_variantfiltration} = 0;
     }
 
+    return;
+}
+
+sub set_recipe_star_aln {
+
+## Function : Set star_aln analysis recipe depending on mix of fastq files
+## Returns  :
+## Arguments: $analysis_recipe_href    => Analysis recipe hash {REF}
+##          : $infile_lane_prefix_href => Infile(s) without the ".ending" {REF}
+##          : $sample_info_href        => Sample info hash {REF}
+
+    my ($arg_href) = @_;
+
+    ## Flatten arguments
+    my $analysis_recipe_href;
+    my $infile_lane_prefix_href;
+    my $sample_info_href;
+
+    my $tmpl = {
+        analysis_recipe_href => {
+            default     => {},
+            defined     => 1,
+            required    => 1,
+            store       => \$analysis_recipe_href,
+            strict_type => 1,
+        },
+        infile_lane_prefix_href => {
+            default     => {},
+            defined     => 1,
+            required    => 1,
+            store       => \$infile_lane_prefix_href,
+            strict_type => 1,
+        },
+        sample_info_href => {
+            default     => {},
+            defined     => 1,
+            required    => 1,
+            store       => \$sample_info_href,
+            strict_type => 1,
+        },
+    };
+
+    check( $tmpl, $arg_href, 1 ) or croak q{Could not parse arguments!};
+
+    use MIP::Recipes::Analysis::Star_aln qw{ analysis_star_aln analysis_star_aln_mixed };
+    use MIP::Sample_info qw{ get_sequence_run_type };
+
+    ## Get sequence run modes
+  SAMPLE_ID:
+    foreach my $sample_id ( keys %{ $sample_info_href->{sample} } ) {
+
+        my %sequence_run_type = get_sequence_run_type(
+            {
+                infile_lane_prefix_href => $infile_lane_prefix_href,
+                sample_id               => $sample_id,
+                sample_info_href        => $sample_info_href,
+            }
+        );
+
+        ## Use regular star_aln_mixed recipe if multiple sequence types are present
+        if ( uniq( values %sequence_run_type ) > 1 ) {
+
+            $analysis_recipe_href->{star_aln} = \&analysis_star_aln_mixed;
+            return;
+        }
+    }
+
+    ## The fastq files are either all single or paired end
+    $analysis_recipe_href->{star_aln} = \&analysis_star_aln;
     return;
 }
 

--- a/lib/MIP/Set/Analysis.pm
+++ b/lib/MIP/Set/Analysis.pm
@@ -521,7 +521,7 @@ sub set_recipe_star_aln {
     use MIP::Recipes::Analysis::Star_aln qw{ analysis_star_aln analysis_star_aln_mixed };
     use MIP::Sample_info qw{ get_sequence_run_type };
 
-    ## Get sequence run modes
+    ## Get sequence run types
   SAMPLE_ID:
     foreach my $sample_id ( keys %{ $sample_info_href->{sample} } ) {
 

--- a/t/analysis_star_aln_mixed.t
+++ b/t/analysis_star_aln_mixed.t
@@ -124,6 +124,16 @@ my %sample_info = (
                         },
                     },
                 },
+                ADM1059A1_161011_TestFilev2_GAGATTCC_lane2 => {
+                    sequence_run_type   => q{single-end},
+                    read_direction_file => {
+                        ADM1059A1_161011_TestFilev2_GAGATTCC_lane2_1 => {
+                            flowcell       => q{TestFilev2},
+                            lane           => q{2},
+                            sample_barcode => q{GAGATTC},
+                        },
+                    },
+                },
             },
         },
     },

--- a/t/analysis_star_aln_mixed.t
+++ b/t/analysis_star_aln_mixed.t
@@ -110,9 +110,14 @@ my %sample_info = (
         $sample_id => {
             file => {
                 ADM1059A1_161011_TestFilev2_GAGATTCC_lane1 => {
-                    sequence_run_type   => q{single-end},
+                    sequence_run_type   => q{paired-end},
                     read_direction_file => {
                         ADM1059A1_161011_TestFilev2_GAGATTCC_lane1_1 => {
+                            flowcell       => q{TestFilev2},
+                            lane           => q{1},
+                            sample_barcode => q{GAGATTC},
+                        },
+                        ADM1059A1_161011_TestFilev2_GAGATTCC_lane1_2 => {
                             flowcell       => q{TestFilev2},
                             lane           => q{1},
                             sample_barcode => q{GAGATTC},

--- a/t/analysis_star_aln_mixed.t
+++ b/t/analysis_star_aln_mixed.t
@@ -25,7 +25,7 @@ use MIP::Constants qw{ $COLON $COMMA $SPACE };
 use MIP::Test::Fixtures qw{ test_log test_mip_hashes test_standard_cli };
 
 my $VERBOSE = 1;
-our $VERSION = 1.01;
+our $VERSION = 1.00;
 
 $VERBOSE = test_standard_cli(
     {
@@ -41,16 +41,16 @@ BEGIN {
 ### Check all internal dependency modules and imports
 ## Modules with import
     my %perl_module = (
-        q{MIP::Recipes::Analysis::Star_aln} => [qw{ analysis_star_aln }],
+        q{MIP::Recipes::Analysis::Star_aln} => [qw{ analysis_star_aln_mixed }],
         q{MIP::Test::Fixtures} => [qw{ test_log test_mip_hashes test_standard_cli }],
     );
 
     test_import( { perl_module_href => \%perl_module, } );
 }
 
-use MIP::Recipes::Analysis::Star_aln qw{ analysis_star_aln };
+use MIP::Recipes::Analysis::Star_aln qw{ analysis_star_aln_mixed };
 
-diag(   q{Test analysis_star_aln from Star_aln.pm v}
+diag(   q{Test analysis_star_aln_mixed from Star_aln.pm v}
       . $MIP::Recipes::Analysis::Star_aln::VERSION
       . $COMMA
       . $SPACE . q{Perl}
@@ -62,7 +62,7 @@ diag(   q{Test analysis_star_aln from Star_aln.pm v}
 my $log = test_log( { log_name => q{MIP}, no_screen => 1, } );
 
 ## Given analysis parameters
-my $recipe_name    = q{star_aln};
+my $recipe_name    = q{star_aln_mixed};
 my $slurm_mock_cmd = catfile( $Bin, qw{ data modules slurm-mock.pl } );
 
 my %active_parameter = test_mip_hashes(
@@ -85,9 +85,7 @@ my %file_info = test_mip_hashes(
         recipe_name   => $recipe_name,
     }
 );
-$file_info{star_aln_reference_genome}          = [q{reference_genome}];
-$file_info{$sample_id}{lanes}                  = [1];
-$file_info{$sample_id}{$recipe_name}{file_tag} = q{star_sorted};
+$file_info{star_aln_reference_genome} = [q{reference_genome}];
 %{ $file_info{io}{TEST}{$sample_id}{$recipe_name} } = test_mip_hashes(
     {
         mip_hash_name => q{io},
@@ -126,7 +124,7 @@ my %sample_info = (
     },
 );
 
-my $is_ok = analysis_star_aln(
+my $is_ok = analysis_star_aln_mixed(
     {
         active_parameter_href   => \%active_parameter,
         file_info_href          => \%file_info,

--- a/t/get_rg_header_line.t
+++ b/t/get_rg_header_line.t
@@ -1,0 +1,98 @@
+#!/usr/bin/env perl
+
+use 5.026;
+use Carp;
+use charnames qw{ :full :short };
+use English qw{ -no_match_vars };
+use File::Basename qw{ dirname };
+use File::Spec::Functions qw{ catdir };
+use FindBin qw{ $Bin };
+use open qw{ :encoding(UTF-8) :std };
+use Params::Check qw{ allow check last_error };
+use Test::More;
+use utf8;
+use warnings qw{ FATAL utf8 };
+
+## CPANM
+use autodie qw { :all };
+use Modern::Perl qw{ 2018 };
+use Readonly;
+
+## MIPs lib/
+use lib catdir( dirname($Bin), q{lib} );
+use MIP::Constants qw{ $COMMA $SPACE };
+use MIP::Test::Fixtures qw{ test_standard_cli };
+
+my $VERBOSE = 1;
+our $VERSION = 1.00;
+
+$VERBOSE = test_standard_cli(
+    {
+        verbose => $VERBOSE,
+        version => $VERSION,
+    }
+);
+
+BEGIN {
+
+    use MIP::Test::Fixtures qw{ test_import };
+
+### Check all internal dependency modules and imports
+## Modules with import
+    my %perl_module = (
+        q{MIP::Sample_info}    => [qw{ get_rg_header_line }],
+        q{MIP::Test::Fixtures} => [qw{ test_standard_cli }],
+    );
+
+    test_import( { perl_module_href => \%perl_module, } );
+}
+
+use MIP::Sample_info qw{ get_rg_header_line };
+
+diag(   q{Test get_rg_header_line from Sample_info.pm v}
+      . $MIP::Sample_info::VERSION
+      . $COMMA
+      . $SPACE . q{Perl}
+      . $SPACE
+      . $PERL_VERSION
+      . $SPACE
+      . $EXECUTABLE_NAME );
+
+## Given input parameters
+my %sample_info = (
+    sample => {
+        ADM1059A1 => {
+            file => {
+                ADM1059A1_161011_TestFilev2_GAGATTCC_lane1 => {
+                    read_direction_file => {
+                        ADM1059A1_161011_TestFilev2_GAGATTCC_lane1_1 => {
+                            flowcell       => q{TestFilev2},
+                            lane           => q{1},
+                            sample_barcode => q{GAGATTC},
+                        },
+                    },
+                },
+            },
+        },
+    },
+);
+
+my %active_parameter = ( platform => q{ILLUMINA}, );
+my $infile_prefix    = q{ADM1059A1_161011_TestFilev2_GAGATTCC_lane1};
+
+my $rg_header_line = get_rg_header_line(
+    {
+        infile_prefix    => $infile_prefix,
+        platform         => $active_parameter{platform},
+        sample_id        => q{ADM1059A1},
+        sample_info_href => \%sample_info,
+        separator        => q{\t},
+    }
+);
+
+## Then return expected read group header line
+my $expected_rg_header_line =
+q{ID:ADM1059A1_161011_TestFilev2_GAGATTCC_lane1\tLB:ADM1059A1\tPL:ILLUMINA\tPU:TestFilev2.1.GAGATTC\tSM:ADM1059A1};
+is( $rg_header_line, $expected_rg_header_line, q{Get read group header line} );
+
+done_testing();

--- a/t/picardtools_addorreplacereadgroups.t
+++ b/t/picardtools_addorreplacereadgroups.t
@@ -25,7 +25,7 @@ use MIP::Test::Commands qw{ test_function };
 use MIP::Test::Fixtures qw{ test_standard_cli };
 
 my $VERBOSE = 1;
-our $VERSION = 1.01;
+our $VERSION = 1.02;
 
 $VERBOSE = test_standard_cli(
     {
@@ -139,6 +139,32 @@ my $module_function_cref = \&picardtools_addorreplacereadgroups;
 
 ## Test both base and function specific arguments
 my @arguments = ( \%base_argument, \%specific_argument );
+
+ARGUMENT_HASH_REF:
+foreach my $argument_href (@arguments) {
+    my @commands = test_function(
+        {
+            argument_href              => $argument_href,
+            do_test_base_command       => 1,
+            function_base_commands_ref => \@function_base_commands,
+            module_function_cref       => $module_function_cref,
+            required_argument_href     => \%required_argument,
+        }
+    );
+}
+
+## Base arguments
+@function_base_commands = qw{ picard java };
+
+my %specific_java_argument = (
+    java_jar => {
+        input           => q{gatk.jar},
+        expected_output => q{-jar gatk.jar},
+    },
+);
+
+## Test both base and function specific arguments
+@arguments = ( \%specific_java_argument );
 
 ARGUMENT_HASH_REF:
 foreach my $argument_href (@arguments) {

--- a/t/picardtools_markduplicates.t
+++ b/t/picardtools_markduplicates.t
@@ -25,7 +25,7 @@ use MIP::Test::Commands qw{ test_function };
 use MIP::Test::Fixtures qw{ test_standard_cli };
 
 my $VERBOSE = 1;
-our $VERSION = 1.02;
+our $VERSION = 1.03;
 
 $VERBOSE = test_standard_cli(
     {
@@ -59,6 +59,9 @@ diag(   q{Test picardtools_markduplicates from Picardtools.pm v}
       . $PERL_VERSION
       . $SPACE
       . $EXECUTABLE_NAME );
+
+## Constants
+Readonly my $DISTANCE => 2500;
 
 ## Base arguments
 my @function_base_commands = qw{ picard MarkDuplicates };
@@ -105,6 +108,10 @@ my %specific_argument = (
     metrics_file => {
         input           => q{metric_file},
         expected_output => q{-METRICS_FILE} . $SPACE . q{metric_file},
+    },
+    optical_duplicate_distance => {
+        input           => $DISTANCE,
+        expected_output => q{-OPTICAL_DUPLICATE_PIXEL_DISTANCE} . $SPACE . $DISTANCE,
     },
     outfile_path => {
         input           => catfile(qw{ out_directory outfile }),

--- a/t/set_recipe_star_aln.t
+++ b/t/set_recipe_star_aln.t
@@ -1,0 +1,106 @@
+#!/usr/bin/env perl
+
+use 5.026;
+use Carp;
+use charnames qw{ :full :short };
+use English qw{ -no_match_vars };
+use File::Basename qw{ dirname };
+use File::Spec::Functions qw{ catdir };
+use FindBin qw{ $Bin };
+use open qw{ :encoding(UTF-8) :std };
+use Params::Check qw{ allow check last_error };
+use Test::More;
+use utf8;
+use warnings qw{ FATAL utf8 };
+
+## CPANM
+use autodie qw { :all };
+use Modern::Perl qw{ 2018 };
+use Readonly;
+
+## MIPs lib/
+use lib catdir( dirname($Bin), q{lib} );
+use MIP::Constants qw{ $COMMA $SPACE };
+use MIP::Test::Fixtures qw{ test_standard_cli };
+
+my $VERBOSE = 1;
+our $VERSION = 1.00;
+
+$VERBOSE = test_standard_cli(
+    {
+        verbose => $VERBOSE,
+        version => $VERSION,
+    }
+);
+
+BEGIN {
+
+    use MIP::Test::Fixtures qw{ test_import };
+
+### Check all internal dependency modules and imports
+## Modules with import
+    my %perl_module = (
+        q{MIP::Set::Analysis}  => [qw{ set_recipe_star_aln }],
+        q{MIP::Test::Fixtures} => [qw{ test_standard_cli }],
+    );
+
+    test_import( { perl_module_href => \%perl_module, } );
+}
+
+use MIP::Recipes::Analysis::Star_aln qw{ analysis_star_aln analysis_star_aln_mixed };
+use MIP::Set::Analysis qw{ set_recipe_star_aln };
+
+diag(   q{Test set_recipe_star_aln from Analysis.pm v}
+      . $MIP::Set::Analysis::VERSION
+      . $COMMA
+      . $SPACE . q{Perl}
+      . $SPACE
+      . $PERL_VERSION
+      . $SPACE
+      . $EXECUTABLE_NAME );
+
+## Given a sample with only paired end fastq files.
+my $sample_id               = q{test};
+my %infile_lane_prefix_hash = ( $sample_id => [qw{ lane1 lane2 }], );
+my %sample_info             = (
+    sample => {
+        $sample_id => {
+            file => {
+                lane1 => {
+                    sequence_run_type => q{paired-end},
+                },
+                lane2 => {
+                    sequence_run_type => q{paired-end},
+                },
+            },
+        },
+    },
+);
+my %analysis_recipe;
+
+## Then use analysis_star_aln recipe
+set_recipe_star_aln(
+    {
+        analysis_recipe_href    => \%analysis_recipe,
+        infile_lane_prefix_href => \%infile_lane_prefix_hash,
+        sample_info_href        => \%sample_info,
+    }
+);
+is( $analysis_recipe{star_aln},
+    \&analysis_star_aln, q{Set star_aln single sequence run type} );
+
+## Given a sample with mixed single and paired end fastq files.
+$sample_info{sample}{$sample_id}{file}{lane2}{sequence_run_type} = q{single-end};
+
+## Then use analysis_star_aln recipe_mixed
+set_recipe_star_aln(
+    {
+        analysis_recipe_href    => \%analysis_recipe,
+        infile_lane_prefix_href => \%infile_lane_prefix_hash,
+        sample_info_href        => \%sample_info,
+    }
+);
+is( $analysis_recipe{star_aln},
+    \&analysis_star_aln_mixed, q{Set star_aln multiple sequence run type} );
+
+done_testing();

--- a/t/star_aln.t
+++ b/t/star_aln.t
@@ -26,7 +26,7 @@ use MIP::Test::Commands qw{ test_function };
 use MIP::Test::Fixtures qw{ test_standard_cli };
 
 my $VERBOSE = 1;
-our $VERSION = 1.03;
+our $VERSION = 1.04;
 
 $VERBOSE = test_standard_cli(
     {
@@ -198,6 +198,10 @@ my %specific_argument = (
     out_filter_multimap_nmax => {
         input           => 1,
         expected_output => q{--outFilterMultimapNmax 1},
+    },
+    out_sam_attr_rgline => {
+        input           => q{ID:xxx},
+        expected_output => q{--outSAMattrRGline ID:xxx},
     },
     out_sam_strand_field => {
         input           => q{intronMotif},


### PR DESCRIPTION
### This PR fixes:
- Align all sample fastq files in one STAR command if the sequence type
  is the same
- STAR adds read group on the fly
- Introduces optical duplicate distance for picardtools markduplicates.
  Default 2500

### How to test:

- Automatic and continuous test pass

### Expected outcome:
- Installation, unit and integration tests pass

### Review:
- [ ] Code review
- [ ] New code is executed and covered by tests
- [ ] Tests pass
