### PR TITLE
fix(cpan stuff): fixes for cpan modules

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -18,10 +18,8 @@ before_install:
   - conda info -a
 
   ## Download cpan libraries
-  ## For some reason DB_File installation fails, it is not needed for the test
-  - sed -i '/DB_File/d' ./definitions/cpanfile
-  - cd definitions; cpanm --quiet --notest --installdeps .
-  - cd -
+  - cpanm --quiet --notest --installdeps .
+  
   ## Set up for cpanm dependencies test
   - cpanm --notest Devel::Cover::Report::Coveralls
 

--- a/cpanfile
+++ b/cpanfile
@@ -7,6 +7,7 @@ requires qw{ Data::Diver 1.0101 };                  # MIP
 requires qw{ Data::Printer 0.40 };                  # MIP
 requires qw{ Email::Valid 1.202 };                  # MIP
 requires qw{ File::Find::Rule 0.34 };               # MIP
+requires qw{ IO::Interactive 1.022 };               # MIP
 requires qw{ IPC::System::Simple 1.25 };            # MIP
 requires qw{ List::MoreUtils 0.413 };               # MIP
 requires qw{ List::Util 1.49 };                     # MIP

--- a/cpanfile
+++ b/cpanfile
@@ -7,7 +7,6 @@ requires qw{ Data::Diver 1.0101 };                  # MIP
 requires qw{ Data::Printer 0.40 };                  # MIP
 requires qw{ Email::Valid 1.202 };                  # MIP
 requires qw{ File::Find::Rule 0.34 };               # MIP
-requires qw{ IO::Interactive 1.022 };               # MIP
 requires qw{ IPC::System::Simple 1.25 };            # MIP
 requires qw{ List::MoreUtils 0.413 };               # MIP
 requires qw{ List::Util 1.49 };                     # MIP
@@ -25,4 +24,4 @@ requires qw{ Test::Trap };                          # MIP
 requires qw{ Text::WagnerFischer 0.04 };            # MIP
 requires qw{ TOML::Parser 0.91 };                   # MIP
 requires qw{ Try::Tiny 0.28 };                      # MIP
-requires qw{ YAML::XS 0.81 };                       # MIP
+requires qw{ YAML 1.24 };                           # MIP

