### PR TITLE
Feature/download envn

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -36,7 +36,7 @@ install:
   - bash mip.sh
   ## Special case: Install bcftools since it is required by some tests
   - conda install -n mip_travis --channel bioconda --channel conda-forge bcftools=1.9=ha228f0b_4
-  - conda install -n mip_rd-rna --channel bioconda --channel conda-forge bcftools=1.9=ha228f0b_4
+  - conda install -n mip_rd_rna --channel bioconda --channel conda-forge bcftools=1.9=ha228f0b_4
 
 script:
   ## Test MIP rd_dna

--- a/.travis.yml
+++ b/.travis.yml
@@ -62,7 +62,7 @@ script:
   ## Set-up test coverage for mip_analyse_vcf_rerun.test
   - PERL5OPT=-MDevel::Cover=-ignore,"^t/",-coverage,statement,branch,condition,path,subroutine perl t/mip_analyse_dragen_rd_dna.test
   ## Set-up test coverage for mip_analyse_rna.test
-  - conda activate mip_rd-rna
+  - conda activate mip_rd_rna
   - PERL5OPT=-MDevel::Cover=-ignore,"^t/",-coverage,statement,branch,condition,path,subroutine perl t/mip_analyse_rd_rna.test
   ## Get some coverage statistics
   - cover

--- a/definitions/download_parameters.yaml
+++ b/definitions/download_parameters.yaml
@@ -20,6 +20,13 @@ dry_run_all:
   data_type: SCALAR
   mandatory: no
   type: mip
+environment_name:
+  associated_recipe:
+    - mip
+  data_type: SCALAR
+  default: mip_rd_dna
+  mandatory: no
+  type: mip
 load_env:
   associated_recipe:
     - mip

--- a/definitions/install_rd_dna_parameters.yaml
+++ b/definitions/install_rd_dna_parameters.yaml
@@ -3,6 +3,6 @@ environment_name:
   associated_recipe:
     - mip
   data_type: SCALAR
-  default: mip_rd-dna
+  default: mip_rd_dna
   mandatory: no
   type: mip

--- a/definitions/install_rd_rna_parameters.yaml
+++ b/definitions/install_rd_rna_parameters.yaml
@@ -3,6 +3,6 @@ environment_name:
   associated_recipe:
     - mip
   data_type: SCALAR
-  default: mip_rd-rna
+  default: mip_rd_rna
   mandatory: no
   type: mip

--- a/lib/MIP/Active_parameter.pm
+++ b/lib/MIP/Active_parameter.pm
@@ -55,6 +55,7 @@ BEGIN {
       set_default_vcfparser_select_file
       set_exome_target_bed
       set_gender_sample_ids
+      set_load_env_environment
       set_parameter_reference_dir_path
       set_pedigree_sample_id_parameter
       set_recipe_resource
@@ -1171,6 +1172,53 @@ sub set_default_parameter {
     ## Can be scalar|array_ref|hash_ref
     $active_parameter_href->{$parameter_name} = $parameter_default;
 
+    return;
+}
+
+sub set_load_env_environment {
+
+## Function : Set load_env environment name based on supplied environment name
+## Returns  :
+## Arguments: $active_parameter_href => Active parameters for this analysis hash {REF}
+
+    my ($arg_href) = @_;
+
+    ## Flatten argument(s)
+    my $active_parameter_href;
+
+    my $tmpl = {
+        active_parameter_href => {
+            default     => {},
+            defined     => 1,
+            required    => 1,
+            store       => \$active_parameter_href,
+            strict_type => 1,
+        },
+    };
+
+    check( $tmpl, $arg_href, 1 ) or croak q{Could not parse arguments};
+
+    ## Unpack
+    my $env_name = $active_parameter_href->{environment_name};
+
+    if ( keys %{ $active_parameter_href->{load_env} } != 1 ) {
+
+        ## Retrieve logger object
+        my $log = Log::Log4perl->get_logger($LOG_NAME);
+
+        $log->warn( q{Could not use }
+              . $env_name
+              . q{ as there are multiple environments to update} );
+        return;
+    }
+
+  ENV:
+    foreach my $config_env_name ( keys %{ $active_parameter_href->{load_env} } ) {
+
+        ## Set new environment name
+        $active_parameter_href->{load_env}{$env_name} =
+          delete $active_parameter_href->{load_env}{$config_env_name};
+    }
     return;
 }
 

--- a/lib/MIP/Cli/Mip/Download/Rd_dna.pm
+++ b/lib/MIP/Cli/Mip/Download/Rd_dna.pm
@@ -20,7 +20,7 @@ use MIP::Definition qw{ get_parameter_from_definition_files };
 use MIP::Main::Download qw{ mip_download };
 use MIP::Script::Utils qw{ print_parameter_defaults };
 
-our $VERSION = 1.07;
+our $VERSION = 1.08;
 
 extends(qw{ MIP::Cli::Mip::Download });
 
@@ -79,6 +79,17 @@ sub _build_usage {
             is      => q{rw},
             isa     => Str,
         )
+    );
+
+    option(
+        q{environment_name} => (
+            cmd_aliases   => [qw{ envn }],
+            cmd_flag      => q{environment_name},
+            cmd_tags      => [q{Default: mip_rd_dna}],
+            documentation => q{Set environment name},
+            is            => q{rw},
+            isa           => Str,
+        ),
     );
     return;
 }

