### PR TITLE
Feature/pan rankvariant

### DIFF
--- a/definitions/rd_dna_panel_parameters.yaml
+++ b/definitions/rd_dna_panel_parameters.yaml
@@ -207,7 +207,7 @@ recipe_time:
     picardtools_collecthsmetrics: 5
     picardtools_collectmultiplemetrics: 5
     qccollect_ar: 1
-    rankvariant: 10
+    rankvariant: 1
     rtg_vcfeval: 1
     sacct: 1
     sambamba_depth: 1

--- a/lib/MIP/Analysis.pm
+++ b/lib/MIP/Analysis.pm
@@ -28,7 +28,7 @@ BEGIN {
     use base qw{ Exporter };
 
     # Set the version for version checking
-    our $VERSION = 1.18;
+    our $VERSION = 1.19;
 
     # Functions and variables which can be optionally exported
     our @EXPORT_OK = qw{
@@ -59,10 +59,10 @@ sub check_analysis_type_to_pipeline {
             strict_type => 1,
         },
         pipeline => {
-            allow       => [qw{ dragen_rd_dna rd_dna rd_dna_panel rd_dna_vcf_rerun rd_rna}],
-            defined     => 1,
-            required    => 1,
-            store       => \$pipeline,
+            allow    => [qw{ dragen_rd_dna rd_dna rd_dna_panel rd_dna_vcf_rerun rd_rna}],
+            defined  => 1,
+            required => 1,
+            store    => \$pipeline,
             strict_type => 1,
         },
     };
@@ -157,14 +157,20 @@ sub get_vcf_parser_analysis_suffix {
 
 ## Function : Get the vcf parser analysis suffix
 ## Returns  : @analysis_suffixes
-## Arguments: $vcfparser_outfile_count => Number of user supplied vcf parser outfiles
+## Arguments: $analysis_type           => Analysis type
+##          : $vcfparser_outfile_count => Number of user supplied vcf parser outfiles
 
     my ($arg_href) = @_;
 
-## Flatten argument(s)
+    ## Flatten argument(s)
+    my $analysis_type;
     my $vcfparser_outfile_count;
 
     my $tmpl = {
+        analysis_type => {
+            store       => \$analysis_type,
+            strict_type => 1,
+        },
         vcfparser_outfile_count => {
             defined     => 1,
             required    => 1,
@@ -176,6 +182,12 @@ sub get_vcf_parser_analysis_suffix {
     check( $tmpl, $arg_href, 1 ) or croak q{Could not parse arguments!};
 
     Readonly my $VCFPARSER_OUTFILE_COUNT => $vcfparser_outfile_count - 1;
+
+    my $analysis_type_suffix = $EMPTY_STR;
+    if ( defined $analysis_type and $analysis_type eq q{panel} ) {
+
+        $analysis_type_suffix = q{all};
+    }
 
     my @analysis_suffixes;
 
@@ -189,7 +201,7 @@ sub get_vcf_parser_analysis_suffix {
             push @analysis_suffixes, q{selected};
             next;
         }
-        push @analysis_suffixes, $EMPTY_STR;
+        push @analysis_suffixes, $analysis_type_suffix;
     }
     return @analysis_suffixes;
 }

--- a/lib/MIP/Analysis.pm
+++ b/lib/MIP/Analysis.pm
@@ -59,7 +59,7 @@ sub check_analysis_type_to_pipeline {
             strict_type => 1,
         },
         pipeline => {
-            allow    => [qw{ dragen_rd_dna rd_dna rd_dna_panel rd_dna_vcf_rerun rd_rna}],
+            allow    => [qw{ dragen_rd_dna rd_dna rd_dna_panel rd_dna_vcf_rerun rd_rna }],
             defined  => 1,
             required => 1,
             store    => \$pipeline,

--- a/lib/MIP/Program/Gatk.pm
+++ b/lib/MIP/Program/Gatk.pm
@@ -26,7 +26,7 @@ BEGIN {
     use base qw{ Exporter };
 
     # Set the version for version checking
-    our $VERSION = 1.15;
+    our $VERSION = 1.16;
 
     # Functions and variables which can be optionally exported
     our @EXPORT_OK = qw{
@@ -1639,7 +1639,7 @@ sub gatk_concatenate_variants {
             strict_type => 1,
         },
         outfile_suffix => {
-            allow       => [qw{ .vcf .selected.vcf }],
+            allow       => [qw{ .all.vcf .vcf .selected.vcf }],
             default     => q{.vcf},
             store       => \$outfile_suffix,
             strict_type => 1,

--- a/lib/MIP/Program/Gatk.pm
+++ b/lib/MIP/Program/Gatk.pm
@@ -1639,7 +1639,7 @@ sub gatk_concatenate_variants {
             strict_type => 1,
         },
         outfile_suffix => {
-            allow       => [qw{ .all.vcf .vcf .selected.vcf }],
+            allow       => [qw{ .all.vcf .selected.vcf .vcf }],
             default     => q{.vcf},
             store       => \$outfile_suffix,
             strict_type => 1,

--- a/lib/MIP/Recipes/Analysis/Mip_vcfparser.pm
+++ b/lib/MIP/Recipes/Analysis/Mip_vcfparser.pm
@@ -557,6 +557,7 @@ sub analysis_mip_vcfparser_panel {
     use MIP::Get::File qw{ get_io_files };
     use MIP::Get::Parameter qw{ get_recipe_attributes get_recipe_resources };
     use MIP::List qw{ get_splitted_lists };
+    use MIP::Parameter qw{ get_cache };
     use MIP::Parse::File qw{ parse_io_outfiles };
     use MIP::Processmanagement::Processes qw{ submit_recipe };
     use MIP::Program::Bcftools qw{ bcftools_view bcftools_view_and_index_vcf };
@@ -600,9 +601,15 @@ sub analysis_mip_vcfparser_panel {
         }
     );
 
+    my $analysis_type = get_cache(
+        {
+            parameter_href => $parameter_href,
+            parameter_name => q{consensus_analysis_type},
+        }
+    );
     my @vcfparser_analysis_suffixes = get_vcf_parser_analysis_suffix(
         {
-            analysis_type           => $parameter_href->{cache}{consensus_analysis_type},
+            analysis_type           => $analysis_type,
             vcfparser_outfile_count => $active_parameter_href->{vcfparser_outfile_count},
         }
     );

--- a/lib/MIP/Recipes/Analysis/Mip_vcfparser.pm
+++ b/lib/MIP/Recipes/Analysis/Mip_vcfparser.pm
@@ -27,7 +27,7 @@ BEGIN {
     use base qw{ Exporter };
 
     # Set the version for version checking
-    our $VERSION = 1.22;
+    our $VERSION = 1.23;
 
     # Functions and variables which can be optionally exported
     our @EXPORT_OK =
@@ -602,6 +602,7 @@ sub analysis_mip_vcfparser_panel {
 
     my @vcfparser_analysis_suffixes = get_vcf_parser_analysis_suffix(
         {
+            analysis_type           => $parameter_href->{cache}{consensus_analysis_type},
             vcfparser_outfile_count => $active_parameter_href->{vcfparser_outfile_count},
         }
     );

--- a/lib/MIP/Recipes/Analysis/Rankvariant.pm
+++ b/lib/MIP/Recipes/Analysis/Rankvariant.pm
@@ -378,7 +378,7 @@ sub analysis_rankvariant {
         genmod_compound(
             {
                 filehandle          => $xargsfilehandle,
-                infile_path         => $DASH,
+                infile_path         => $genmod_indata,
                 outfile_path        => $outfile_path{$contig_index},
                 stderrfile_path     => $compound_stderrfile_path,
                 temp_directory_path => $temp_directory,

--- a/lib/MIP/Recipes/Pipeline/Analyse_rd_dna_panel.pm
+++ b/lib/MIP/Recipes/Pipeline/Analyse_rd_dna_panel.pm
@@ -25,7 +25,7 @@ BEGIN {
     use base qw{ Exporter };
 
     # Set the version for version checking
-    our $VERSION = 1.10;
+    our $VERSION = 1.11;
 
     # Functions and variables which can be optionally exported
     our @EXPORT_OK = qw{ pipeline_analyse_rd_dna_panel };
@@ -175,6 +175,7 @@ sub pipeline_analyse_rd_dna_panel {
       qw{ analysis_picardtools_collecthsmetrics };
     use MIP::Recipes::Analysis::Picardtools_collectmultiplemetrics
       qw{ analysis_picardtools_collectmultiplemetrics };
+    use MIP::Recipes::Analysis::Rankvariant qw{ analysis_rankvariant };
     use MIP::Recipes::Analysis::Rtg_vcfeval qw{ analysis_rtg_vcfeval  };
     use MIP::Recipes::Analysis::Sambamba_depth qw{ analysis_sambamba_depth };
     use MIP::Recipes::Analysis::Samtools_merge qw{ analysis_samtools_merge_panel };
@@ -250,6 +251,7 @@ sub pipeline_analyse_rd_dna_panel {
         picardtools_collecthsmetrics => \&analysis_picardtools_collecthsmetrics,
         picardtools_collectmultiplemetrics =>
           \&analysis_picardtools_collectmultiplemetrics,
+        rankvariant            => \&analysis_rankvariant,
         rtg_vcfeval            => \&analysis_rtg_vcfeval,
         sambamba_depth         => \&analysis_sambamba_depth,
         samtools_merge         => \&analysis_samtools_merge_panel,

--- a/t/get_vcf_parser_analysis_suffix.t
+++ b/t/get_vcf_parser_analysis_suffix.t
@@ -16,6 +16,7 @@ use warnings qw{ FATAL utf8 };
 ## CPANM
 use autodie qw { :all };
 use Modern::Perl qw{ 2018 };
+use Readonly;
 
 ## MIPs lib/
 use lib catdir( dirname($Bin), q{lib} );
@@ -23,7 +24,7 @@ use MIP::Constants qw{ $COMMA $EMPTY_STR $SPACE };
 use MIP::Test::Fixtures qw{ test_standard_cli };
 
 my $VERBOSE = 1;
-our $VERSION = 1.01;
+our $VERSION = 1.02;
 
 $VERBOSE = test_standard_cli(
     {
@@ -57,23 +58,42 @@ diag(   q{Test get_vcf_parser_analysis_suffix from Analysis.pm v}
       . $SPACE
       . $EXECUTABLE_NAME );
 
-my @expected_suffix    = ($EMPTY_STR);
-my @expected_sv_suffix = ( $EMPTY_STR, q{selected} );
+Readonly my $TWO => 2;
+
+my @expected_suffixes       = ($EMPTY_STR);
+my @expected_sv_suffixes    = ( $EMPTY_STR, q{selected} );
+my @expected_panel_suffixes = qw{ all selected };
 
 ## Given research outfile
-my $vcfparser_outfile_count = 1;
-my @analysis_suffix         = get_vcf_parser_analysis_suffix(
-    { vcfparser_outfile_count => $vcfparser_outfile_count, } );
+my @analysis_suffixes = get_vcf_parser_analysis_suffix(
+    {
+        vcfparser_outfile_count => 1,
+    }
+);
 
 ## Then return only $EMPTY_STR suffix
-is_deeply( \@analysis_suffix, \@expected_suffix, q{Get single analysis suffix} );
+is_deeply( \@analysis_suffixes, \@expected_suffixes, q{Get single analysis suffix} );
 
 ## Given research and select outfiles
-my $sv_vcfparser_outfile_count = 2;
-my @analysis_sv_suffix         = get_vcf_parser_analysis_suffix(
-    { vcfparser_outfile_count => $sv_vcfparser_outfile_count, } );
+my @analysis_sv_suffixes = get_vcf_parser_analysis_suffix(
+    {
+        vcfparser_outfile_count => $TWO,
+    }
+);
 
 ## Then return both suffixes
-is_deeply( \@analysis_sv_suffix, \@expected_sv_suffix, q{Get both analysis suffixes} );
+is_deeply( \@analysis_sv_suffixes, \@expected_sv_suffixes,
+    q{Get both analysis suffixes} );
+
+my @analysis_panel_suffixes = get_vcf_parser_analysis_suffix(
+    {
+        analysis_type           => q{panel},
+        vcfparser_outfile_count => $TWO,
+    }
+);
+
+## Then return both suffixes
+is_deeply( \@analysis_panel_suffixes, \@expected_panel_suffixes,
+    q{Get both panel suffixes} );
 
 done_testing();


### PR DESCRIPTION
### This PR fixes:

- adds the rankvariant recipe to the panel pipe
- adds the new suffix 'all' in tvcfparser to denote the research vcf for the panel pipe. This is done to enable use of the regular rankvariant recipe.   
- part of #1424

### How to test:

- Automatic and continuous test pass

### Expected outcome:
- Installation, unit and integration tests pass

### Review:
- [ ] Code review
- [ ] New code is executed and covered by tests
- [ ] Tests pass