--- a/lib/MIP/Check/Modules.pm
+++ b/lib/MIP/Check/Modules.pm
@@ -17,7 +17,7 @@ BEGIN {
     use base qw{ Exporter };
 
     # Set the version for version checking
-    our $VERSION = 1.01;
+    our $VERSION = 1.02;
 
     # Functions and variables which can be optionally exported
     our @EXPORT_OK = qw{ check_perl_modules parse_cpan_file };
@@ -58,6 +58,9 @@ sub check_perl_modules {
 
   MODULE:
     foreach my $module ( @{$modules_ref} ) {
+
+        ## Special case for Readonly::XS since it is not a standalone module
+        $module =~ s{Readonly::XS}{Readonly}sxmg;
 
         ## Replace "::" with "/" since the automatic replacement magic only occurs for barewords.
         $module =~ s{::}{/}sxmg;

--- a/lib/MIP/Check/Unix.pm
+++ b/lib/MIP/Check/Unix.pm
@@ -17,10 +17,10 @@ BEGIN {
     require Exporter;
 
     # Set the version for version checking
-    our $VERSION = 1.06;
+    our $VERSION = 1.07;
 
     # Functions and variables which can be optionally exported
-    our @EXPORT_OK = qw{ check_binary_in_path is_binary_in_path };
+    our @EXPORT_OK = qw{ check_binary_in_path };
 }
 
 sub check_binary_in_path {

--- a/lib/MIP/Main/Analyse.pm
+++ b/lib/MIP/Main/Analyse.pm
@@ -34,8 +34,6 @@ use MIP::Active_parameter qw{
   set_parameter_reference_dir_path
   update_to_absolute_path };
 use MIP::Analysis qw{ get_overall_analysis_type };
-use MIP::Check::Modules qw{ check_perl_modules };
-
 use MIP::Check::Parameter qw{
   check_load_env_packages
   check_recipe_name
@@ -91,7 +89,7 @@ BEGIN {
     require Exporter;
 
     # Set the version for version checking
-    our $VERSION = 1.43;
+    our $VERSION = 1.44;
 
     # Functions and variables which can be optionally exported
     our @EXPORT_OK = qw{ mip_analyse };

--- a/lib/MIP/Main/Vercollect.pm
+++ b/lib/MIP/Main/Vercollect.pm
@@ -22,7 +22,8 @@ use Modern::Perl qw{ 2018 };
 
 ## MIPs lib/
 use MIP::Constants qw{ $SPACE };
-use MIP::Io::Read qw{ read_from_file write_to_file };
+use MIP::Io::Read qw{ read_from_file };
+use MIP::Io::Write qw{ write_to_file };
 
 BEGIN {
 
@@ -30,7 +31,7 @@ BEGIN {
     require Exporter;
 
     # Set the version for version checking
-    our $VERSION = q{1.0.1};
+    our $VERSION = q{1.0.2};
 
     # Functions and variables which can be optionally exported
     our @EXPORT_OK = qw{ mip_vercollect };

--- a/lib/MIP/Recipes/Install/Mip_scripts.pm
+++ b/lib/MIP/Recipes/Install/Mip_scripts.pm
@@ -29,7 +29,7 @@ BEGIN {
     use base qw{ Exporter };
 
     # Set the version for version checking
-    our $VERSION = 1.14;
+    our $VERSION = 1.15;
 
     # Functions and variables which can be optionally exported
     our @EXPORT_OK = qw{ install_mip_scripts };
@@ -111,7 +111,7 @@ sub install_mip_scripts {
     my $pwd = cwd();
 
     ## Define MIP scripts and yaml files
-    my @mip_scripts = qw{ mip };
+    my @mip_scripts = qw{ cpanfile mip };
 
     my %mip_sub_script = (
         utility_scripts => [qw{ calculate_af.pl max_af.pl }],

--- a/lib/MIP/Set/Parameter.pm
+++ b/lib/MIP/Set/Parameter.pm
@@ -25,7 +25,7 @@ BEGIN {
     use base qw{ Exporter };
 
     # Set the version for version checking
-    our $VERSION = 1.30;
+    our $VERSION = 1.31;
 
     # Functions and variables which can be optionally exported
     our @EXPORT_OK = qw{
@@ -65,17 +65,13 @@ sub set_conda_path {
 
     check( $tmpl, $arg_href, 1 ) or croak q{Could not parse arguments!};
 
-    use MIP::Check::Unix qw{ is_binary_in_path };
+    use MIP::Environment qw{ is_binary_in_path };
     use MIP::Get::Parameter qw{ get_conda_path };
-
-    ## Retrieve logger object
-    my $log = Log::Log4perl->get_logger($LOG_NAME);
 
     ## Check if conda is in path
     is_binary_in_path(
         {
             binary => q{conda},
-            log    => $log,
         }
     );
 

--- a/mip
+++ b/mip
@@ -19,7 +19,7 @@ use autodie qw{ :all };
 use lib catdir( $Bin, q{lib} );
 use MIP::Cli::Mip;
 
-our $VERSION = 0.01;
+our $VERSION = 0.02;
 
 BEGIN {
 
@@ -28,7 +28,7 @@ BEGIN {
 
     my @modules =
       parse_cpan_file {
-        cpanfile_path => catfile( $Bin, qw{ definitions cpanfile } ),
+        cpanfile_path => catfile( $Bin, q{cpanfile} ),
       };
 
     ## Evaluate that all modules required are installed

--- a/t/mip_analysis.test
+++ b/t/mip_analysis.test
@@ -39,9 +39,7 @@ BEGIN {
     use MIP::Check::Modules qw{ parse_cpan_file };
 
     my @modules =
-      parse_cpan_file {
-        cpanfile_path => catfile( dirname($Bin), qw{ definitions cpanfile } ),
-      };
+      parse_cpan_file { cpanfile_path => catfile( dirname($Bin), q{cpanfile} ), };
 
     ## Evaluate that all modules required throughout entire analysis are installed
     check_perl_modules(
@@ -55,7 +53,7 @@ BEGIN {
 my ( $config_file, $infile );
 my ( %active_parameter, %parameter, %pedigree, %vcfparser_data, );
 
-our $VERSION = 2.06;
+our $VERSION = 2.07;
 
 if ( scalar @ARGV == 0 ) {
 
@@ -298,7 +296,7 @@ sub test_modules {
     push @ARGV, qw{ -verbose 2 };
     my $verbose = 1;
     ok( GetOptions( q{verbose:n} => \$verbose ), q{Getopt::Long: Get options call} );
-    ok( $verbose == 2, q{Getopt::Long: Get options modified} );
+    ok( $verbose == 2,                           q{Getopt::Long: Get options modified} );
 
     return;
 }

--- a/t/mip_core.t
+++ b/t/mip_core.t
@@ -25,7 +25,7 @@ use MIP::Check::Modules qw{ check_perl_modules };
 use MIP::Script::Utils qw{ help };
 
 my $VERBOSE = 1;
-our $VERSION = 1.10;
+our $VERSION = 1.11;
 
 our $USAGE = build_usage( {} );
 
@@ -259,7 +259,7 @@ sub test_modules {
 
     my $verbose = 1;
     ok( GetOptions( q{verbose:n} => \$verbose ), q{Getopt::Long: Get options call} );
-    ok( $verbose == 2, q{Getopt::Long: Get options modified} );
+    ok( $verbose == 2,                           q{Getopt::Long: Get options modified} );
 
     ## Check time
     use Time::Piece;
@@ -287,7 +287,7 @@ sub mip_scripts {
 ## Returns  :
 ## Arguments:
 
-    my @mip_scripts = qw{ mip };
+    my @mip_scripts = qw{ mip cpanfile };
 
   SCRIPT:
     foreach my $script (@mip_scripts) {
@@ -299,7 +299,6 @@ sub mip_scripts {
         utility_scripts => [qw{ calculate_af.pl max_af.pl }],
         definitions     => [
             qw{ analyse_parameters.yaml
-              cpanfile
               download_rd_dna_parameters.yaml
               download_rd_rna_parameters.yaml
               install_rd_dna_parameters.yaml


### PR DESCRIPTION
### This PR fixes:

Last merge to develop introduced some bugs. 
- Reverts back to using YAML instead of YAML::XS since $YAML::XS::QuoteNumericStrings = 1 didn't seem to work properly. This could most likely be fixed with a clearer head...
- Adds a special case for Readonly::XS when checking for installed cpan modules.
- Updates the path to the cpanfile for those scripts that are using it. 
- Some other random fixes

### How to test:

- Automatic and continuous test pass

### Expected outcome:
- Installation, unit and integration tests pass

### Review:
- [x] Code review
- [ ] New code is executed and covered by tests
- [ ] Tests pass
