### PR TITLE
Feature/cadd to vcfanno

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,8 @@ All notable changes to this project will be documented in this file.
 This project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Develop]
+- Moved annotationof CADD and SPIDEX to vcfanno´s toml config
+- Removed CADD and SPIDEX annotations from Rankvariants recipe, CLI and parameters
 - Turned off bcftools_mpileup by default
 - Replaced sambamba sort with samtools sort after alignment
 - Replaced recipe picartools_mergesamfiles with samtools_merge
@@ -15,6 +17,10 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 - htslib: 1.9-hc238db4_4 -> 1.10.2=h78d89cc_0 (DNA)
 - picard: 2.20.7 -> 2.22.0 (DNA)
 - samtools: 1.9=h8571acd_11 -> 1.10-h9402c20_2 (DNA)
+
+**References**
+- grch38_frequency_vcfanno_filter_config_-v1.2-.toml -> grch38_frequency_vcfanno_filter_config_-v1.3-.toml
+- grch37_frequency_vcfanno_filter_config_-v1.3-.toml -> grch37_frequency_vcfanno_filter_config_-v1.4-.toml
 
 ## [8.2.4]
 - Chromograph patch

--- a/definitions/dragen_rd_dna_parameters.yaml
+++ b/definitions/dragen_rd_dna_parameters.yaml
@@ -729,29 +729,12 @@ rankvariant:
   program_executables:
     - genmod
   type: recipe
-genmod_annotate_cadd_files:
-  associated_recipe:
-    - rankvariant
-  data_type: ARRAY
-  exists_check: file
-  is_reference: 1
-  mandatory: no
-  reference: reference_dir
-  type: path
 genmod_annotate_regions:
   associated_recipe:
     - rankvariant
   data_type: SCALAR
   default: 0
   type: recipe_argument
-genmod_annotate_spidex_file:
-  associated_recipe:
-    - rankvariant
-  data_type: SCALAR
-  exists_check: file
-  is_reference: 1
-  reference: reference_dir
-  type: path
 genmod_models_case_type:
   associated_recipe:
     - rankvariant

--- a/definitions/rd_dna_panel_parameters.yaml
+++ b/definitions/rd_dna_panel_parameters.yaml
@@ -1123,30 +1123,12 @@ rankvariant:
   program_executables:
     - genmod
   type: recipe
-genmod_annotate_cadd_files:
-  associated_recipe:
-    - rankvariant
-  data_type: ARRAY
-  exists_check: file
-  is_reference: 1
-  mandatory: no
-  reference: reference_dir
-  type: path
 genmod_annotate_regions:
   associated_recipe:
     - rankvariant
   data_type: SCALAR
   default: 1
   type: recipe_argument
-genmod_annotate_spidex_file:
-  associated_recipe:
-    - rankvariant
-  data_type: SCALAR
-  exists_check: file
-  is_reference: 1
-  mandatory: no
-  reference: reference_dir
-  type: path
 genmod_models_case_type:
   associated_recipe:
     - rankvariant

--- a/definitions/rd_dna_parameters.yaml
+++ b/definitions/rd_dna_parameters.yaml
@@ -1898,30 +1898,12 @@ rankvariant:
   program_executables:
     - genmod
   type: recipe
-genmod_annotate_cadd_files:
-  associated_recipe:
-    - rankvariant
-  data_type: ARRAY
-  exists_check: file
-  is_reference: 1
-  mandatory: no
-  reference: reference_dir
-  type: path
 genmod_annotate_regions:
   associated_recipe:
     - rankvariant
   data_type: SCALAR
   default: 1
   type: recipe_argument
-genmod_annotate_spidex_file:
-  associated_recipe:
-    - rankvariant
-  data_type: SCALAR
-  exists_check: file
-  is_reference: 1
-  mandatory: no
-  reference: reference_dir
-  type: path
 genmod_models_case_type:
   associated_recipe:
     - rankvariant

--- a/definitions/rd_dna_vcf_rerun_parameters.yaml
+++ b/definitions/rd_dna_vcf_rerun_parameters.yaml
@@ -714,29 +714,12 @@ rankvariant:
   program_executables:
     - genmod
   type: recipe
-genmod_annotate_cadd_files:
-  associated_recipe:
-    - rankvariant
-  data_type: ARRAY
-  exists_check: file
-  is_reference: 1
-  mandatory: no
-  reference: reference_dir
-  type: path
 genmod_annotate_regions:
   associated_recipe:
     - rankvariant
   data_type: SCALAR
   default: 1
   type: recipe_argument
-genmod_annotate_spidex_file:
-  associated_recipe:
-    - rankvariant
-  data_type: SCALAR
-  exists_check: file
-  is_reference: 1
-  reference: reference_dir
-  type: path
 genmod_models_case_type:
   associated_recipe:
     - rankvariant

