### PR TITLE
fix(markduplicates): increase java mem

### DIFF
--- a/lib/MIP/Recipes/Analysis/Markduplicates.pm
+++ b/lib/MIP/Recipes/Analysis/Markduplicates.pm
@@ -27,7 +27,7 @@ BEGIN {
     use base qw{ Exporter };
 
     # Set the version for version checking
-    our $VERSION = 1.24;
+    our $VERSION = 1.25;
 
     # Functions and variables which can be optionally exported
     our @EXPORT_OK = qw{ analysis_markduplicates analysis_markduplicates_rna };
@@ -35,7 +35,7 @@ BEGIN {
 }
 
 ## Constants
-Readonly my $JAVA_MEMORY_ALLOCATION      => 4;
+Readonly my $JAVA_MEMORY_ALLOCATION      => 6;
 Readonly my $JAVA_MEMORY_RECIPE_ADDITION => 1;
 Readonly my $JAVA_GUEST_OS_MEMORY        => $ANALYSIS{JAVA_GUEST_OS_MEMORY} +
   $JAVA_MEMORY_RECIPE_ADDITION;


### PR DESCRIPTION
### This PR fixes:

- Increases java memory to 6gb from 4

### How to test:

- Automatic and continuous test pass

### Expected outcome:
- Installation, unit and integration tests pass

### Review:
- [ ] Code review
- [ ] New code is executed and covered by tests
- [ ] Tests pass