--- a/lib/MIP/Cli/Mip/Download/Rd_rna.pm
+++ b/lib/MIP/Cli/Mip/Download/Rd_rna.pm
@@ -20,7 +20,7 @@ use MIP::Definition qw{ get_parameter_from_definition_files };
 use MIP::Main::Download qw{ mip_download };
 use MIP::Script::Utils qw{ print_parameter_defaults };
 
-our $VERSION = 1.04;
+our $VERSION = 1.05;
 
 extends(qw{ MIP::Cli::Mip::Download });
 
@@ -80,6 +80,17 @@ sub _build_usage {
             is      => q{rw},
             isa     => Str,
         )
+    );
+
+    option(
+        q{environment_name} => (
+            cmd_aliases   => [qw{ envn }],
+            cmd_flag      => q{environment_name},
+            cmd_tags      => [q{Default: mip_rd_rna}],
+            documentation => q{Set environment name},
+            is            => q{rw},
+            isa           => Str,
+        ),
     );
     return;
 }

--- a/lib/MIP/Cli/Mip/Install/Rd_dna.pm
+++ b/lib/MIP/Cli/Mip/Install/Rd_dna.pm
@@ -24,7 +24,7 @@ use MIP::Get::Parameter qw{ get_install_parameter_attribute };
 use MIP::Main::Install qw{ mip_install };
 use MIP::Script::Utils qw{ print_parameter_defaults };
 
-our $VERSION = 2.20;
+our $VERSION = 2.21;
 
 extends(qw{ MIP::Cli::Mip::Install });
 
