### PR TITLE
feat(select_file_contigs): Use column one and not header to get conti…

### DIFF
--- a/lib/MIP/Analysis.pm
+++ b/lib/MIP/Analysis.pm
@@ -28,7 +28,7 @@ BEGIN {
     use base qw{ Exporter };
 
     # Set the version for version checking
-    our $VERSION = 1.17;
+    our $VERSION = 1.18;
 
     # Functions and variables which can be optionally exported
     our @EXPORT_OK = qw{
@@ -36,6 +36,64 @@ BEGIN {
       get_overall_analysis_type
       get_vcf_parser_analysis_suffix
     };
+}
+
+sub check_analysis_type_to_pipeline {
+
+## Function : Check if consensus analysis type is compatible with the pipeline
+## Returns  :
+## Arguments: $analysis_type => Analysis type
+##          : $pipeline      => Pipeline
+
+    my ($arg_href) = @_;
+
+    ## Flatten argument(s)
+    my $analysis_type;
+    my $pipeline;
+
+    my $tmpl = {
+        analysis_type => {
+            defined     => 1,
+            required    => 1,
+            store       => \$analysis_type,
+            strict_type => 1,
+        },
+        pipeline => {
+            allow       => [qw{ dragen_rd_dna rd_dna rd_dna_panel rd_dna_vcf_rerun rd_rna}],
+            defined     => 1,
+            required    => 1,
+            store       => \$pipeline,
+            strict_type => 1,
+        },
+    };
+
+    check( $tmpl, $arg_href, 1 ) or croak q{Could not parse arguments!};
+
+    ## Retrieve logger object
+    my $log = Log::Log4perl->get_logger($LOG_NAME);
+
+    my %analysis_pipeline_map = (
+        dragen_rd_dna => q{dragen_rd_dna},
+        mixed         => q{rd_dna},
+        panel         => q{rd_dna_panel},
+        vrn           => q{rd_dna_vcf_rerun},
+        wes           => q{rd_dna},
+        wgs           => q{rd_dna},
+        wts           => q{rd_rna},
+    );
+
+    if ( $analysis_pipeline_map{$analysis_type} ne $pipeline ) {
+
+        $log->fatal(
+qq{Analysis type: $analysis_type is not compatible with MIP pipeline: $pipeline}
+        );
+        $log->fatal(
+qq{Start MIP pipeline: $analysis_pipeline_map{$analysis_type} for this analysis type}
+        );
+        $log->fatal(q{Aborting run});
+        exit 1;
+    }
+    return 1;
 }
 
 sub get_overall_analysis_type {
@@ -134,63 +192,6 @@ sub get_vcf_parser_analysis_suffix {
         push @analysis_suffixes, $EMPTY_STR;
     }
     return @analysis_suffixes;
-}
-
-sub check_analysis_type_to_pipeline {
-
-## Function : Check if consensus analysis type is compatible with the pipeline
-## Returns  :
-## Arguments: $analysis_type => Analysis type
-##          : $pipeline      => Pipeline
-
-    my ($arg_href) = @_;
-
-    ## Flatten argument(s)
-    my $analysis_type;
-    my $pipeline;
-
-    my $tmpl = {
-        analysis_type => {
-            defined     => 1,
-            required    => 1,
-            store       => \$analysis_type,
-            strict_type => 1,
-        },
-        pipeline => {
-            allow       => [qw{ dragen_rd_dna rd_dna rd_dna_vcf_rerun rd_rna}],
-            defined     => 1,
-            required    => 1,
-            store       => \$pipeline,
-            strict_type => 1,
-        },
-    };
-
-    check( $tmpl, $arg_href, 1 ) or croak q{Could not parse arguments!};
-
-    ## Retrieve logger object
-    my $log = Log::Log4perl->get_logger($LOG_NAME);
-
-    my %analysis_pipeline_map = (
-        dragen_rd_dna => q{dragen_rd_dna},
-        mixed         => q{rd_dna},
-        vrn           => q{rd_dna_vcf_rerun},
-        wes           => q{rd_dna},
-        wgs           => q{rd_dna},
-        wts           => q{rd_rna},
-    );
-
-    if ( $analysis_pipeline_map{$analysis_type} ne $pipeline ) {
-
-        $log->fatal(
-qq{Analysis type: $analysis_type is not compatible with MIP pipeline: $pipeline}
-        );
-        $log->fatal(
-qq{Start MIP pipeline: $analysis_pipeline_map{$analysis_type} for this analysis type}
-        );
-        $log->fatal(q{Aborting run});
-        exit 1;
-    }
-    return 1;
 }
 
 1;

--- a/lib/MIP/Check/Pipeline.pm
+++ b/lib/MIP/Check/Pipeline.pm
@@ -16,7 +16,8 @@ use warnings qw{ FATAL utf8 };
 use autodie qw{ :all };
 
 ## MIPs lib/
-use MIP::Constants qw{ $LOG_NAME $SPACE };
+use MIP::Constants qw{ $LOG_NAME };
+use MIP::Parameter qw{ get_cache };
 
 BEGIN {
     require Exporter;
@@ -135,7 +136,7 @@ sub check_dragen_rd_dna {
     use MIP::Parse::File qw{ parse_fastq_infiles };
     use MIP::Parse::Gender qw{ parse_fastq_for_gender };
     use MIP::Reference qw{ get_select_file_contigs };
-    use MIP::Update::Contigs qw{ size_sort_select_file_contigs update_contigs_for_run };
+    use MIP::Update::Contigs qw{ update_contigs_for_run };
     use MIP::Set::Parameter qw{ set_parameter_to_broadcast };
     use MIP::Sample_info qw{ set_parameter_in_sample_info };
 
@@ -163,10 +164,17 @@ sub check_dragen_rd_dna {
     set_vcfparser_outfile_counter( { active_parameter_href => $active_parameter_href, } );
 
     ## Collect select file contigs to loop over downstream
+    my $consensus_analysis_type = get_cache(
+        {
+            parameter_href => $parameter_href,
+            parameter_name => q{consensus_analysis_type},
+        }
+    );
     parse_select_file_contigs(
         {
-            file_info_href   => $file_info_href,
-            select_file_path => $active_parameter_href->{vcfparser_select_file},
+            consensus_analysis_type => $consensus_analysis_type,
+            file_info_href          => $file_info_href,
+            select_file_path        => $active_parameter_href->{vcfparser_select_file},
         }
     );
 
@@ -242,17 +250,6 @@ sub check_dragen_rd_dna {
             file_info_href      => $file_info_href,
             found_male          => $active_parameter_href->{found_male},
             log                 => $log,
-        }
-    );
-
-    ## Sorts array depending on reference array. NOTE: Only entries present in reference array will survive in sorted array.
-    @{ $file_info_href->{sorted_select_file_contigs} } = size_sort_select_file_contigs(
-        {
-            consensus_analysis_type => $parameter_href->{cache}{consensus_analysis_type},
-            file_info_href          => $file_info_href,
-            hash_key_sort_reference => q{contigs_size_ordered},
-            hash_key_to_sort        => q{select_file_contigs},
-            log                     => $log,
         }
     );
 
@@ -409,7 +406,7 @@ sub check_rd_dna {
     use MIP::Parse::File qw{ parse_fastq_infiles };
     use MIP::Parse::Gender qw{ parse_fastq_for_gender };
     use MIP::Reference qw{ get_select_file_contigs parse_exome_target_bed };
-    use MIP::Update::Contigs qw{ size_sort_select_file_contigs update_contigs_for_run };
+    use MIP::Update::Contigs qw{ update_contigs_for_run };
     use MIP::Update::Recipes
       qw{ update_prioritize_flag update_recipe_mode_for_analysis_type };
     use MIP::Set::Parameter qw{ set_parameter_to_broadcast };
@@ -446,10 +443,17 @@ sub check_rd_dna {
     set_vcfparser_outfile_counter( { active_parameter_href => $active_parameter_href, } );
 
 ## Collect select file contigs to loop over downstream
+    my $consensus_analysis_type = get_cache(
+        {
+            parameter_href => $parameter_href,
+            parameter_name => q{consensus_analysis_type},
+        }
+    );
     parse_select_file_contigs(
         {
-            file_info_href   => $file_info_href,
-            select_file_path => $active_parameter_href->{vcfparser_select_file},
+            consensus_analysis_type => $consensus_analysis_type,
+            file_info_href          => $file_info_href,
+            select_file_path        => $active_parameter_href->{vcfparser_select_file},
         }
     );
 
@@ -600,17 +604,6 @@ sub check_rd_dna {
             file_info_href      => $file_info_href,
             found_male          => $active_parameter_href->{found_male},
             log                 => $log,
-        }
-    );
-
-    ## Sorts array depending on reference array. NOTE: Only entries present in reference array will survive in sorted array.
-    @{ $file_info_href->{sorted_select_file_contigs} } = size_sort_select_file_contigs(
-        {
-            consensus_analysis_type => $parameter_href->{cache}{consensus_analysis_type},
-            file_info_href          => $file_info_href,
-            hash_key_sort_reference => q{contigs_size_ordered},
-            hash_key_to_sort        => q{select_file_contigs},
-            log                     => $log,
         }
     );
 
@@ -1034,7 +1027,7 @@ sub check_rd_dna_vcf_rerun {
     use MIP::Reference qw{ get_select_file_contigs };
     use MIP::Sample_info qw{ set_parameter_in_sample_info };
     use MIP::Set::Parameter qw{ set_parameter_to_broadcast };
-    use MIP::Update::Contigs qw{ size_sort_select_file_contigs update_contigs_for_run };
+    use MIP::Update::Contigs qw{ update_contigs_for_run };
 
     ## Check sample_id provided in hash parameter is included in the analysis
     check_sample_id_in_hash_parameter(
@@ -1060,10 +1053,17 @@ sub check_rd_dna_vcf_rerun {
     set_vcfparser_outfile_counter( { active_parameter_href => $active_parameter_href, } );
 
 ## Collect select file contigs to loop over downstream
+    my $consensus_analysis_type = get_cache(
+        {
+            parameter_href => $parameter_href,
+            parameter_name => q{consensus_analysis_type},
+        }
+    );
     parse_select_file_contigs(
         {
-            file_info_href   => $file_info_href,
-            select_file_path => $active_parameter_href->{vcfparser_select_file},
+            consensus_analysis_type => $consensus_analysis_type,
+            file_info_href          => $file_info_href,
+            select_file_path        => $active_parameter_href->{vcfparser_select_file},
         }
     );
 
@@ -1139,17 +1139,6 @@ sub check_rd_dna_vcf_rerun {
             file_info_href      => $file_info_href,
             found_male          => $active_parameter_href->{found_male},
             log                 => $log,
-        }
-    );
-
-    ## Sorts array depending on reference array. NOTE: Only entries present in reference array will survive in sorted array.
-    @{ $file_info_href->{sorted_select_file_contigs} } = size_sort_select_file_contigs(
-        {
-            consensus_analysis_type => $parameter_href->{cache}{consensus_analysis_type},
-            file_info_href          => $file_info_href,
-            hash_key_sort_reference => q{contigs_size_ordered},
-            hash_key_to_sort        => q{select_file_contigs},
-            log                     => $log,
         }
     );
 

--- a/lib/MIP/File_info.pm
+++ b/lib/MIP/File_info.pm
@@ -24,7 +24,7 @@ BEGIN {
     use base qw{ Exporter };
 
     # Set the version for version checking
-    our $VERSION = 1.04;
+    our $VERSION = 1.05;
 
     # Functions and variables which can be optionally exported
     our @EXPORT_OK = qw{
@@ -479,9 +479,8 @@ sub parse_select_file_contigs {
 
     check( $tmpl, $arg_href, 1 ) or croak q{Could not parse arguments!};
 
-    use MIP::Contigs qw{ check_select_file_contigs };
+    use MIP::Contigs qw{ check_select_file_contigs sort_contigs_to_contig_set };
     use MIP::Reference qw{ get_select_file_contigs };
-    use MIP::Update::Contigs qw{ sort_contigs_to_contig_set };
 
     ## Retrieve logger object
     my $log = Log::Log4perl->get_logger($LOG_NAME);
@@ -519,10 +518,9 @@ sub parse_select_file_contigs {
 
             @{ $file_info_href->{$contigs_set_name} } = sort_contigs_to_contig_set(
                 {
-                    consensus_analysis_type => $consensus_analysis_type,
-                    file_info_href          => $file_info_href,
-                    hash_key_sort_reference => $sort_reference,
-                    hash_key_to_sort        => q{select_file_contigs},
+                    consensus_analysis_type    => $consensus_analysis_type,
+                    sort_contigs_ref           => $file_info_href->{select_file_contigs},
+                    sort_reference_contigs_ref => $file_info_href->{$sort_reference},
                 }
             );
         }

--- a/lib/MIP/Language/Perl.pm
+++ b/lib/MIP/Language/Perl.pm
@@ -170,7 +170,6 @@ sub perl_nae_oneliners {
     ## Oneliner dispatch table
     my %oneliner = (
         get_dict_contigs          => \&_get_dict_contigs,
-        get_select_contigs        => \&_get_select_contigs,
         get_select_contigs_by_col => \&_get_select_contigs_by_col,
         get_vep_version           => \&_get_vep_version,
         synonyms_grch37_to_grch38 => \&_synonyms_grch37_to_grch38,
@@ -251,29 +250,6 @@ sub _get_dict_contigs {
     $get_dict_contigs .= q?print $contig_name, q{,};} }'?;
 
     return $get_dict_contigs;
-}
-
-sub _get_select_contigs {
-
-## Function : Return contig names from file header
-## Returns  : $get_select_contigs
-## Arguments:
-
-    my ($arg_href) = @_;
-
-    # Get contig name
-    my $get_select_contigs = q?'if ($_=~/ contig=(\w+) /xsm) { ?;
-
-    # Alias capture
-    $get_select_contigs .= q?my $contig_name = $1; ?;
-
-    # Write contig name and comma
-    $get_select_contigs .= q?print $contig_name, q{,};} ?;
-
-    # Quit if "#CHROM" found in line
-    $get_select_contigs .= q?if($_=~/ [#]CHROM /xsm) {last;}' ?;
-
-    return $get_select_contigs;
 }
 
 sub _get_select_contigs_by_col {

--- a/lib/MIP/Language/Perl.pm
+++ b/lib/MIP/Language/Perl.pm
@@ -25,7 +25,7 @@ BEGIN {
     use base qw{ Exporter };
 
     # Set the version for version checking
-    our $VERSION = 1.04;
+    our $VERSION = 1.05;
 
     our @EXPORT_OK = qw{ perl_base perl_nae_oneliners };
 }
@@ -171,6 +171,7 @@ sub perl_nae_oneliners {
     my %oneliner = (
         get_dict_contigs          => \&_get_dict_contigs,
         get_select_contigs        => \&_get_select_contigs,
+        get_select_contigs_by_col => \&_get_select_contigs_by_col,
         get_vep_version           => \&_get_vep_version,
         synonyms_grch37_to_grch38 => \&_synonyms_grch37_to_grch38,
         synonyms_grch38_to_grch37 => \&_synonyms_grch38_to_grch37,
@@ -261,7 +262,7 @@ sub _get_select_contigs {
     my ($arg_href) = @_;
 
     # Get contig name
-    my $get_select_contigs .= q?'if ($_=~/ contig=(\w+) /xsm) { ?;
+    my $get_select_contigs = q?'if ($_=~/ contig=(\w+) /xsm) { ?;
 
     # Alias capture
     $get_select_contigs .= q?my $contig_name = $1; ?;
@@ -271,6 +272,39 @@ sub _get_select_contigs {
 
     # Quit if "#CHROM" found in line
     $get_select_contigs .= q?if($_=~/ [#]CHROM /xsm) {last;}' ?;
+
+    return $get_select_contigs;
+}
+
+sub _get_select_contigs_by_col {
+
+## Function : Return contig names from column one of bed file
+## Returns  : $get_select_contigs
+## Arguments:
+
+    my ($arg_href) = @_;
+
+    # Initilize hash
+    my $get_select_contigs = q?'my %contig; ?;
+
+    # Loop per line
+    $get_select_contigs .= q?while (<>) { ?;
+
+    # Get contig name
+    $get_select_contigs .= q?my ($contig_name) = $_=~/(\w+)/sxm; ?;
+
+    # Skip if on black list
+    $get_select_contigs .=
+      q?next if($contig_name =~/browser|contig|chromosome|gene_panel|track/); ?;
+
+    # Set contig name in hash
+    $get_select_contigs .= q?if($contig_name) { $contig{$contig_name}=undef } } ?;
+
+    # Print contig names to string
+    $get_select_contigs .= q?print join ",", sort keys %contig; ?;
+
+    # Exit perl program
+    $get_select_contigs .= q?last;' ?;
 
     return $get_select_contigs;
 }

--- a/lib/MIP/Reference.pm
+++ b/lib/MIP/Reference.pm
@@ -25,7 +25,7 @@ BEGIN {
     use base qw{ Exporter };
 
     # Set the version for version checking
-    our $VERSION = 1.04;
+    our $VERSION = 1.05;
 
     # Functions and variables which can be optionally exported
     our @EXPORT_OK = qw{
@@ -267,7 +267,7 @@ sub get_select_file_contigs {
     ## Build regexp to get contig names
     my @get_select_contigs_cmds = perl_nae_oneliners(
         {
-            oneliner_name  => q{get_select_contigs},
+            oneliner_name  => q{get_select_contigs_by_col},
             stdinfile_path => $select_file_path,
         }
     );
@@ -292,7 +292,6 @@ sub get_select_file_contigs {
     }
     return @contigs;
 }
-
 
 sub parse_meta_file_suffixes {
 

--- a/lib/MIP/Update/Contigs.pm
+++ b/lib/MIP/Update/Contigs.pm
@@ -21,6 +21,7 @@ use Readonly;
 
 ## MIPs lib/
 use lib catdir( dirname($Bin), q{lib} );
+use MIP::Constants qw{ $LOG_NAME };
 
 BEGIN {
     require Exporter;
@@ -30,18 +31,17 @@ BEGIN {
     our $VERSION = 1.03;
 
     # Functions and variables which can be optionally exported
-    our @EXPORT_OK = qw{ size_sort_select_file_contigs update_contigs_for_run };
+    our @EXPORT_OK = qw{ sort_contigs_to_contig_set update_contigs_for_run };
 }
 
-sub size_sort_select_file_contigs {
+sub sort_contigs_to_contig_set {
 
 ## Function : Sorts array depending on reference array. NOTE: Only entries present in reference array will survive in sorted array.
 ## Returns  : @sorted_contigs
 ## Arguments: $consensus_analysis_type => Consensus analysis_type {REF}
-##          : $file_info_href              => File info hash {REF}
-##          : $hash_key_sort_reference     => The hash keys sort reference
-##          : $hash_key_to_sort            => The keys to sort
-##          : $log                         => Log object
+##          : $file_info_href          => File info hash {REF}
+##          : $hash_key_sort_reference => The hash keys sort reference
+##          : $hash_key_to_sort        => The keys to sort
 
     my ($arg_href) = @_;
 
@@ -50,7 +50,6 @@ sub size_sort_select_file_contigs {
     my $file_info_href;
     my $hash_key_sort_reference;
     my $hash_key_to_sort;
-    my $log;
 
     my $tmpl = {
         consensus_analysis_type => {
@@ -78,16 +77,14 @@ sub size_sort_select_file_contigs {
             store       => \$hash_key_to_sort,
             strict_type => 1,
         },
-        log => {
-            defined  => 1,
-            required => 1,
-            store    => \$log,
-        },
     };
 
     check( $tmpl, $arg_href, 1 ) or croak q{Could not parse arguments!};
 
     use MIP::Check::Hash qw{ check_element_exist_hash_of_array };
+
+    ## Retrieve logger object
+    my $log = Log::Log4perl->get_logger($LOG_NAME);
 
     my @sorted_contigs;
 

--- a/t/data/643594-miptest/aggregated_gene_panel_test_no_contigs.txt
+++ b/t/data/643594-miptest/aggregated_gene_panel_test_no_contigs.txt
@@ -1,0 +1,27 @@
+##gene_panel=TEST,version=1.0,updated_at=2016-12-08,display_name=gene_panel_test
+##contig=1
+##contig=2
+##contig=3
+##contig=4
+##contig=5
+##contig=6
+##contig=7
+##contig=8
+##contig=9
+##contig=10
+##contig=11
+##contig=12
+##contig=13
+##contig=14
+##contig=15
+##contig=16
+##contig=17
+##contig=18
+##contig=19
+##contig=20
+##contig=21
+##contig=22
+##contig=X
+##contig=Y
+##contig=MT
+#chromosome	gene_start	gene_stop	hgnc_id	hgnc_symbol

--- a/t/get_select_file_contigs.t
+++ b/t/get_select_file_contigs.t
@@ -25,7 +25,7 @@ use MIP::Constants qw{ $COMMA $SPACE };
 use MIP::Test::Fixtures qw{ test_log test_standard_cli };
 
 my $VERBOSE = 1;
-our $VERSION = 1.03;
+our $VERSION = 1.04;
 
 $VERBOSE = test_standard_cli(
     {
@@ -76,13 +76,15 @@ my $select_file_path =
     }
 );
 my @expected_contigs = ( 1 .. $AUTOSOMAL_CONTIG_NR, qw{ X Y MT} );
+@expected_contigs = sort @expected_contigs;
 
 ## Then return the expected contigs
 is_deeply( \@{ $file_info{select_file_contigs} },
     \@expected_contigs, q{Got select file contigs} );
 
-## Given inproper file path
-my $wrong_file = catfile( $Bin, qw{ data 643594-miptest 643594-miptest_pedigree.yaml } );
+## Given bed file with no contigs
+my $wrong_file =
+  catfile( $Bin, qw{ data 643594-miptest aggregated_gene_panel_test_no_contigs.txt } );
 
 trap {
     get_select_file_contigs(

--- a/t/parse_select_file_contigs.t
+++ b/t/parse_select_file_contigs.t
@@ -60,16 +60,21 @@ diag(   q{Test parse_select_file_contigs from File_info.pm v}
 my $log = test_log( { no_screen => 0, } );
 
 ## Given a vcfparser select file path and contigs
-my %file_info =
-  ( contigs => [qw{ 1 2 3 4 5 6 7 8 9 10 11 12 13 14 15 16 17 18 19 20 21 22 X Y MT }], );
+my $consensus_analysis_type = q{wes};
+my %file_info               = (
+    contigs => [qw{ 1 2 3 4 5 6 7 8 9 10 11 12 13 14 15 16 17 18 19 20 21 22 X Y MT }],
+    contigs_size_ordered =>
+      [qw{ 1 2 3 4 5 6 7 X 8 9 10 11 12 13 14 15 16 17 18 19 20 21 22 Y MT }]
+);
 
 my $vcfparser_select_file_path =
   catfile( $Bin, qw{ data 643594-miptest aggregated_gene_panel_test.txt } );
 
 my $is_ok = parse_select_file_contigs(
     {
-        file_info_href   => \%file_info,
-        select_file_path => $vcfparser_select_file_path,
+        consensus_analysis_type => $consensus_analysis_type,
+        file_info_href          => \%file_info,
+        select_file_path        => $vcfparser_select_file_path,
     }
 );
 

--- a/t/size_sort_select_file_contigs.t
+++ b/t/size_sort_select_file_contigs.t
@@ -4,11 +4,9 @@ use 5.026;
 use Carp;
 use charnames qw{ :full :short };
 use English qw{ -no_match_vars };
-use File::Basename qw{ basename dirname };
-use File::Spec::Functions qw{ catdir catfile };
-use File::Temp;
+use File::Basename qw{ dirname };
+use File::Spec::Functions qw{ catdir };
 use FindBin qw{ $Bin };
-use Getopt::Long;
 use open qw{ :encoding(UTF-8) :std };
 use Params::Check qw{ allow check last_error };
 use Test::More;
@@ -18,79 +16,40 @@ use warnings qw{ FATAL utf8 };
 ## CPANM
 use autodie qw { :all };
 use Modern::Perl qw{ 2018 };
-use Readonly;
 use Test::Trap;
 
 ## MIPs lib/
 use lib catdir( dirname($Bin), q{lib} );
-use MIP::Log::MIP_log4perl qw{ initiate_logger };
-use MIP::Script::Utils qw{ help };
-
-our $USAGE = build_usage( {} );
+use MIP::Constants qw{ $COMMA $SPACE };
+use MIP::Test::Fixtures qw{ test_log test_standard_cli };
 
 my $VERBOSE = 1;
-our $VERSION = '1.0.0';
+our $VERSION = 1.02;
 
-## Constants
-Readonly my $COMMA   => q{,};
-Readonly my $NEWLINE => qq{\n};
-Readonly my $SPACE   => q{ };
-
-### User Options
-GetOptions(
-
-    # Display help text
-    q{h|help} => sub {
-        done_testing();
-        say {*STDOUT} $USAGE;
-        exit;
-    },
-
-    # Display version number
-    q{v|version} => sub {
-        done_testing();
-        say {*STDOUT} $NEWLINE . basename($PROGRAM_NAME) . $SPACE . $VERSION . $NEWLINE;
-        exit;
-    },
-    q{vb|verbose} => $VERBOSE,
-  )
-  or (
-    done_testing(),
-    help(
-        {
-            USAGE     => $USAGE,
-            exit_code => 1,
-        }
-    )
-  );
+$VERBOSE = test_standard_cli(
+    {
+        verbose => $VERBOSE,
+        version => $VERSION,
+    }
+);
 
 BEGIN {
+
+    use MIP::Test::Fixtures qw{ test_import };
 
 ### Check all internal dependency modules and imports
 ## Modules with import
     my %perl_module = (
-        q{MIP::Log::MIP_log4perl} => [qw{ initiate_logger }],
-        q{MIP::Script::Utils}     => [qw{ help }],
+        q{MIP::Update::Contigs} => [qw{ sort_contigs_to_contig_set }],
+        q{MIP::Test::Fixtures}  => [qw{ test_log test_standard_cli }],
     );
 
-  PERL_MODULE:
-    while ( my ( $module, $module_import ) = each %perl_module ) {
-        use_ok( $module, @{$module_import} )
-          or BAIL_OUT q{Cannot load} . $SPACE . $module;
-    }
-
-## Modules
-    my @modules = (q{MIP::Update::Contigs});
-
-  MODULE:
-    for my $module (@modules) {
-        require_ok($module) or BAIL_OUT q{Cannot load} . $SPACE . $module;
-    }
+    test_import( { perl_module_href => \%perl_module, } );
 }
 
-use MIP::Update::Contigs qw{ size_sort_select_file_contigs };
+use MIP::Update::Contigs qw{ sort_contigs_to_contig_set };
 
-diag(   q{Test size_sort_select_file_contigs from Contigs.pm v}
+diag(   q{Test sort_contigs_to_contig_set from Contigs.pm v}
       . $MIP::Update::Contigs::VERSION
       . $COMMA
       . $SPACE . q{Perl}
@@ -99,17 +58,8 @@ diag(   q{Test size_sort_select_file_contigs from Contigs.pm v}
       . $SPACE
       . $EXECUTABLE_NAME );
 
-## Create temp logger
-my $test_dir      = File::Temp->newdir();
-my $test_log_path = catfile( $test_dir, q{test.log} );
-
 ## Creates log object
-my $log = initiate_logger(
-    {
-        file_path => $test_log_path,
-        log_name  => q{TEST},
-    }
-);
+my $log = test_log( {} );
 
 my $consensus_analysis_type = q{wes};
 
@@ -117,13 +67,12 @@ my $consensus_analysis_type = q{wes};
 my %file_info = ( contigs_size_ordered => [qw{ chr1 chr2 chr3 chrM}], );
 
 trap {
-    size_sort_select_file_contigs(
+    sort_contigs_to_contig_set(
         {
             consensus_analysis_type => $consensus_analysis_type,
             file_info_href          => \%file_info,
             hash_key_sort_reference => q{contigs_size_ordered},
             hash_key_to_sort        => q{select_file_contigs},
-            log                     => $log,
         }
     )
 };
@@ -137,13 +86,12 @@ like( $trap->stderr, qr/FATAL/xms,
 %file_info = ( select_file_contigs => [qw{chr2 chr1 chrM chr3}], );
 
 trap {
-    size_sort_select_file_contigs(
+    sort_contigs_to_contig_set(
         {
             consensus_analysis_type => $consensus_analysis_type,
             file_info_href          => \%file_info,
             hash_key_sort_reference => q{contigs_size_ordered},
             hash_key_to_sort        => q{select_file_contigs},
-            log                     => $log,
         }
     )
 };
@@ -160,13 +108,12 @@ like( $trap->stderr, qr/FATAL/xms,
     select_file_contigs  => [qw{chr2 chr1 chr3}],
 );
 
-@{ $file_info{sorted_select_file_contigs} } = size_sort_select_file_contigs(
+@{ $file_info{sorted_select_file_contigs} } = sort_contigs_to_contig_set(
     {
         consensus_analysis_type => $consensus_analysis_type,
         file_info_href          => \%file_info,
         hash_key_sort_reference => q{contigs_size_ordered},
         hash_key_to_sort        => q{select_file_contigs},
-        log                     => $log,
     }
 );
 
@@ -187,13 +134,12 @@ is_deeply(
 );
 
 trap {
-    size_sort_select_file_contigs(
+    sort_contigs_to_contig_set(
         {
             consensus_analysis_type => $consensus_analysis_type,
             file_info_href          => \%file_info,
             hash_key_sort_reference => q{contigs_size_ordered},
             hash_key_to_sort        => q{select_file_contigs},
-            log                     => $log,
         }
     )
 };
@@ -209,13 +155,12 @@ like( $trap->stderr, qr/FATAL/xms,
     select_file_contigs  => [qw{chr2 chr1 chrM chr3}],
 );
 
-@{ $file_info{sorted_select_file_contigs} } = size_sort_select_file_contigs(
+@{ $file_info{sorted_select_file_contigs} } = sort_contigs_to_contig_set(
     {
         consensus_analysis_type => $consensus_analysis_type,
         file_info_href          => \%file_info,
         hash_key_sort_reference => q{contigs_size_ordered},
         hash_key_to_sort        => q{select_file_contigs},
-        log                     => $log,
     }
 );
 
@@ -227,36 +172,3 @@ is_deeply(
 );
 
 done_testing();
-
-######################
-####SubRoutines#######
-######################
-
-sub build_usage {
-
-## Function  : Build the USAGE instructions
-## Returns   :
-## Arguments : $program_name => Name of the script
-
-    my ($arg_href) = @_;
-
-    ## Default(s)
-    my $program_name;
-
-    my $tmpl = {
-        program_name => {
-            default     => basename($PROGRAM_NAME),
-            store       => \$program_name,
-            strict_type => 1,
-        },
-    };
-
-    check( $tmpl, $arg_href, 1 ) or croak q{Could not parse arguments!};
-
-    return <<"END_USAGE";
- $program_name [options]
-    -vb/--verbose Verbose
-    -h/--help     Display this help message
-    -v/--version  Display version
-END_USAGE
-}

--- a/t/sort_contigs_to_contig_set.t
+++ b/t/sort_contigs_to_contig_set.t
@@ -64,15 +64,16 @@ my $log = test_log( {} );
 my $consensus_analysis_type = q{wes};
 
 ## Given a reference hash of array, when no hash of array to sort exists
-my %file_info = ( contigs_size_ordered => [qw{ chr1 chr2 chr3 chrM}], );
+my %file_info = ( contigs_size_ordered => [qw{ chr1 chr2 chr3 chrM}],
+select_file_contigs => [],
+);
 
 trap {
     sort_contigs_to_contig_set(
         {
             consensus_analysis_type => $consensus_analysis_type,
-            file_info_href          => \%file_info,
-            hash_key_sort_reference => q{contigs_size_ordered},
-            hash_key_to_sort        => q{select_file_contigs},
+            sort_contigs_ref        => $file_info{select_file_contigs},
+            sort_reference_contigs_ref => $file_info{contigs_size_ordered},
         }
     )
 };
@@ -83,15 +84,15 @@ like( $trap->stderr, qr/FATAL/xms,
     q{Throw fatal log message if hash key to sort does not exist in supplied hash} );
 
 ## Given a hash of array to sort, when no hash of array as reference exists
-%file_info = ( select_file_contigs => [qw{chr2 chr1 chrM chr3}], );
+%file_info = ( contigs_size_ordered => [],
+select_file_contigs => [qw{chr2 chr1 chrM chr3}], );
 
 trap {
     sort_contigs_to_contig_set(
         {
             consensus_analysis_type => $consensus_analysis_type,
-            file_info_href          => \%file_info,
-            hash_key_sort_reference => q{contigs_size_ordered},
-            hash_key_to_sort        => q{select_file_contigs},
+            sort_contigs_ref        => $file_info{select_file_contigs},
+            sort_reference_contigs_ref => $file_info{contigs_size_ordered},
         }
     )
 };
@@ -111,9 +112,8 @@ like( $trap->stderr, qr/FATAL/xms,
 @{ $file_info{sorted_select_file_contigs} } = sort_contigs_to_contig_set(
     {
         consensus_analysis_type => $consensus_analysis_type,
-        file_info_href          => \%file_info,
-        hash_key_sort_reference => q{contigs_size_ordered},
-        hash_key_to_sort        => q{select_file_contigs},
+        sort_contigs_ref        => $file_info{select_file_contigs},
+        sort_reference_contigs_ref => $file_info{contigs_size_ordered},
     }
 );
 
@@ -137,9 +137,8 @@ trap {
     sort_contigs_to_contig_set(
         {
             consensus_analysis_type => $consensus_analysis_type,
-            file_info_href          => \%file_info,
-            hash_key_sort_reference => q{contigs_size_ordered},
-            hash_key_to_sort        => q{select_file_contigs},
+            sort_contigs_ref        => $file_info{select_file_contigs},
+            sort_reference_contigs_ref => $file_info{contigs_size_ordered},
         }
     )
 };
@@ -158,9 +157,8 @@ like( $trap->stderr, qr/FATAL/xms,
 @{ $file_info{sorted_select_file_contigs} } = sort_contigs_to_contig_set(
     {
         consensus_analysis_type => $consensus_analysis_type,
-        file_info_href          => \%file_info,
-        hash_key_sort_reference => q{contigs_size_ordered},
-        hash_key_to_sort        => q{select_file_contigs},
+        sort_contigs_ref        => $file_info{select_file_contigs},
+        sort_reference_contigs_ref => $file_info{contigs_size_ordered},
     }
 );
 

--- a/t/sort_contigs_to_contig_set.t
+++ b/t/sort_contigs_to_contig_set.t
@@ -40,17 +40,17 @@ BEGIN {
 ### Check all internal dependency modules and imports
 ## Modules with import
     my %perl_module = (
-        q{MIP::Update::Contigs} => [qw{ sort_contigs_to_contig_set }],
+        q{MIP::Contigs} => [qw{ sort_contigs_to_contig_set }],
         q{MIP::Test::Fixtures}  => [qw{ test_log test_standard_cli }],
     );
 
     test_import( { perl_module_href => \%perl_module, } );
 }
 
-use MIP::Update::Contigs qw{ sort_contigs_to_contig_set };
+use MIP::Contigs qw{ sort_contigs_to_contig_set };
 
 diag(   q{Test sort_contigs_to_contig_set from Contigs.pm v}
-      . $MIP::Update::Contigs::VERSION
+      . $MIP::Contigs::VERSION
       . $COMMA
       . $SPACE . q{Perl}
       . $SPACE


### PR DESCRIPTION
…g name

- Added new oneliner to get contig names
- Return is lexiographically sorted (for testing predictability purpose), but will be size sorted downstream

### This PR fixes:

- See above

### How to test:

- Automatic and continuous test pass

### Expected outcome:
- Installation, unit and integration tests pass

### Review:
- [ ] Code review
- [ ] New code is executed and covered by tests
- [ ] Tests pass
