### PR TITLE
fix(splitncigarreads): loop over Y for F

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 All notable changes to this project will be documented in this file.
 This project adheres to [Semantic Versioning](http://semver.org/).
 
+## [8.2.2]
+- Fixes a crash in MIP caused by not looping over the Y chromosomes for females in the GATK SplitNCigarReads recipe
+
 ## [8.2.1]
 - Removes multiple identical entries in the store file. Keeps the most recent
 

--- a/lib/MIP/Constants.pm
+++ b/lib/MIP/Constants.pm
@@ -20,7 +20,7 @@ BEGIN {
     use base qw{ Exporter };
 
     # Set the version for version checking
-    our $VERSION = 1.18;
+    our $VERSION = 1.19;
 
     # Functions and variables which can be optionally exported
 
@@ -80,7 +80,7 @@ Readonly our %ANALYSIS => (
 );
 
 ## Set MIP version
-Readonly our $MIP_VERSION => q{v8.2.1};
+Readonly our $MIP_VERSION => q{v8.2.2};
 
 ## Cli
 Readonly our $MOOSEX_APP_SCEEN_WIDTH => 160;

--- a/lib/MIP/Recipes/Analysis/Gatk_splitncigarreads.pm
+++ b/lib/MIP/Recipes/Analysis/Gatk_splitncigarreads.pm
@@ -27,7 +27,7 @@ BEGIN {
     use base qw{ Exporter };
 
     # Set the version for version checking
-    our $VERSION = 1.15;
+    our $VERSION = 1.16;
 
     # Functions and variables which can be optionally exported
     our @EXPORT_OK = qw{ analysis_gatk_splitncigarreads };
@@ -210,7 +210,7 @@ sub analysis_gatk_splitncigarreads {
                 id               => $sample_id,
                 file_info_href   => $file_info_href,
                 file_name_prefix => $infile_name_prefix,
-                iterators_ref    => $file_info_href->{contigs_size_ordered},
+                iterators_ref    => $file_info_href->{bam_contigs_size_ordered},
                 outdata_dir      => $active_parameter_href->{outdata_dir},
                 parameter_href   => $parameter_href,
                 recipe_name      => $recipe_name,
@@ -278,7 +278,7 @@ sub analysis_gatk_splitncigarreads {
 
   CONTIG:
     while ( my ( $infile_index, $contig ) =
-        each @{ $file_info_href->{contigs_size_ordered} } )
+        each @{ $file_info_href->{bam_contigs_size_ordered} } )
     {
 
         my $stderrfile_path =


### PR DESCRIPTION
### This PR fixes:

- Loop over bam contigs in gatk splitncigarreads

### How to test:

- Automatic and continuous test pass

### Expected outcome:
- Installation, unit and integration tests pass

### Review:
- [x] Code review
- [x] New code is executed and covered by tests
- [x] Tests pass