@@ -97,8 +97,8 @@ sub _build_usage {
         q{environment_name} => (
             cmd_aliases   => [qw{ envn }],
             cmd_flag      => q{environment_name},
-            cmd_tags      => [q{Default: MIP_rd-dna}],
-            documentation => q{Set environment names},
+            cmd_tags      => [q{Default: mip_rd_dna}],
+            documentation => q{Set environment name},
             is            => q{rw},
             isa           => Str,
         ),

--- a/lib/MIP/Cli/Mip/Install/Rd_rna.pm
+++ b/lib/MIP/Cli/Mip/Install/Rd_rna.pm
@@ -23,7 +23,7 @@ use MIP::Definition qw{ get_parameter_from_definition_files };
 use MIP::Main::Install qw{ mip_install };
 use MIP::Script::Utils qw{ print_parameter_defaults };
 
-our $VERSION = 2.17;
+our $VERSION = 2.18;
 
 extends(qw{ MIP::Cli::Mip::Install });
 
@@ -96,8 +96,8 @@ sub _build_usage {
         q{environment_name} => (
             cmd_aliases   => [qw{ envn }],
             cmd_flag      => q{environment_name},
-            cmd_tags      => [q{Default: MIP_rd-rna }],
-            documentation => q{Set environment names},
+            cmd_tags      => [q{Default: mip_rd_rna }],
+            documentation => q{Set environment name},
             is            => q{rw},
             isa           => Str,
             required      => 0,

--- a/lib/MIP/File/Decompression.pm
+++ b/lib/MIP/File/Decompression.pm
@@ -24,7 +24,7 @@ BEGIN {
     use base qw{ Exporter };
 
     # Set the version for version checking
-    our $VERSION = 1.02;
+    our $VERSION = 1.03;
 
     # Functions and variables which can be optionally exported
     our @EXPORT_OK = qw{ decompress_files };
@@ -130,6 +130,10 @@ sub decompress_files {
 
     my @commands =
       $decompress_api{$program}{method}->( { %{ $decompress_api{$program}{arg_href} } } );
+
+    if ( defined $filehandle ) {
+        say {$filehandle} $NEWLINE;
+    }
 
     return @commands;
 }

--- a/lib/MIP/Main/Download.pm
+++ b/lib/MIP/Main/Download.pm
@@ -22,13 +22,14 @@ use Readonly;
 ## MIPs lib/
 use MIP::Active_parameter qw{
   check_recipe_mode
+  set_load_env_environment
   update_recipe_mode_with_dry_run_all
   update_to_absolute_path
 };
 use MIP::Check::Download qw{ check_user_reference };
 use MIP::Config qw{ check_cmd_config_vs_definition_file set_config_to_active_parameters };
 use MIP::Constants
-  qw{ $COLON $COMMA $DOT $MIP_VERSION $NEWLINE $SINGLE_QUOTE $SPACE $UNDERSCORE };
+  qw{ $COLON $COMMA $DOT $LOG_NAME $MIP_VERSION $NEWLINE $SINGLE_QUOTE $SPACE $UNDERSCORE };
 use MIP::Environment::Cluster qw{ check_max_core_number };
 use MIP::Environment::User qw{ check_email_address };
 use MIP::Io::Read qw{ read_from_file };
@@ -47,7 +48,7 @@ BEGIN {
     use base qw{ Exporter };
 
     # Set the version for version checking
-    our $VERSION = 1.19;
+    our $VERSION = 1.20;
 
     # Functions and variables that can be optionally exported
     our @EXPORT_OK = qw{ mip_download };
@@ -269,6 +270,8 @@ sub mip_download {
             recipes_ref           => \@{ $parameter{cache}{recipe} },
         }
     );
+
+    set_load_env_environment( { active_parameter_href => \%active_parameter, } );
 
     ## Remodel depending on if "--reference" was used or not as the user info is stored as a scalar per reference_id while yaml is stored as arrays per reference_id
     parse_download_reference_parameter(

--- a/lib/MIP/Recipes/Download/Gnomad.pm
+++ b/lib/MIP/Recipes/Download/Gnomad.pm
@@ -26,7 +26,7 @@ BEGIN {
     use base qw{ Exporter };
 
     # Set the version for version checking
-    our $VERSION = 1.05;
+    our $VERSION = 1.06;
 
     # Functions and variables which can be optionally exported
     our @EXPORT_OK = qw{ download_gnomad };
@@ -188,8 +188,9 @@ sub download_gnomad {
 
 ## Map of key names to keep from reference vcf
     my %info_key = (
-        q{r2.0.1} => [ qw{AF AF_POPMAX}, ],
-        q{r2.1.1} => [ qw{AF AF_popmax}, ],
+        q{r2.0.1}    => [ qw{AF AF_POPMAX}, ],
+        q{r2.1.1}    => [ qw{AF AF_popmax}, ],
+        q{r2.1.1_sv} => [ qw{AF POPMAX_AF}, ],
     );
 
     my $reformated_outfile = join $UNDERSCORE,

--- a/t/data/test_data/download_active_parameters.yaml
+++ b/t/data/test_data/download_active_parameters.yaml
@@ -3,7 +3,7 @@ bash_set_errexit: 1
 bash_set_nounset: 1
 bash_set_pipefail: 1
 load_env:
-  MIP_rd_dna:
+  mip_rd_dna:
     method: conda
     mip: ~
 project_id: development

--- a/t/set_load_env_environment.t
+++ b/t/set_load_env_environment.t
@@ -1,0 +1,104 @@
+#!/usr/bin/env perl
+
+use 5.026;
+use Carp;
+use charnames qw{ :full :short };
+use English qw{ -no_match_vars };
+use File::Basename qw{ dirname };
+use File::Spec::Functions qw{ catdir };
+use FindBin qw{ $Bin };
+use open qw{ :encoding(UTF-8) :std };
+use Params::Check qw{ allow check last_error };
+use Test::More;
+use utf8;
+use warnings qw{ FATAL utf8 };
+
+## CPANM
+use autodie qw { :all };
+use Modern::Perl qw{ 2018 };
+use Test::Trap;
+
+## MIPs lib/
+use lib catdir( dirname($Bin), q{lib} );
+use MIP::Constants qw{ $COMMA $SPACE };
+use MIP::Test::Fixtures qw{ test_log test_standard_cli };
+
+my $VERBOSE = 1;
+our $VERSION = 1.00;
+
+$VERBOSE = test_standard_cli(
+    {
+        verbose => $VERBOSE,
+        version => $VERSION,
+    }
+);
+
+BEGIN {
+
+    use MIP::Test::Fixtures qw{ test_import };
+
+### Check all internal dependency modules and imports
+## Modules with import
+    my %perl_module = (
+        q{MIP::Active_parameter} => [qw{ set_load_env_environment }],
+        q{MIP::Test::Fixtures}   => [qw{ test_log test_standard_cli }],
+    );
+
+    test_import( { perl_module_href => \%perl_module, } );
+}
+
+use MIP::Active_parameter qw{ set_load_env_environment };
+
+diag(   q{Test set_load_env_environment from Active_parameter.pm v}
+      . $MIP::Active_parameter::VERSION
+      . $COMMA
+      . $SPACE . q{Perl}
+      . $SPACE
+      . $PERL_VERSION
+      . $SPACE
+      . $EXECUTABLE_NAME );
+
+my $log = test_log( { } );
+
+## Given a single load_env environment
+my $user_env_name    = q{user_env_name};
+my %active_parameter = (
+    load_env => {
+        mip_rd_dna => {
+            method => q{conda},
+            mip    => undef,
+        },
+    },
+    environment_name => $user_env_name,
+);
+
+set_load_env_environment( { active_parameter_href => \%active_parameter, } );
+
+my %expected_load_env = (
+    load_env => {
+        $user_env_name => {
+            method => q{conda},
+            mip    => undef,
+        },
+    },
+);
+
+## Then user supplied environment name should be set in active_parameters load_env
+is_deeply(
+    $active_parameter{load_env},
+    $expected_load_env{load_env},
+    q{Set user environment name in load_env}
+);
+
+## Given multiple load_env environments
+$active_parameter{load_env}{another_env} = {
+        method => q{conda},
+        mip    => undef,
+    };
+
+trap { set_load_env_environment( { active_parameter_href => \%active_parameter, } )
+};
+
+like( $trap->stderr, qr/Could\s+not\s+use/xms, q{Throw warning log message} );
+
+done_testing();

--- a/templates/mip_download_rd_dna_config_-1.0-.yaml
+++ b/templates/mip_download_rd_dna_config_-1.0-.yaml
@@ -94,6 +94,7 @@ reference:
   gnomad:
     - r2.0.1
     - r2.1.1
+    - r2.1.1_sv
   gnomad_pli_per_gene:
     - r2.1.1
   hapmap:
@@ -694,6 +695,14 @@ reference_feature:
         outfile: grch37_gnomad.genomes_-r2.1.1-.vcf.gz
         outfile_index: grch37_gnomad.genomes_-r2.1.1-.vcf.gz.tbi
         url_prefix: https://storage.googleapis.com/gnomad-public/release/2.1.1/vcf/genomes/
+      r2.1.1_sv:
+        file: gnomad_v2_sv.sites.vcf.gz
+        file_index: gnomad_v2_sv.sites.vcf.gz.tbi
+        outfile: grch37_gnomad.genomes_-r2.1.1_sv-.vcf.gz
+        outfile_index: grch37_gnomad.genomes_-r2.1.1_sv-.vcf.gz.tbi
+        outfile_decompress: gzip
+        outfile_index_decompress: gzip
+        url_prefix: https://storage.googleapis.com/gnomad-public/papers/2019-sv/
     grch38:
       r2.1.1:
         file: gnomad.genomes.r2.1.1.sites.liftover_grch38.vcf.bgz

--- a/templates/mip_download_rd_dna_config_-1.0-.yaml
+++ b/templates/mip_download_rd_dna_config_-1.0-.yaml
@@ -2,7 +2,7 @@
 bash_set_errexit: 1
 bash_set_pipefail: 1
 load_env:
-  MIP_rd_dna:
+  mip_rd_dna:
     method: conda
     mip:
 project_id: development

--- a/templates/mip_download_rd_rna_config_-1.0-.yaml
+++ b/templates/mip_download_rd_rna_config_-1.0-.yaml
@@ -1,6 +1,6 @@
 ---
 load_env:
-  MIP_rd_rna:
+  mip_rd_rna:
     method: conda
     mip:
 project_id: development


### PR DESCRIPTION
### This PR fixes:

- Added CLI option to rename load_env environment in download template config 
- Lower cased default load_env environments in template config for install and modfied them to be snake_case
- Added r2.1.1_sv download to templates config again
- Fixed bug in gnomad recipe by also including gnomad_sv keep keys
- Fixed bug in decompression by adding newline after sub call

### How to test:

- Automatic and continuous test pass

### Expected outcome:
- Installation, unit and integration tests pass

### Review:
- [ ] Code review
- [ ] New code is executed and covered by tests
- [ ] Tests pass