--- a/lib/MIP/Check/Reference.pm
+++ b/lib/MIP/Check/Reference.pm
@@ -24,7 +24,7 @@ BEGIN {
     use base qw{ Exporter };
 
     # Set the version for version checking
-    our $VERSION = 1.13;
+    our $VERSION = 1.14;
 
     # Functions and variables which can be optionally exported
     our @EXPORT_OK = qw{
@@ -341,6 +341,9 @@ sub _parse_vcfanno_toml_path {
 
         ## Annotation file path to check
         my $annotation_file_path = $annotation_href->{file};
+
+        ## Only check vcf files which should have the fields annotation
+        next ANNOTATION if ( not exists $annotation_href->{fields} );
 
         if ( not exists $seen_href->{$annotation_file_path} ) {
 

--- a/lib/MIP/Cli/Mip/Analyse/Dragen_rd_dna.pm
+++ b/lib/MIP/Cli/Mip/Analyse/Dragen_rd_dna.pm
@@ -17,7 +17,7 @@ use Moose::Util::TypeConstraints;
 ## MIPs lib
 use MIP::Main::Analyse qw{ mip_analyse };
 
-our $VERSION = 1.13;
+our $VERSION = 1.14;
 
 extends(qw{ MIP::Cli::Mip::Analyse });
 
@@ -794,16 +794,6 @@ q{Default: hgvs, symbol, numbers, sift, polyphen, humdiv, domains, protein, ccds
     );
 
     option(
-        q{genmod_annotate_cadd_files} => (
-            cmd_aliases   => [qw{ ravcad }],
-            cmd_flag      => q{genmod_ann_cadd_fs},
-            documentation => q{CADD score files},
-            is            => q{rw},
-            isa           => ArrayRef [Str],
-        )
-    );
-
-    option(
         q{genmod_annotate_regions} => (
             cmd_aliases => [qw{ ravanr }],
             cmd_flag    => q{genmod_ann_reg},
@@ -811,16 +801,6 @@ q{Default: hgvs, symbol, numbers, sift, polyphen, humdiv, domains, protein, ccds
               q{Use predefined gene annotation supplied with genmod for defining genes},
             is  => q{rw},
             isa => Bool,
-        )
-    );
-
-    option(
-        q{genmod_annotate_spidex_file} => (
-            cmd_aliases   => [qw{ ravspi }],
-            cmd_flag      => q{genmod_ann_spidex_f},
-            documentation => q{Spidex database for alternative splicing},
-            is            => q{rw},
-            isa           => Str,
         )
     );
 

--- a/lib/MIP/Cli/Mip/Analyse/Rd_dna.pm
+++ b/lib/MIP/Cli/Mip/Analyse/Rd_dna.pm
@@ -17,7 +17,7 @@ use Moose::Util::TypeConstraints;
 ## MIPs lib
 use MIP::Main::Analyse qw{ mip_analyse };
 
-our $VERSION = 1.50;
+our $VERSION = 1.51;
 
 extends(qw{ MIP::Cli::Mip::Analyse });
 
@@ -1941,16 +1941,6 @@ q{Default: hgvs, symbol, numbers, sift, polyphen, humdiv, domains, protein, ccds
     );
 
     option(
-        q{genmod_annotate_cadd_files} => (
-            cmd_aliases   => [qw{ ravcad }],
-            cmd_flag      => q{genmod_ann_cadd_fs},
-            documentation => q{CADD score files},
-            is            => q{rw},
-            isa           => ArrayRef [Str],
-        )
-    );
-
-    option(
         q{genmod_annotate_regions} => (
             cmd_aliases => [qw{ ravanr }],
             cmd_flag    => q{genmod_ann_reg},
@@ -1958,16 +1948,6 @@ q{Default: hgvs, symbol, numbers, sift, polyphen, humdiv, domains, protein, ccds
               q{Use predefined gene annotation supplied with genmod for defining genes},
             is  => q{rw},
             isa => Bool,
-        )
-    );
-
-    option(
-        q{genmod_annotate_spidex_file} => (
-            cmd_aliases   => [qw{ ravspi }],
-            cmd_flag      => q{genmod_ann_spidex_f},
-            documentation => q{Spidex database for alternative splicing},
-            is            => q{rw},
-            isa           => Str,
         )
     );
 

--- a/lib/MIP/Cli/Mip/Analyse/Rd_dna_panel.pm
+++ b/lib/MIP/Cli/Mip/Analyse/Rd_dna_panel.pm
@@ -17,7 +17,7 @@ use Moose::Util::TypeConstraints;
 ## MIPs lib
 use MIP::Main::Analyse qw{ mip_analyse };
 
-our $VERSION = 1.04;
+our $VERSION = 1.03;
 
 extends(qw{ MIP::Cli::Mip::Analyse });
 
@@ -1197,16 +1197,6 @@ q{Default: hgvs, symbol, numbers, sift, polyphen, humdiv, domains, protein, ccds
     );
 
     option(
-        q{genmod_annotate_cadd_files} => (
-            cmd_aliases   => [qw{ ravcad }],
-            cmd_flag      => q{genmod_ann_cadd_fs},
-            documentation => q{CADD score files},
-            is            => q{rw},
-            isa           => ArrayRef [Str],
-        )
-    );
-
-    option(
         q{genmod_annotate_regions} => (
             cmd_aliases => [qw{ ravanr }],
             cmd_flag    => q{genmod_ann_reg},
@@ -1214,16 +1204,6 @@ q{Default: hgvs, symbol, numbers, sift, polyphen, humdiv, domains, protein, ccds
               q{Use predefined gene annotation supplied with genmod for defining genes},
             is  => q{rw},
             isa => Bool,
-        )
-    );
-
-    option(
-        q{genmod_annotate_spidex_file} => (
-            cmd_aliases   => [qw{ ravspi }],
-            cmd_flag      => q{genmod_ann_spidex_f},
-            documentation => q{Spidex database for alternative splicing},
-            is            => q{rw},
-            isa           => Str,
         )
     );
 

--- a/lib/MIP/Cli/Mip/Analyse/Rd_dna_vcf_rerun.pm
+++ b/lib/MIP/Cli/Mip/Analyse/Rd_dna_vcf_rerun.pm
@@ -17,7 +17,7 @@ use Moose::Util::TypeConstraints;
 ## MIPs lib
 use MIP::Main::Analyse qw{ mip_analyse };
 
-our $VERSION = 1.27;
+our $VERSION = 1.28;
 
 extends(qw{ MIP::Cli::Mip::Analyse });
 
@@ -777,16 +777,6 @@ q{Default: hgvs, symbol, numbers, sift, polyphen, humdiv, domains, protein, ccds
     );
 
     option(
-        q{genmod_annotate_cadd_files} => (
-            cmd_aliases   => [qw{ ravcad }],
-            cmd_flag      => q{genmod_ann_cadd_fs},
-            documentation => q{CADD score files},
-            is            => q{rw},
-            isa           => ArrayRef [Str],
-        )
-    );
-
-    option(
         q{genmod_annotate_regions} => (
             cmd_aliases => [qw{ ravanr }],
             cmd_flag    => q{genmod_ann_reg},
@@ -794,16 +784,6 @@ q{Default: hgvs, symbol, numbers, sift, polyphen, humdiv, domains, protein, ccds
               q{Use predefined gene annotation supplied with genmod for defining genes},
             is  => q{rw},
             isa => Bool,
-        )
-    );
-
-    option(
-        q{genmod_annotate_spidex_file} => (
-            cmd_aliases   => [qw{ ravspi }],
-            cmd_flag      => q{genmod_ann_spidex_f},
-            documentation => q{Spidex database for alternative splicing},
-            is            => q{rw},
-            isa           => Str,
         )
     );
 

--- a/lib/MIP/Recipes/Analysis/Rankvariant.pm
+++ b/lib/MIP/Recipes/Analysis/Rankvariant.pm
@@ -312,14 +312,11 @@ sub analysis_rankvariant {
 
         genmod_annotate(
             {
-                annotate_region => $active_parameter_href->{genmod_annotate_regions},
-                cadd_file_paths_ref =>
-                  \@{ $active_parameter_href->{genmod_annotate_cadd_files} },
-                filehandle       => $xargsfilehandle,
-                infile_path      => $infile_path,
-                outfile_path     => $genmod_outfile_path,
-                spidex_file_path => $active_parameter_href->{genmod_annotate_spidex_file},
-                stderrfile_path  => $annotate_stderrfile_path,
+                annotate_region     => $active_parameter_href->{genmod_annotate_regions},
+                filehandle          => $xargsfilehandle,
+                infile_path         => $infile_path,
+                outfile_path        => $genmod_outfile_path,
+                stderrfile_path     => $annotate_stderrfile_path,
                 temp_directory_path => $temp_directory,
                 verbosity           => q{v},
             }
@@ -715,14 +712,11 @@ sub analysis_rankvariant_unaffected {
 
         genmod_annotate(
             {
-                annotate_region => $active_parameter_href->{genmod_annotate_regions},
-                cadd_file_paths_ref =>
-                  \@{ $active_parameter_href->{genmod_annotate_cadd_files} },
-                filehandle       => $xargsfilehandle,
-                infile_path      => $genmod_indata,
-                outfile_path     => $genmod_outfile_path,
-                spidex_file_path => $active_parameter_href->{genmod_annotate_spidex_file},
-                stderrfile_path  => $annotate_stderrfile_path,
+                annotate_region     => $active_parameter_href->{genmod_annotate_regions},
+                filehandle          => $xargsfilehandle,
+                infile_path         => $genmod_indata,
+                outfile_path        => $genmod_outfile_path,
+                stderrfile_path     => $annotate_stderrfile_path,
                 temp_directory_path => $temp_directory,
                 verbosity           => q{v},
             }

--- a/lib/MIP/Vcfanno.pm
+++ b/lib/MIP/Vcfanno.pm
@@ -22,7 +22,7 @@ BEGIN {
     use base qw{ Exporter };
 
     # Set the version for version checking
-    our $VERSION = 1.00;
+    our $VERSION = 1.01;
 
     # Functions and variables which can be optionally exported
     our @EXPORT_OK = qw{ check_vcfanno_toml parse_toml_config_parameters };
@@ -70,7 +70,11 @@ sub check_vcfanno_toml {
             path   => $vcfanno_file_toml,
         }
     );
-    my @vcfanno_features = qw{ file fields ops };
+    my %vcfanno_feature = (
+        vcf   => [qw{ file fields ops }],
+        other => [qw{ columns file names ops }],
+    );
+
     my $err_msg = q{ is not defined or empty vcfanno toml features. Please check file: }
       . $vcfanno_file_toml;
     my @missing_annotations;
@@ -78,8 +82,13 @@ sub check_vcfanno_toml {
   ANNOTATION:
     foreach my $annotation_href ( @{ $vcfanno_config{annotation} } ) {
 
+        my $file_format = q{other};
+        if ( $annotation_href->{file} =~ qr/[.]vcf | [.]vcf[.]gz/xsm ) {
+            $file_format = q{vcf};
+        }
+
       FEATURE:
-        foreach my $feature (@vcfanno_features) {
+        foreach my $feature ( @{ $vcfanno_feature{$file_format} } ) {
 
             ## Check mandatory feature keys for vcfanno
             next FEATURE if ( defined $annotation_href->{$feature} );

--- a/t/check_vcfanno_toml.t
+++ b/t/check_vcfanno_toml.t
@@ -42,9 +42,10 @@ BEGIN {
 ### Check all internal dependency modules and imports
 ## Modules with import
     my %perl_module = (
-        q{MIP::Vcfanno}                    => [qw{ check_vcfanno_toml }],
-        q{MIP::Test::Fixtures}             => [qw{ test_log test_standard_cli }],
-        q{MIP::Environment::Child_process} => [qw{ child_process }],
+        q{MIP::Environment::Child_process} => [qw{child_process}],
+        q{MIP::Vcfanno}                    => [qw{check_vcfanno_toml}],
+        q{MIP::Test::Fixtures}             => [qw{test_log test_standard_cli}],
+        q{MIP::Toml}                       => [qw{ load_toml write_toml }],
     );
 
     test_import( { perl_module_href => \%perl_module, } );
@@ -52,6 +53,7 @@ BEGIN {
 
 use MIP::Vcfanno qw{ check_vcfanno_toml };
 use MIP::Environment::Child_process qw{ child_process };
+use MIP::Toml qw{ load_toml write_toml };
 
 diag(   q{Test check_vcfanno_toml from Vcfanno.pm v}
       . $MIP::Vcfanno::VERSION
@@ -75,24 +77,26 @@ my $fqa_vcfanno_config =
 
 # For the actual test
 my $test_fqa_vcfanno_config = catfile( $test_reference_dir,
-    qw{ grch37_frequency_vcfanno_filter_config_test_check_toml_-v1.0-.toml  } );
+    qw{ grch37_frequency_vcfanno_filter_config_test_check_vcfanno_-v1.0-.toml  } );
 
-my $file_path = catfile( $test_reference_dir, q{grch37_gnomad.genomes_-r2.0.1-.vcf.gz} );
-
-## Replace line starting with "file=" with dynamic file path
-my $parse_path =
-    q?perl -nae 'chomp;if($_=~/file=/) {say STDOUT q{file="?
-  . $file_path
-  . q?"};} else {say STDOUT $_}' ?;
-
-## Parse original file and create new config for test
-my $command_string = join $SPACE,
-  ( $parse_path, $fqa_vcfanno_config, q{>}, $test_fqa_vcfanno_config );
-
-my %process_return = child_process(
+my $toml_href = load_toml(
     {
-        commands_ref => [ $command_string, ],
-        process_type => q{open3},
+        path => $fqa_vcfanno_config,
+    }
+);
+
+## Set test file paths
+$toml_href->{annotation}[0]{file} =
+  catfile( $Bin, qw{ data references grch37_gnomad.genomes_-r2.0.1-.vcf.gz } );
+$toml_href->{annotation}[1]{file} =
+  catfile( $Bin, qw{ data references grch37_gnomad.genomes_-r2.1.1_sv-.vcf } );
+$toml_href->{annotation}[2]{file} =
+  catfile( $Bin, qw{ data references grch37_cadd_whole_genome_snvs_-v1.4-.tsv.gz } );
+
+write_toml(
+    {
+        data_href => $toml_href,
+        path      => $test_fqa_vcfanno_config,
     }
 );
 

--- a/t/check_vcfanno_toml.t
+++ b/t/check_vcfanno_toml.t
@@ -43,9 +43,9 @@ BEGIN {
 ## Modules with import
     my %perl_module = (
         q{MIP::Environment::Child_process} => [qw{child_process}],
-        q{MIP::Vcfanno}                    => [qw{check_vcfanno_toml}],
         q{MIP::Test::Fixtures}             => [qw{test_log test_standard_cli}],
         q{MIP::Toml}                       => [qw{ load_toml write_toml }],
+        q{MIP::Vcfanno}                    => [qw{check_vcfanno_toml}],
     );
 
     test_import( { perl_module_href => \%perl_module, } );

--- a/t/data/references/grch37_frequency_vcfanno_filter_config_-v1.0-.toml
+++ b/t/data/references/grch37_frequency_vcfanno_filter_config_-v1.0-.toml
@@ -13,3 +13,9 @@ file="/mnt/hds/proj/cust003/develop/mip_references/grch37_gnomad.genomes_-r2.1.1
 fields = ["AF", "AF_POPMAX"]
 ops=["self", "self"]
 names=["GNOMADAF", "GNOMADAF_POPMAX"]
+
+[[annotation]]
+file="/mnt/hds/proj/cust003/develop/mip_references/grch37_cadd_whole_genome_snvs_-v1.4-.tsv.gz"
+names=["CADD"]
+ops=["mean"]
+columns=[6]

--- a/t/mip_analysis.test
+++ b/t/mip_analysis.test
@@ -53,7 +53,7 @@ BEGIN {
 my ( $config_file, $infile );
 my ( %active_parameter, %parameter, %pedigree, %vcfparser_data, );
 
-our $VERSION = 2.07;
+our $VERSION = 2.08;
 
 if ( scalar @ARGV == 0 ) {
 
@@ -296,7 +296,7 @@ sub test_modules {
     push @ARGV, qw{ -verbose 2 };
     my $verbose = 1;
     ok( GetOptions( q{verbose:n} => \$verbose ), q{Getopt::Long: Get options call} );
-    ok( $verbose == 2,                           q{Getopt::Long: Get options modified} );
+    ok( $verbose == 2, q{Getopt::Long: Get options modified} );
 
     return;
 }
@@ -458,11 +458,8 @@ sub read_infile_vcf {
             ## Test Rankvariants
             _test_rankvariants_in_vcf_header(
                 {
-                    genmod_annotate_cadd_files_ref =>
-                      \@{ $active_parameter_href->{genmod_annotate_cadd_files} },
                     rankvariant_mode       => $active_parameter_href->{rankvariant},
                     sample_ids_ref         => \@{ $active_parameter_href->{sample_ids} },
-                    spidex_file            => $active_parameter_href->{spidex_file},
                     unaffected_samples_ref => \@{ $parameter_href->{cache}{unaffected} },
                     vcf_header_href        => \%vcf_header,
                 }
@@ -1415,29 +1412,20 @@ sub _test_rankvariants_in_vcf_header {
 
 ## Function : Test if rankvariants info keys are present in vcf header
 ## Returns  :
-## Arguments: $genmod_annotate_cadd_files_ref => Cadd files annotate via genmod
-##          : $rankvariant_mode               => Rankvariant_Mode description
-##          : $sample_ids_ref                 => Array ref description {REF}
-##          : $spidex_file                    => Spidex file
-##          : $unaffected_samples_ref         => Number of unaffected individuals in analysis
-##          : $vcf_header_href                => Vcf header info {REF}
+## Arguments: $rankvariant_mode       => Rankvariant_Mode description
+##          : $sample_ids_ref         => Array ref description {REF}
+##          : $unaffected_samples_ref => Number of unaffected individuals in analysis
+##          : $vcf_header_href        => Vcf header info {REF}
 
     my ($arg_href) = @_;
 
     ## Flatten argument(s)
-    my $genmod_annotate_cadd_files_ref;
     my $rankvariant_mode;
     my $sample_ids_ref;
-    my $spidex_file;
     my $unaffected_samples_ref;
     my $vcf_header_href;
 
     my $tmpl = {
-        genmod_annotate_cadd_files_ref => {
-            default     => [],
-            store       => \$genmod_annotate_cadd_files_ref,
-            strict_type => 1,
-        },
         rankvariant_mode => {
             allow       => qr{ \A\d+\z }sxm,
             defined     => 1,
@@ -1450,10 +1438,6 @@ sub _test_rankvariants_in_vcf_header {
             defined     => 1,
             required    => 1,
             store       => \$sample_ids_ref,
-            strict_type => 1,
-        },
-        spidex_file => {
-            store       => \$spidex_file,
             strict_type => 1,
         },
         vcf_header_href => {
@@ -1491,17 +1475,6 @@ sub _test_rankvariants_in_vcf_header {
     foreach my $genmod_key (@genmod_keys) {
 
         ok( defined $vcf_header_href->{INFO}{$genmod_key}, q{Genmod: } . $genmod_key );
-    }
-
-    ## Spidex key from genmodAnnotate
-    if ($spidex_file) {
-
-        ok( defined $vcf_header_href->{INFO}{SPIDEX}, q{Genmod annotate: SPIDEX key} );
-    }
-    ## CADD key from genmodAnnotate
-    if ( @{$genmod_annotate_cadd_files_ref} ) {
-
-        ok( defined $vcf_header_href->{INFO}{CADD}, q{Genmod annotate: CADD key} );
     }
     return;
 }

--- a/t/parse_toml_config_parameters.t
+++ b/t/parse_toml_config_parameters.t
@@ -42,9 +42,10 @@ BEGIN {
 ### Check all internal dependency modules and imports
 ## Modules with import
     my %perl_module = (
-        q{MIP::Vcfanno}                    => [qw{ parse_toml_config_parameters }],
-        q{MIP::Test::Fixtures}             => [qw{ test_log test_standard_cli }],
         q{MIP::Environment::Child_process} => [qw{ child_process }],
+        q{MIP::Test::Fixtures}             => [qw{ test_log test_standard_cli }],
+        q{MIP::Toml}                       => [qw{ load_toml write_toml }],
+        q{MIP::Vcfanno}                    => [qw{ parse_toml_config_parameters }],
     );
 
     test_import( { perl_module_href => \%perl_module, } );
@@ -52,6 +53,7 @@ BEGIN {
 
 use MIP::Environment::Child_process qw{ child_process };
 use MIP::Vcfanno qw{ parse_toml_config_parameters };
+use MIP::Toml qw{ load_toml write_toml };
 
 diag(   q{Test parse_toml_config_parameters from Vcfanno.pm v}
       . $MIP::Vcfanno::VERSION
@@ -77,22 +79,24 @@ my $fqa_vcfanno_config =
 my $test_fqa_vcfanno_config = catfile( $test_reference_dir,
     qw{ grch37_frequency_vcfanno_filter_config_test_parse_toml_-v1.0-.toml  } );
 
-my $file_path = catfile( $test_reference_dir, q{grch37_gnomad.genomes_-r2.0.1-.vcf.gz} );
-
-## Replace line starting with "file=" with dynamic file path
-my $parse_path =
-    q?perl -nae 'chomp;if($_=~/file=/) {say STDOUT q{file="?
-  . $file_path
-  . q?"};} else {say STDOUT $_}' ?;
-
-## Parse original file and create new config for test
-my $command_string = join $SPACE,
-  ( $parse_path, $fqa_vcfanno_config, q{>}, $test_fqa_vcfanno_config );
-
-my %process_return = child_process(
+my $toml_href = load_toml(
     {
-        commands_ref => [ $command_string, ],
-        process_type => q{open3},
+        path => $fqa_vcfanno_config,
+    }
+);
+
+## Set test file paths
+$toml_href->{annotation}[0]{file} =
+  catfile( $Bin, qw{ data references grch37_gnomad.genomes_-r2.0.1-.vcf.gz } );
+$toml_href->{annotation}[1]{file} =
+  catfile( $Bin, qw{ data references grch37_gnomad.genomes_-r2.1.1_sv-.vcf } );
+$toml_href->{annotation}[2]{file} =
+  catfile( $Bin, qw{ data references grch37_cadd_whole_genome_snvs_-v1.4-.tsv.gz } );
+
+write_toml(
+    {
+        data_href => $toml_href,
+        path      => $test_fqa_vcfanno_config,
     }
 );
 

--- a/templates/grch38_mip_rd_dna_config.yaml
+++ b/templates/grch38_mip_rd_dna_config.yaml
@@ -22,7 +22,7 @@ outscript_dir: cluster_constant_path!/case_id!/analysis_constant_path!/scripts
 sample_info_file: cluster_constant_path!/case_id!/analysis_constant_path!/case_id!_qc_sample_info.yaml
 ## References
 expansionhunter_variant_catalog_file_path: grch38_expansionhunter_variant_catalog_-3.1.2-.json
-fqf_vcfanno_config: grch38_frequency_vcfanno_filter_config_-v1.1-.toml
+fqf_vcfanno_config: grch38_frequency_vcfanno_filter_config_-v1.3-.toml
 gatk_baserecalibration_known_sites:
   - grch38_dbsnp_-146-.vcf.gz
   - grch38_1000g_snps_high_confidence_-phase1-.vcf.gz

--- a/templates/grch38_mip_rd_dna_config.yaml
+++ b/templates/grch38_mip_rd_dna_config.yaml
@@ -40,9 +40,6 @@ gatk_variantrecalibration_resource_snv:
   grch38_1000g_snps_high_confidence_-phase1-.vcf.gz: "1000G,known=false,training=true,truth=false,prior=10.0"
 gatk_varianteval_dbsnp: grch38_variant_-gold_standard_dbsnp-.vcf.gz
 gatk_varianteval_gold: grch38_mills_and_1000g_-gold_standard_indels-.vcf.gz
-genmod_annotate_cadd_files:
-  - grch38_cadd_whole_genome_snvs_-v1.5-.tsv.gz
-  - grch38_cadd_bravo_topmed_freeze5_-v1.5-.tsv.gz
 genmod_models_reduced_penetrance_file: grch38_cust003-cmms-red-pen_-2017_FAKE-.tsv
 human_genome_reference: grch38_homo_sapiens_-assembly-.fasta
 manta_call_regions_file_path: grch38_manta_call_regions_-1.0-.bed.gz

--- a/templates/mip_dragen_rd_dna_config.yaml
+++ b/templates/mip_dragen_rd_dna_config.yaml
@@ -20,7 +20,7 @@ outdata_dir: cluster_constant_path!/case_id!/analysis_constant_path!
 outscript_dir: cluster_constant_path!/case_id!/analysis_constant_path!/scripts
 sample_info_file: cluster_constant_path!/case_id!/analysis_constant_path!/case_id!_qc_sample_info.yaml
 ## References
-fqa_vcfanno_config: grch37_frequency_vcfanno_filter_config_-v1.3-.toml
+fqa_vcfanno_config: grch37_frequency_vcfanno_filter_config_-v1.4-.toml
 genmod_models_reduced_penetrance_file: grch37_cust003-cmms-red-pen_-2017-.tsv
 human_genome_reference: grch37_homo_sapiens_-d5-.fasta
 rank_model_file: rank_model_cmms_-v1.28-.ini

--- a/templates/mip_dragen_rd_dna_config.yaml
+++ b/templates/mip_dragen_rd_dna_config.yaml
@@ -21,10 +21,6 @@ outscript_dir: cluster_constant_path!/case_id!/analysis_constant_path!/scripts
 sample_info_file: cluster_constant_path!/case_id!/analysis_constant_path!/case_id!_qc_sample_info.yaml
 ## References
 fqa_vcfanno_config: grch37_frequency_vcfanno_filter_config_-v1.3-.toml
-genmod_annotate_cadd_files:
-  - grch37_cadd_whole_genome_snvs_-v1.4-.tsv.gz
-  - grch37_cadd_gnomad.genomes.r2.0.1_-v1.4-.tsv.gz
-genmod_annotate_spidex_file: grch37_spidex_public_noncommercial_-v1_0-.tab.gz
 genmod_models_reduced_penetrance_file: grch37_cust003-cmms-red-pen_-2017-.tsv
 human_genome_reference: grch37_homo_sapiens_-d5-.fasta
 rank_model_file: rank_model_cmms_-v1.28-.ini

--- a/templates/mip_rd_dna_config.yaml
+++ b/templates/mip_rd_dna_config.yaml
@@ -20,7 +20,7 @@ outdata_dir: cluster_constant_path!/case_id!/analysis_constant_path!
 outscript_dir: cluster_constant_path!/case_id!/analysis_constant_path!/scripts
 sample_info_file: cluster_constant_path!/case_id!/analysis_constant_path!/case_id!_qc_sample_info.yaml
 ## References
-fqa_vcfanno_config: grch37_frequency_vcfanno_filter_config_-v1.3-.toml
+fqa_vcfanno_config: grch37_frequency_vcfanno_filter_config_-v1.4-.toml
 gatk_genotypegvcfs_ref_gvcf: grch37_merged_reference_infiles_-2014-.gvcf
 genmod_models_reduced_penetrance_file: grch37_cust003-cmms-red-pen_-2017-.tsv
 human_genome_reference: grch37_homo_sapiens_-d5-.fasta

--- a/templates/mip_rd_dna_config.yaml
+++ b/templates/mip_rd_dna_config.yaml
@@ -22,10 +22,6 @@ sample_info_file: cluster_constant_path!/case_id!/analysis_constant_path!/case_i
 ## References
 fqa_vcfanno_config: grch37_frequency_vcfanno_filter_config_-v1.3-.toml
 gatk_genotypegvcfs_ref_gvcf: grch37_merged_reference_infiles_-2014-.gvcf
-genmod_annotate_cadd_files:
-  - grch37_cadd_whole_genome_snvs_-v1.4-.tsv.gz
-  - grch37_cadd_gnomad.genomes.r2.0.1_-v1.4-.tsv.gz
-genmod_annotate_spidex_file: grch37_spidex_public_noncommercial_-v1_0-.tab.gz
 genmod_models_reduced_penetrance_file: grch37_cust003-cmms-red-pen_-2017-.tsv
 human_genome_reference: grch37_homo_sapiens_-d5-.fasta
 rank_model_file: rank_model_cmms_-v1.28-.ini

--- a/templates/mip_rd_dna_panel_config.yaml
+++ b/templates/mip_rd_dna_panel_config.yaml
@@ -19,7 +19,7 @@ outdata_dir: cluster_constant_path!/case_id!/analysis_constant_path!
 outscript_dir: cluster_constant_path!/case_id!/analysis_constant_path!/scripts
 sample_info_file: cluster_constant_path!/case_id!/analysis_constant_path!/case_id!_qc_sample_info.yaml
 ## References
-fqa_vcfanno_config: grch37_frequency_vcfanno_filter_config_-v1.3-.toml
+fqa_vcfanno_config: grch37_frequency_vcfanno_filter_config_-v1.4-.toml
 gatk_genotypegvcfs_ref_gvcf: grch37_merged_reference_infiles_-2014-.gvcf
 genmod_models_reduced_penetrance_file: grch37_cust003-cmms-red-pen_-2017-.tsv
 human_genome_reference: grch37_homo_sapiens_-d5-.fasta

--- a/templates/mip_rd_dna_panel_config.yaml
+++ b/templates/mip_rd_dna_panel_config.yaml
@@ -21,10 +21,6 @@ sample_info_file: cluster_constant_path!/case_id!/analysis_constant_path!/case_i
 ## References
 fqa_vcfanno_config: grch37_frequency_vcfanno_filter_config_-v1.3-.toml
 gatk_genotypegvcfs_ref_gvcf: grch37_merged_reference_infiles_-2014-.gvcf
-genmod_annotate_cadd_files:
-  - grch37_cadd_whole_genome_snvs_-v1.4-.tsv.gz
-  - grch37_cadd_gnomad.genomes.r2.0.1_-v1.4-.tsv.gz
-genmod_annotate_spidex_file: grch37_spidex_public_noncommercial_-v1_0-.tab.gz
 genmod_models_reduced_penetrance_file: grch37_cust003-cmms-red-pen_-2017-.tsv
 human_genome_reference: grch37_homo_sapiens_-d5-.fasta
 rank_model_file: rank_model_cmms_-v1.28-.ini

--- a/templates/mip_rd_dna_vcf_rerun_config.yaml
+++ b/templates/mip_rd_dna_vcf_rerun_config.yaml
@@ -20,7 +20,7 @@ outdata_dir: cluster_constant_path!/case_id!/analysis_constant_path!
 outscript_dir: cluster_constant_path!/case_id!/analysis_constant_path!/scripts
 sample_info_file: cluster_constant_path!/case_id!/analysis_constant_path!/case_id!_qc_sample_info.yaml
 ## References
-fqa_vcfanno_config: grch37_frequency_vcfanno_filter_config_-v1.3-.toml
+fqa_vcfanno_config: grch37_frequency_vcfanno_filter_config_-v1.4-.toml
 genmod_models_reduced_penetrance_file: grch37_cust003-cmms-red-pen_-2017-.tsv
 human_genome_reference: grch37_homo_sapiens_-d5-.fasta
 rank_model_file: rank_model_cmms_-v1.28-.ini

--- a/templates/mip_rd_dna_vcf_rerun_config.yaml
+++ b/templates/mip_rd_dna_vcf_rerun_config.yaml
@@ -21,10 +21,6 @@ outscript_dir: cluster_constant_path!/case_id!/analysis_constant_path!/scripts
 sample_info_file: cluster_constant_path!/case_id!/analysis_constant_path!/case_id!_qc_sample_info.yaml
 ## References
 fqa_vcfanno_config: grch37_frequency_vcfanno_filter_config_-v1.3-.toml
-genmod_annotate_cadd_files:
-  - grch37_cadd_whole_genome_snvs_-v1.4-.tsv.gz
-  - grch37_cadd_gnomad.genomes.r2.0.1_-v1.4-.tsv.gz
-genmod_annotate_spidex_file: grch37_spidex_public_noncommercial_-v1_0-.tab.gz
 genmod_models_reduced_penetrance_file: grch37_cust003-cmms-red-pen_-2017-.tsv
 human_genome_reference: grch37_homo_sapiens_-d5-.fasta
 rank_model_file: rank_model_cmms_-v1.28-.ini


### PR DESCRIPTION
### This PR fixes:

- Moves annotationof CADD and SPIDEX to vcfanno´s toml config
- Removed CADD and SPIDEX annotations from Rankvariants recipe, CLI and parameters
- Added distinction of file format and corresponding features in vcfanno config parsing
- Added skip of tsv files in vt normalise and decompose to not run vt on tsv file from toml config
- Added new vcfanno config to templates
- Removed annotation using gnomad indels as we are dynamically calculating them anyway

### How to test:
- Automatic and continuous test pass
- [x] Tested on Hasta

### Expected outcome:
- Installation, unit and integration tests pass

### Review:
- [ ] Code review
- [ ] New code is executed and covered by tests
- [ ] Tests pass
