### PR TITLE
Feature/vcf2cytosure blacklist

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,12 +6,14 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 - STAR aligns sample fastq files with the same sequnece mode (eg. single-end or paired-end) within one job
 - Dropped option to run sambamba markduplicates for RNA
 - Added SMNCopyNumberCaller to MIP for SMN calling with WGS data
+- Added downlod of vcf2cytosure blacklist file for grch37
 
 **CLI**
 - New CLI option for picard markduplicates optical duplicate distance. Default: 2500
 - Removed sambamba markduplicates CLI options from RNA
 - Removed CLI optono markduplicates_no_bam_to_cram
 - New analysis recipe option for smncopynumbercaller
+- New option for vcf2cytosure "--vcf2cytosure_blacklist"
 
 ## [8.0.0]
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,9 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 - New analysis recipe option for smncopynumbercaller
 - New option for vcf2cytosure "--vcf2cytosure_blacklist"
 
+**Tools**
+- vcf2cytosure: 0.4.3 -> 0.5.0
+
 ## [8.0.0]
 
 - Added BAM contigs set to allow for single ladies to get a proper check sex (no pun intended:). Actually it is for all female only analyses.

--- a/definitions/download_rd_dna_parameters.yaml
+++ b/definitions/download_rd_dna_parameters.yaml
@@ -241,6 +241,7 @@ recipe_core_number:
     scout_exons: 1
     svrank_model: 1
     sv_fqa_vcfanno_config: 1
+    vcf2cytosure_blacklist_regions: 1
   type: mip
 recipe_memory:
   associated_recipe:
@@ -288,6 +289,7 @@ recipe_time:
     scout_exons: 1
     svrank_model: 1
     sv_fqa_vcfanno_config: 1
+    vcf2cytosure_blacklist_regions: 1
   type: mip
 reduced_penetrance:
   analysis_mode: case
@@ -329,7 +331,7 @@ sv_fqa_vcfanno_config:
   data_type: SCALAR
   default: 1
   type: recipe
-vcf2cytosure_blacklist:
+vcf2cytosure_blacklist_regions:
   analysis_mode: case
   associated_recipe:
    - mip

--- a/definitions/download_rd_dna_parameters.yaml
+++ b/definitions/download_rd_dna_parameters.yaml
@@ -329,3 +329,10 @@ sv_fqa_vcfanno_config:
   data_type: SCALAR
   default: 1
   type: recipe
+vcf2cytosure_blacklist:
+  analysis_mode: case
+  associated_recipe:
+   - mip
+  data_type: SCALAR
+  default: 1
+  type: recipe

--- a/definitions/dragen_rd_dna_initiation_map.yaml
+++ b/definitions/dragen_rd_dna_initiation_map.yaml
@@ -8,7 +8,6 @@ CHAIN_ALL:
          - sv_vcfparser
          - sv_rankvariant
          - sv_reformat
-         - vcf2cytosure_ar
    - CHAIN_MAIN:
       - prepareforvariantannotationblock
       - rhocall_ar
@@ -22,4 +21,4 @@ CHAIN_ALL:
       - endvariantannotationblock
    - version_collect_ar
    - analysisrunstatus
-   - sacct 
+   - sacct

--- a/definitions/dragen_rd_dna_parameters.yaml
+++ b/definitions/dragen_rd_dna_parameters.yaml
@@ -77,7 +77,6 @@ recipe_core_number:
     sv_reformat: 1
     sv_varianteffectpredictor: 0
     sv_vcfparser: 16
-    vcf2cytosure_ar: 0
     version_collect_ar: 1
     vt_ar: 13
     vt_core: 1
@@ -95,7 +94,6 @@ recipe_memory:
     sv_reformat: 24
     sv_varianteffectpredictor: 7
     varianteffectpredictor: 7
-    vcf2cytosure_ar: 6
   type: mip
 recipe_time:
   associated_recipe:

--- a/definitions/rd_dna_parameters.yaml
+++ b/definitions/rd_dna_parameters.yaml
@@ -885,6 +885,15 @@ vcf2cytosure_ar:
     - TIDDIT.py
     - vcf2cytosure
   type: recipe
+vcf2cytosure_blacklist:
+  associated_recipe:
+   - vcf2cytosure_ar
+  data_type: SCALAR
+  exists_check: file
+  is_reference: 1
+  mandatory: no
+  reference: reference_dir
+  type: path
 vcf2cytosure_exclude_filter:
   associated_recipe:
    - vcf2cytosure_ar

--- a/definitions/rd_dna_vcf_rerun_initiation_map.yaml
+++ b/definitions/rd_dna_vcf_rerun_initiation_map.yaml
@@ -7,7 +7,6 @@ CHAIN_ALL:
          - sv_vcfparser
          - sv_rankvariant
          - sv_reformat
-         - vcf2cytosure_ar
    - CHAIN_MAIN:
       - vcf_rerun_reformat
       - prepareforvariantannotationblock

--- a/definitions/rd_dna_vcf_rerun_parameters.yaml
+++ b/definitions/rd_dna_vcf_rerun_parameters.yaml
@@ -61,7 +61,6 @@ recipe_core_number:
     sv_varianteffectpredictor: 0
     sv_vcf_rerun_reformat: 1
     sv_vcfparser: 13
-    vcf2cytosure_ar: 0
     vcf_rerun_reformat: 1
     version_collect_ar: 1
     vt_ar: 13
@@ -80,7 +79,6 @@ recipe_memory:
     sv_reformat: 24
     sv_varianteffectpredictor: 9
     varianteffectpredictor: 7
-    vcf2cytosure_ar: 6
   type: mip
 recipe_time:
   associated_recipe:

--- a/lib/MIP/Cli/Mip/Analyse/Rd_dna.pm
+++ b/lib/MIP/Cli/Mip/Analyse/Rd_dna.pm
@@ -17,7 +17,7 @@ use Moose::Util::TypeConstraints;
 ## MIPs lib
 use MIP::Main::Analyse qw{ mip_analyse };
 
-our $VERSION = 1.43;
+our $VERSION = 1.44;
 
 extends(qw{ MIP::Cli::Mip::Analyse });
 
@@ -940,6 +940,15 @@ q{Default: grch37_dbsnp_-138-.vcf, grch37_1000g_indels_-phase1-.vcf, grch37_mill
 q{Convert a VCF with structural variants to the “.CGH” format used by the commercial Cytosure software},
             is  => q{rw},
             isa => enum( [ 0, 1, 2 ] ),
+        )
+    );
+
+    option(
+        q{vcf2cytosure_blacklist} => (
+            cmd_aliases   => [qw{ v2cbl }],
+            documentation => q{Exclude regions file path},
+            is            => q{rw},
+            isa           => Str,
         )
     );
 

