### PR TITLE
Feature/panel clean

### DIFF
--- a/definitions/rd_dna_panel_initiation_map.yaml
+++ b/definitions/rd_dna_panel_initiation_map.yaml
@@ -3,8 +3,6 @@ CHAIN_ALL:
   - CHAIN_MAIN:
     - gzip_fastq
   # Parallel chain (branch)
-  - CHAIN_SPLITFASTQ:
-    - split_fastq_file
   - CHAIN_FASTQ:
     - fastqc_ar
   - CHAIN_MAIN:
@@ -22,7 +20,6 @@ CHAIN_ALL:
   - CHAIN_MAIN:
     # PARALLEL chains, which inherit from MAIN in initiation, but are merged back to CHAIN_MAIN after execution
     - PARALLEL:
-      - bcftools_mpileup
       - GATK_HAPLOTYPECALLER:
         - gatk_haplotypecaller
         - gatk_genotypegvcfs

--- a/definitions/rd_dna_panel_parameters.yaml
+++ b/definitions/rd_dna_panel_parameters.yaml
@@ -53,7 +53,6 @@ expected_coverage:
 ## genomeAnalysisToolKitPath
 gatk_logging_level:
   associated_recipe:
-    - bcftools_mpileup
     - gatk_baserecalibration
     - gatk_combinevariantcallsets
     - gatk_gathervcfs
@@ -84,7 +83,6 @@ gatk_use_new_qual_calculator:
 ## HumanGenomeReference
 human_genome_reference:
   associated_recipe:
-    - bcftools_mpileup
     - bwa_mem
     - gatk_baserecalibration
     - gatk_haplotypecaller
@@ -104,7 +102,6 @@ human_genome_reference:
   type: path
 human_genome_reference_file_endings:
   associated_recipe:
-    - bcftools_mpileup
     - bwa_mem
     - gatk_baserecalibration
     - gatk_haplotypecaller
@@ -128,7 +125,6 @@ recipe_core_number:
   data_type: HASH
   default:
     analysisrunstatus: 1
-    bcftools_mpileup: 16
     bwa_mem: 36
     endvariantannotationblock: 1
     fastqc_ar: 0
@@ -152,7 +148,6 @@ recipe_core_number:
     sacct: 1
     sambamba_depth: 1
     samtools_merge: 2
-    split_fastq_file: 4
     variant_integrity_ar: 1
     version_collect_ar: 1
     vt_ar: 13
@@ -181,7 +176,6 @@ recipe_memory:
     picardtools_collecthsmetrics: 8
     picardtools_collectmultiplemetrics: 8
     sambamba_depth: 10
-    split_fastq_file: 2
     varianteffectpredictor: 7
   type: mip
 set_recipe_memory:
@@ -197,7 +191,6 @@ recipe_time:
   default:
     analysisrunstatus: 1
     bwa_mem: 3
-    bcftools_mpileup: 40
     cadd_ar: 10
     endvariantannotationblock: 2
     fastqc_ar: 10
@@ -223,7 +216,6 @@ recipe_time:
     sacct: 1
     sambamba_depth: 10
     samtools_merge: 2
-    split_fastq_file: 10
     varianteffectpredictor: 10
     variant_integrity_ar: 1
     version_collect_ar: 1
@@ -247,7 +239,6 @@ infile_dirs:
 picardtools_path:
   associated_recipe:
     - bwa_mem
-    - markduplicates
     - picardtools_collecthsmetrics
     - picardtools_collectmultiplemetrics
   data_type: SCALAR
@@ -259,24 +250,6 @@ replace_iupac:
   default: 0
   type: mip
 ### Programs
-split_fastq_file:
-  analysis_mode: sample
-  associated_recipe:
-    - mip
-  data_type: SCALAR
-  default: 0
-  file_tag: nofile_tag
-  outfile_suffix: ".fastq.gz"
-  program_executables:
-    - pigz
-    - split
-  type: recipe
-split_fastq_file_read_batch:
-  associated_recipe:
-    - split_fastq_file
-  data_type: SCALAR
-  default: 25000000
-  type: recipe_argument
 ## Gzip
 gzip_fastq:
   analysis_mode: sample
@@ -498,37 +471,6 @@ picardtools_collecthsmetrics:
   default: 1
   file_tag: _collecthsmetrics
   type: recipe
-## Bcftools
-bcftools_mpileup:
-  analysis_mode: case
-  associated_recipe:
-    - mip
-  data_type: SCALAR
-  default: 0
-  file_tag: _mpileup
-  program_executables:
-    - bcftools
-  recipe_type: variant_callers
-  outfile_suffix: ".vcf"
-  type: recipe
-bcftools_mpileup_constrain:
-  associated_recipe:
-    - bcftools_mpileup
-  data_type: SCALAR
-  mandatory: no
-  type: recipe_argument
-bcftools_mpileup_filter_variant:
-  associated_recipe:
-    - bcftools_mpileup
-  data_type: SCALAR
-  default: 0
-  type: recipe_argument
-bcftools_mpileup_keep_unnormalised:
-  associated_recipe:
-    - bcftools_mpileup
-  data_type: SCALAR
-  default: 0
-  type: recipe_argument
 ## GATK Genotype
 gatk_haplotypecaller:
   analysis_mode: sample