--- a/lib/MIP/Program/Vcf2cytosure.pm
+++ b/lib/MIP/Program/Vcf2cytosure.pm
@@ -25,7 +25,7 @@ BEGIN {
     use base qw{ Exporter };
 
     # Set the version for version checking
-    our $VERSION = 1.05;
+    our $VERSION = 1.06;
 
     # Functions and variables which can be optionally exported
     our @EXPORT_OK = qw{ vcf2cytosure_convert };
@@ -33,9 +33,10 @@ BEGIN {
 
 sub vcf2cytosure_convert {
 
-## Function : Perl wrapper for Vcf2cytosure 0.4.3.
+## Function : Perl wrapper for Vcf2cytosure 0.5.0.
 ## Returns  : @commands
-## Arguments: $coverage_file          => Path to coverage file
+## Arguments: $blacklist_file_path    => List of regions to exclude file path
+##          : $coverage_file          => Path to coverage file
 ##          : $filehandle             => Filehandle to write to
 ##          : $frequency              => Maximum frequency
 ##          : $frequency_tag          => Frequency tag of the info field
@@ -53,6 +54,7 @@ sub vcf2cytosure_convert {
     my ($arg_href) = @_;
 
     ## Flatten argument(s)
+    my $blacklist_file_path;
     my $coverage_file;
     my $filehandle;
     my $maxbnd;
@@ -71,6 +73,10 @@ sub vcf2cytosure_convert {
     my $version;
 
     my $tmpl = {
+        blacklist_file_path => {
+            store       => \$blacklist_file_path,
+            strict_type => 1,
+        },
         coverage_file => {
             defined     => 1,
             required    => 1,
@@ -156,6 +162,10 @@ sub vcf2cytosure_convert {
         push @commands, q{--version};
     }
 
+    if ($blacklist_file_path) {
+
+        push @commands, q{--blacklist} . $SPACE . $blacklist_file_path;
+    }
     if ($variant_size) {
 
         push @commands, q{--size} . $SPACE . $variant_size;

--- a/lib/MIP/Recipes/Analysis/Vcf2cytosure.pm
+++ b/lib/MIP/Recipes/Analysis/Vcf2cytosure.pm
@@ -25,7 +25,7 @@ BEGIN {
     use base qw{ Exporter };
 
     # Set the version for version checking
-    our $VERSION = 1.18;
+    our $VERSION = 1.19;
 
     # Functions and variables which can be optionally exported
     our @EXPORT_OK = qw{ analysis_vcf2cytosure };
@@ -364,13 +364,14 @@ sub analysis_vcf2cytosure {
 
         vcf2cytosure_convert(
             {
-                coverage_file   => $vcf2cytosure_file_info{$sample_id}{in}{q{.tab}},
-                filehandle      => $filehandle,
-                maxbnd          => $active_parameter_href->{vcf2cytosure_maxbnd},
-                outfile_path    => $outfile_path{$sample_id},
-                sex             => $sample_id_sex,
-                variant_size    => $active_parameter_href->{vcf2cytosure_var_size},
-                vcf_infile_path => $vcf2cytosure_file_info{$sample_id}{in}{q{.vcf}},
+                blacklist_file_path => $active_parameter_href->{vcf2cytosure_blacklist},
+                coverage_file       => $vcf2cytosure_file_info{$sample_id}{in}{q{.tab}},
+                filehandle          => $filehandle,
+                maxbnd              => $active_parameter_href->{vcf2cytosure_maxbnd},
+                outfile_path        => $outfile_path{$sample_id},
+                sex                 => $sample_id_sex,
+                variant_size        => $active_parameter_href->{vcf2cytosure_var_size},
+                vcf_infile_path     => $vcf2cytosure_file_info{$sample_id}{in}{q{.vcf}},
             }
         );
         say {$filehandle} $AMPERSAND . $SPACE . $NEWLINE;

--- a/lib/MIP/Recipes/Download/Vcf2cytosure_blacklist_regions.pm
+++ b/lib/MIP/Recipes/Download/Vcf2cytosure_blacklist_regions.pm
@@ -1,4 +1,4 @@
-package MIP::Recipes::Download::RECIPE_NAME;
+package MIP::Recipes::Download::Vcf2cytosure_blacklist_regions;
 
 use 5.026;
 use Carp;
@@ -28,13 +28,13 @@ BEGIN {
     our $VERSION = 1.00;
 
     # Functions and variables which can be optionally exported
-    our @EXPORT_OK = qw{ download_RECIPE_NAME };
+    our @EXPORT_OK = qw{ download_vcf2cytosure_blacklist_regions };
 
 }
 
-sub download_RECIPE_NAME {
+sub download_vcf2cytosure_blacklist_regions {
 
-## Function : Download RECIPE_NAME
+## Function : Download vcf2cytosure blacklist files
 ## Returns  :
 ## Arguments: $active_parameter_href => Active parameters for this download hash {REF}
 ##          : $genome_version        => Human genome version

--- a/lib/MIP/Recipes/Pipeline/Download_rd_dna.pm
+++ b/lib/MIP/Recipes/Pipeline/Download_rd_dna.pm
@@ -25,7 +25,7 @@ BEGIN {
     use base qw{ Exporter };
 
     # Set the version for version checking
-    our $VERSION = 1.14;
+    our $VERSION = 1.15;
 
     # Functions and variables which can be optionally exported
     our @EXPORT_OK = qw{ pipeline_download_rd_dna };
@@ -118,6 +118,8 @@ sub pipeline_download_rd_dna {
     use MIP::Recipes::Download::Svrank_model qw{ download_svrank_model };
     use MIP::Recipes::Download::Sv_fqa_vcfanno_config
       qw{ download_sv_fqa_vcfanno_config };
+    use MIP::Recipes::Download::Vcf2cytosure_blacklist_regions
+      qw{ download_vcf2cytosure_blacklist_regions };
 
     ## Retrieve logger object now that log_file has been set
     my $log = Log::Log4perl->get_logger( uc q{mip_download} );
@@ -125,38 +127,39 @@ sub pipeline_download_rd_dna {
     ### Download recipes
     ## Create code reference table for download recipes
     my %download_recipe = (
-        q{1000g_all_sv}          => \&download_1000g_all_sv,
-        q{1000g_all_wgs}         => \&download_1000g_all_wgs,
-        q{1000g_indels}          => \&download_1000g_indels,
-        q{1000g_omni}            => \&download_1000g_omni,
-        q{1000g_sites}           => \&download_1000g_sites,
-        q{1000g_snps}            => \&download_1000g_snps,
-        cadd_bravo_topmed        => \&download_cadd_bravo_topmed,
-        cadd_gnomad_genomes      => \&download_cadd_gnomad_genomes,
-        cadd_offline_annotations => \&download_cadd_offline_annotations,
-        cadd_to_vcf_header       => \&download_cadd_to_vcf_header,
-        cadd_whole_genome_snvs   => \&download_cadd_whole_genome_snvs,
-        clinvar                  => \&download_clinvar,
-        dbnsfp                   => \&download_dbnsfp,
-        dbsnp                    => \&download_dbsnp,
-        delly_exclude            => \&download_delly_exclude,
-        expansionhunter          => \&download_expansionhunter,
-        fqa_vcfanno_config       => \&download_fqa_vcfanno_config,
-        gatk_mitochondrial_ref   => \&download_gatk_mitochondrial_ref,
-        genbank_haplogroup       => \&download_genbank_haplogroup,
-        genomic_superdups        => \&download_genomic_superdups,
-        giab                     => \&download_giab,
-        gnomad                   => \&download_gnomad,
-        gnomad_pli_per_gene      => \&download_gnomad_pli_per_gene,
-        hapmap                   => \&download_hapmap,
-        human_reference          => \&download_human_reference,
-        manta_call_regions       => \&download_manta_call_regions,
-        mills_and_1000g_indels   => \&download_mills_and_1000g_indels,
-        rank_model               => \&download_rank_model,
-        reduced_penetrance       => \&download_reduced_penetrance,
-        scout_exons              => \&download_scout_exons,
-        svrank_model             => \&download_svrank_model,
-        sv_fqa_vcfanno_config    => \&download_sv_fqa_vcfanno_config,
+        q{1000g_all_sv}                => \&download_1000g_all_sv,
+        q{1000g_all_wgs}               => \&download_1000g_all_wgs,
+        q{1000g_indels}                => \&download_1000g_indels,
+        q{1000g_omni}                  => \&download_1000g_omni,
+        q{1000g_sites}                 => \&download_1000g_sites,
+        q{1000g_snps}                  => \&download_1000g_snps,
+        cadd_bravo_topmed              => \&download_cadd_bravo_topmed,
+        cadd_gnomad_genomes            => \&download_cadd_gnomad_genomes,
+        cadd_offline_annotations       => \&download_cadd_offline_annotations,
+        cadd_to_vcf_header             => \&download_cadd_to_vcf_header,
+        cadd_whole_genome_snvs         => \&download_cadd_whole_genome_snvs,
+        clinvar                        => \&download_clinvar,
+        dbnsfp                         => \&download_dbnsfp,
+        dbsnp                          => \&download_dbsnp,
+        delly_exclude                  => \&download_delly_exclude,
+        expansionhunter                => \&download_expansionhunter,
+        fqa_vcfanno_config             => \&download_fqa_vcfanno_config,
+        gatk_mitochondrial_ref         => \&download_gatk_mitochondrial_ref,
+        genbank_haplogroup             => \&download_genbank_haplogroup,
+        genomic_superdups              => \&download_genomic_superdups,
+        giab                           => \&download_giab,
+        gnomad                         => \&download_gnomad,
+        gnomad_pli_per_gene            => \&download_gnomad_pli_per_gene,
+        hapmap                         => \&download_hapmap,
+        human_reference                => \&download_human_reference,
+        manta_call_regions             => \&download_manta_call_regions,
+        mills_and_1000g_indels         => \&download_mills_and_1000g_indels,
+        rank_model                     => \&download_rank_model,
+        reduced_penetrance             => \&download_reduced_penetrance,
+        scout_exons                    => \&download_scout_exons,
+        svrank_model                   => \&download_svrank_model,
+        sv_fqa_vcfanno_config          => \&download_sv_fqa_vcfanno_config,
+        vcf2cytosure_blacklist_regions => \&download_vcf2cytosure_blacklist_regions,
     );
 
     # Storing job_ids from SLURM, however currently all are independent

--- a/t/data/test_data/download_active_parameters.yaml
+++ b/t/data/test_data/download_active_parameters.yaml
@@ -108,11 +108,13 @@ reference:
   reduced_penetrance:
     - 2017
   scout_exons:
-    - 201701 
+    - 201701
   svrank_model:
     - v1.8
   sv_fqa_vcfanno_config:
     - v1.2
+  vcf2cytosure_blacklist_regions:
+    - 1.0
 reference_feature:
   1000g_all_sv:
     grch37:
@@ -489,7 +491,7 @@ reference_feature:
         outfile: grch37_genbank_haplogroup_-2015-08-01-.vcf.gz
         outfile_check: grch37_genbank_haplogroup_-2015-08-01-.vcf.gz.md5
         outfile_check_method: md5sum
-        url_prefix: https://raw.githubusercontent.com/Clinical-Genomics/reference-files/master/rare-disease/frequency/ 
+        url_prefix: https://raw.githubusercontent.com/Clinical-Genomics/reference-files/master/rare-disease/frequency/
   gencode_annotation:
     grch37:
       v29:
@@ -654,7 +656,7 @@ reference_feature:
         outfile: rank_model_cmms_-v1.25-.ini
         outfile_check: rank_model_cmms_-v1.25-.ini.md5
         outfile_check_method: md5sum
-        url_prefix: https://raw.githubusercontent.com/Clinical-Genomics/reference-files/master/rare-disease/rank_model/ 
+        url_prefix: https://raw.githubusercontent.com/Clinical-Genomics/reference-files/master/rare-disease/rank_model/
   reduced_penetrance:
     grch37:
       2017:
@@ -689,6 +691,15 @@ reference_feature:
         outfile_check: grch37_frequency_vcfanno_filter_config_-v1.2-.toml.md5
         outfile_check_method: md5sum
         url_prefix: https://raw.githubusercontent.com/Clinical-Genomics/reference-files/master/rare-disease/annotation/
+  vcf2cytosure_blacklist_regions:
+    grch37:
+      1.0:
+        file: grch37_cytosure_blacklist_-1.0-.bed
+        file_check: grch37_cytosure_blacklist_-1.0-.bed.md5
+        outfile: grch37_cytosure_blacklist_-1.0-.bed
+        outfile_check: grch37_cytosure_blacklist_-1.0-.bed.md5
+        outfile_check_method: md5sum
+        url_prefix: https://raw.githubusercontent.com/Clinical-Genomics/reference-files/master/rare-disease/region/
 reference_genome_versions:
   - grch37
   - grch38
@@ -707,4 +718,3 @@ sacct_format_fields:
 sbatch_mode: 1
 submission_profile: slurm
 verbose: '0'
-

--- a/t/download_vcf2cytosure.t
+++ b/t/download_vcf2cytosure.t
@@ -1,0 +1,105 @@
+#!/usr/bin/env perl
+
+use 5.026;
+use Carp;
+use charnames qw{ :full :short };
+use English qw{ -no_match_vars };
+use File::Basename qw{ dirname };
+use File::Spec::Functions qw{ catdir catfile };
+use File::Temp;
+use FindBin qw{ $Bin };
+use open qw{ :encoding(UTF-8) :std };
+use Params::Check qw{ allow check last_error };
+use Test::More;
+use utf8;
+use warnings qw{ FATAL utf8 };
+
+## CPANM
+use autodie qw { :all };
+use Modern::Perl qw{ 2018 };
+use Readonly;
+
+## MIPs lib/
+use lib catdir( dirname($Bin), q{lib} );
+use MIP::Constants qw{ $COMMA $SPACE };
+use MIP::Test::Fixtures qw{ test_log test_mip_hashes test_standard_cli };
+
+my $VERBOSE = 1;
+our $VERSION = 1.00;
+
+$VERBOSE = test_standard_cli(
+    {
+        verbose => $VERBOSE,
+        version => $VERSION,
+    }
+);
+
+BEGIN {
+
+    use MIP::Test::Fixtures qw{ test_import };
+
+### Check all internal dependency modules and imports
+## Modules with import
+    my %perl_module = (
+        q{MIP::Recipes::Download::Vcf2cytosure_blacklist_regions} =>
+          [qw{ download_vcf2cytosure_blacklist_regions }],
+        q{MIP::Test::Fixtures} => [qw{ test_log test_mip_hashes test_standard_cli }],
+    );
+
+    test_import( { perl_module_href => \%perl_module, } );
+}
+
+use MIP::Recipes::Download::Vcf2cytosure_blacklist_regions
+  qw{ download_vcf2cytosure_blacklist_regions };
+
+diag(   q{Test download_vcf2cytosure_blacklist_regions from Vcf2cytosure.pm v}
+      . $MIP::Recipes::Download::Vcf2cytosure_blacklist_regions::VERSION
+      . $COMMA
+      . $SPACE . q{Perl}
+      . $SPACE
+      . $PERL_VERSION
+      . $SPACE
+      . $EXECUTABLE_NAME );
+
+my $test_dir  = File::Temp->newdir();
+my $file_path = catfile( $test_dir, q{recipe_script.sh} );
+my $log       = test_log( { log_name => uc q{mip_download}, no_screen => 1, } );
+
+## Given download parameters for recipe
+my $genome_version    = q{grch37};
+my $recipe_name       = q{vcf2cytosure_blacklist_regions};
+my $reference_version = q{1.0};
+my $slurm_mock_cmd    = catfile( $Bin, qw{ data modules slurm-mock.pl } );
+
+my %active_parameter = test_mip_hashes(
+    {
+        mip_hash_name => q{download_active_parameter},
+    }
+);
+$active_parameter{$recipe_name}                     = 1;
+$active_parameter{project_id}                       = q{test};
+$active_parameter{reference_dir}                    = catfile($test_dir);
+$active_parameter{recipe_core_number}{$recipe_name} = 1;
+$active_parameter{recipe_time}{$recipe_name}        = 1;
+my $reference_href =
+  $active_parameter{reference_feature}{$recipe_name}{$genome_version}{$reference_version};
+
+my %job_id;
+
+my $is_ok = download_vcf2cytosure_blacklist_regions(
+    {
+        active_parameter_href => \%active_parameter,
+        genome_version        => $genome_version,
+        job_id_href           => \%job_id,
+        profile_base_command  => $slurm_mock_cmd,
+        recipe_name           => $recipe_name,
+        reference_href        => $reference_href,
+        reference_version     => $reference_version,
+        temp_directory        => catfile($test_dir),
+    }
+);
+
+## Then
+ok( $is_ok, q{ Executed download recipe } . $recipe_name );
+
+done_testing();

--- a/t/vcf2cytosure.t
+++ b/t/vcf2cytosure.t
@@ -25,7 +25,7 @@ use MIP::Test::Commands qw{ test_function };
 use MIP::Test::Fixtures qw{ test_standard_cli };
 
 my $VERBOSE = 1;
-our $VERSION = 1.05;
+our $VERSION = 1.06;
 
 $VERBOSE = test_standard_cli(
     {
@@ -102,6 +102,10 @@ my %required_argument = (
 );
 
 my %specific_argument = (
+    blacklist_file_path => {
+        input           => q{a_file_path},
+        expected_output => q{--blacklist} . $SPACE . q{a_file_path},
+    },
     frequency => {
         input           => $MAX_FREQUENCY,
         expected_output => q{--frequency} . $SPACE . $MAX_FREQUENCY,

--- a/templates/mip_download_rd_dna_config_-1.0-.yaml
+++ b/templates/mip_download_rd_dna_config_-1.0-.yaml
@@ -112,6 +112,8 @@ reference:
     - v1.8
   sv_fqa_vcfanno_config:
     - v1.2
+  vcf2cytosure_blacklist_regions:
+    - 1.0
 reference_feature:
   human_reference:
     grch37:
@@ -797,3 +799,12 @@ reference_feature:
         outfile_check: svrank_model_cmms_-v1.8-.ini.md5
         outfile_check_method: md5sum
         url_prefix: https://raw.githubusercontent.com/Clinical-Genomics/reference-files/master/rare-disease/rank_model/
+  vcf2cytosure_blacklist_regions:
+    grch37:
+      1.0:
+        file: grch37_cytosure_blacklist_-1.0-.bed
+        file_check: grch37_cytosure_blacklist_-1.0-.bed.md5
+        outfile: grch37_cytosure_blacklist_-1.0-.bed
+        outfile_check: grch37_cytosure_blacklist_-1.0-.bed.md5
+        outfile_check_method: md5sum
+        url_prefix: https://raw.githubusercontent.com/Clinical-Genomics/reference-files/master/rare-disease/region/

--- a/templates/mip_dragen_rd_dna_config.yaml
+++ b/templates/mip_dragen_rd_dna_config.yaml
@@ -40,7 +40,6 @@ sv_svdb_query_db_files:
   grch37_svdb_query_clingen_cgh_pathogenic_-v1.0.0-.vcf: clingen_cgh_pathogenic
   grch37_svdb_query_clingen_ngi_-v1.0.0-.vcf: clingen_ngi|AF|OCC|FRQ|OCC|1
   grch37_swegen_concat_sort_-20170830-.vcf: swegen|AF|OCC|FRQ|OCC|1
-vcf2cytosure_blacklist: grch37_cytosure_blacklist_-1.0-.bed
 ### Analysis
 ## Programs
 ## Parameters

--- a/templates/mip_dragen_rd_dna_config.yaml
+++ b/templates/mip_dragen_rd_dna_config.yaml
@@ -40,6 +40,7 @@ sv_svdb_query_db_files:
   grch37_svdb_query_clingen_cgh_pathogenic_-v1.0.0-.vcf: clingen_cgh_pathogenic
   grch37_svdb_query_clingen_ngi_-v1.0.0-.vcf: clingen_ngi|AF|OCC|FRQ|OCC|1
   grch37_swegen_concat_sort_-20170830-.vcf: swegen|AF|OCC|FRQ|OCC|1
+vcf2cytosure_blacklist: grch37_cytosure_blacklist_-1.0-.bed
 ### Analysis
 ## Programs
 ## Parameters

--- a/templates/mip_install_rd_dna_config_-1.0-.yaml
+++ b/templates/mip_install_rd_dna_config_-1.0-.yaml
@@ -150,7 +150,7 @@ singularity:
   vcf2cytosure:
     executable:
       vcf2cytosure:
-    uri: shub://J35P312/vcf2cytosure:0.4.3
+    uri: shub://J35P312/vcf2cytosure:0.5.0
   vt:
     executable:
       vt:

--- a/templates/mip_rd_dna_config.yaml
+++ b/templates/mip_rd_dna_config.yaml
@@ -43,6 +43,7 @@ sv_svdb_query_db_files:
   grch37_svdb_query_clingen_ngi_-v1.0.0-.vcf: clingen_ngi|AF|OCC|FRQ|OCC|1
   grch37_swegen_concat_sort_-20170830-.vcf: swegen|AF|OCC|FRQ|OCC|1
 qccollect_regexp_file: qc_regexp_-v1.24-.yaml
+vcf2cytosure_blacklist: grch37_cytosure_blacklist_-1.0-.bed 
 ### Analysis
 ### Programs
 ## Parameters

--- a/templates/mip_rd_dna_vcf_rerun_config.yaml
+++ b/templates/mip_rd_dna_vcf_rerun_config.yaml
@@ -40,7 +40,6 @@ sv_svdb_query_db_files:
   grch37_svdb_query_clingen_cgh_pathogenic_-v1.0.0-.vcf: clingen_cgh_pathogenic
   grch37_svdb_query_clingen_ngi_-v1.0.0-.vcf: clingen_ngi|AF|OCC|FRQ|OCC|1
   grch37_swegen_concat_sort_-20170830-.vcf: swegen|AF|OCC|FRQ|OCC|1
-vcf2cytosure_blacklist: grch37_cytosure_blacklist_-1.0-.bed
 ### Analysis
 ## Programs
 ## Parameters

--- a/templates/mip_rd_dna_vcf_rerun_config.yaml
+++ b/templates/mip_rd_dna_vcf_rerun_config.yaml
@@ -40,6 +40,7 @@ sv_svdb_query_db_files:
   grch37_svdb_query_clingen_cgh_pathogenic_-v1.0.0-.vcf: clingen_cgh_pathogenic
   grch37_svdb_query_clingen_ngi_-v1.0.0-.vcf: clingen_ngi|AF|OCC|FRQ|OCC|1
   grch37_swegen_concat_sort_-20170830-.vcf: swegen|AF|OCC|FRQ|OCC|1
+vcf2cytosure_blacklist: grch37_cytosure_blacklist_-1.0-.bed
 ### Analysis
 ## Programs
 ## Parameters


### PR DESCRIPTION
### This PR fixes:

- Updated vcf2cytosure to 0.5.0
- Added blacklist bed file to mip download
- Adds new cli option to vcf2cytosure "--blacklist"
- Adds a default for option blacklist to configs
- Use option in vcf2cytosure recipe

### How to test:

- Automatic and continuous test pass

### Expected outcome:
- Installation, unit and integration tests pass
- [x] Install tested on hasta
- [x] Donwload tested on hasta
- [x] Recipe tested on hasta

### Review:
- [x] Code review
- [x] New code is executed and covered by tests
- [x] Tests pass