@@ -583,7 +525,7 @@ gatk_haplotypecaller_pcr_indel_model:
   associated_recipe:
     - gatk_haplotypecaller
   data_type: SCALAR
-  default: "NONE"
+  default: "CONSERVATIVE"
   type: recipe_argument
 gatk_haplotypecaller_snp_known_set:
   associated_recipe:

--- a/lib/MIP/Cli/Mip/Analyse/Rd_dna_panel.pm
+++ b/lib/MIP/Cli/Mip/Analyse/Rd_dna_panel.pm
@@ -17,7 +17,7 @@ use Moose::Util::TypeConstraints;
 ## MIPs lib
 use MIP::Main::Analyse qw{ mip_analyse };
 
-our $VERSION = 1.01;
+our $VERSION = 1.02;
 
 extends(qw{ MIP::Cli::Mip::Analyse });
 
@@ -593,46 +593,6 @@ q{Default: grch37_dbsnp_-138-.vcf, grch37_1000g_indels_-phase1-.vcf, grch37_mill
     );
 
     option(
-        q{bcftools_mpileup} => (
-            cmd_aliases   => [qw{ bmp }],
-            cmd_tags      => [q{Analysis recipe switch}],
-            documentation => q{Variant calling using bcftools mpileup},
-            is            => q{rw},
-            isa           => enum( [ 0, 1, 2 ] ),
-        )
-    );
-
-    option(
-        q{bcftools_mpileup_constrain} => (
-            cmd_aliases   => [qw{ bmpcon }],
-            cmd_flag      => q{bcftools_mpileup_constrain},
-            documentation => q{Use contrain in trio calling},
-            is            => q{rw},
-            isa           => Bool,
-        )
-    );
-
-    option(
-        q{bcftools_mpileup_filter_variant} => (
-            cmd_aliases   => [qw{ bmpfv }],
-            cmd_flag      => q{bcftools_mpileup_fil_var},
-            documentation => q{Use standard bcftools filters},
-            is            => q{rw},
-            isa           => Bool,
-        )
-    );
-
-    option(
-        q{bcftools_mpileup_keep_unnormalised} => (
-            cmd_aliases   => [qw{ bmpkn }],
-            cmd_flag      => q{bcftools_mpileup_keep_unn},
-            documentation => q{Do not normalise variants},
-            is            => q{rw},
-            isa           => Bool,
-        )
-    );
-
-    option(
         q{gatk_haplotypecaller} => (
             cmd_aliases   => [qw{ ghc }],
             cmd_tags      => [q{Analysis recipe switch}],
@@ -964,7 +924,7 @@ q{Number of hom-ref genotypes to infer at sites not present in a panel. Connecte
             cmd_flag      => q{gatk_combinevar_prio_cal},
             documentation => q{Prioritization order of variant callers},
             is            => q{rw},
-            isa           => enum( [qw{ gatk bcftools }] ),
+            isa           => enum( [qw{ gatk }] ),
         )
     );
 

--- a/lib/MIP/Cli/Mip/Analyse/Rd_dna_panel.pm
+++ b/lib/MIP/Cli/Mip/Analyse/Rd_dna_panel.pm
@@ -295,27 +295,6 @@ q{gatk_baserecalibration_known_sites, gatk_haplotypecaller_snp_known_set, gatk_v
     );
 
     option(
-        q{split_fastq_file} => (
-            cmd_aliases   => [qw{ sfq }],
-            cmd_tags      => [q{Analysis recipe switch}],
-            documentation => q{Split fastq files in batches of X reads and exits},
-            is            => q{rw},
-            isa           => enum( [ 0, 1, 2 ] ),
-        )
-    );
-
-    option(
-        q{split_fastq_file_read_batch} => (
-            cmd_aliases   => [qw{ sfqrdb }],
-            cmd_flag      => q{spt_fsq_rd_bt},
-            cmd_tags      => [q{Default: 25,000,000}],
-            documentation => q{Number of sequence reads to place in each batch},
-            is            => q{rw},
-            isa           => Int,
-        )
-    );
-
-    option(
         q{gzip_fastq} => (
             cmd_aliases   => [qw{ gz }],
             cmd_tags      => [q{Analysis recipe switch}],


### PR DESCRIPTION
### This PR fixes:
- removes references to bcftools_mpileup and split_fastq from the panel pipe
- part of #1424

### How to test:

- Automatic and continuous test pass

### Expected outcome:
- Installation, unit and integration tests pass

### Review:
- [ ] Code review
- [ ] New code is executed and covered by tests
- [ ] Tests pass
