### PR TITLE
Feature/parse fastq infiles format

### DIFF
--- a/lib/MIP/Fastq.pm
+++ b/lib/MIP/Fastq.pm
@@ -1,0 +1,102 @@
+package MIP::Fastq;
+
+use 5.026;
+use Carp;
+use charnames qw{ :full :short };
+use English qw{ -no_match_vars };
+use open qw{ :encoding(UTF-8) :std };
+use Params::Check qw{ allow check last_error };
+use strict;
+use utf8;
+use warnings;
+use warnings qw{ FATAL utf8 };
+
+## CPANM
+use autodie qw{ :all };
+
+## MIPs lib/
+use MIP::Constants qw{ $COMMA $LOG_NAME $SPACE };
+
+BEGIN {
+    require Exporter;
+    use base qw{ Exporter };
+
+    # Set the version for version checking
+    our $VERSION = 1.00;
+
+    # Functions and variables which can be optionally exported
+    our @EXPORT_OK = qw{ parse_fastq_infiles_format };
+}
+
+sub parse_fastq_infiles_format {
+
+## Function : Parse infile according to MIP filename convention
+## Returns  : %infile_info or undef
+## Arguments: $file_name => File name
+
+    my ($arg_href) = @_;
+
+    ## Flatten argument(s)
+    my $file_name;
+
+    my $tmpl = {
+        file_name => {
+            defined     => 1,
+            required    => 1,
+            store       => \$file_name,
+            strict_type => 1,
+        },
+    };
+
+    check( $tmpl, $arg_href, 1 ) or croak q{Could not parse arguments!};
+
+    ## Retrieve logger object
+    my $log = Log::Log4perl->get_logger($LOG_NAME);
+
+    # Store fastq file name features
+    my %fastq_file_name;
+    my @missing_feature;
+
+    ## Define MIP fastq file name formats matching regexp
+    my %fastq_file_name_regexp = _fastq_file_name_regexp();
+
+    # Parse fastq file name
+    my @file_features = $file_name =~ /$fastq_file_name_regexp{regexp}/sxm;
+
+  FEATURE:
+    while ( my ( $index, $feature ) = each @{ $fastq_file_name_regexp{features} } ) {
+
+        ## Return undef if not all expected features found
+        if ( not $file_features[$index] ) {
+            push @missing_feature, $feature;
+        }
+
+        # Store feature
+        $fastq_file_name{$feature} = $file_features[$index];
+    }
+    if (@missing_feature) {
+        $log->warn(qq{Could not detect MIP file name convention for file: $file_name });
+        $log->warn( q{Missing file name feature: } . join $COMMA . $SPACE,
+            @missing_feature );
+        return;
+    }
+    return %fastq_file_name;
+}
+
+sub _fastq_file_name_regexp {
+
+## Function : Define MIP fastq file name formats matching regexp
+## Returns  : %fastq_file_name_regexp
+## Arguments:
+
+    my ($arg_href) = @_;
+
+    my %fastq_file_name_regexp = (
+        features => [qw{ lane date flowcell infile_sample_id index direction }],
+        regexp   => q?(\d+)_(\d+)_([^_]+)_([^_]+)_([^_]+)_(\d).fastq?,
+    );
+
+    return %fastq_file_name_regexp;
+}
+
+1;

--- a/lib/MIP/File/Format/Mip.pm
+++ b/lib/MIP/File/Format/Mip.pm
@@ -22,23 +22,7 @@ BEGIN {
     our $VERSION = 1.03;
 
     # Functions and variables which can be optionally exported
-    our @EXPORT_OK = qw{ fastq_file_name_regexp };
-}
-
-sub fastq_file_name_regexp {
-
-## Function : Define MIP fastq file name formats matching regexp
-## Returns  : %mip_file_name_regexp
-## Arguments:
-
-    my ($arg_href) = @_;
-
-    my %mip_file_name_regexp = (
-        features => [qw{ lane date flowcell infile_sample_id index direction }],
-        regexp   => q?(\d+)_(\d+)_([^_]+)_([^_]+)_([^_]+)_(\d).fastq?,
-    );
-
-    return %mip_file_name_regexp;
+    our @EXPORT_OK = qw{  };
 }
 
 1;

--- a/lib/MIP/Parse/File.pm
+++ b/lib/MIP/Parse/File.pm
@@ -100,6 +100,7 @@ sub parse_fastq_infiles {
 
     use MIP::Check::File qw{ check_interleaved };
     use MIP::Check::Parameter qw{ check_infile_contain_sample_id };
+    use MIP::Fastq qw{ parse_fastq_infiles_format };
     use MIP::File_info
       qw{ parse_file_compression_features parse_files_compression_status };
     use MIP::Get::File qw{ get_fastq_file_header_info get_read_length };

--- a/lib/MIP/Parse/File.pm
+++ b/lib/MIP/Parse/File.pm
@@ -25,11 +25,10 @@ BEGIN {
     use base qw{ Exporter };
 
     # Set the version for version checking
-    our $VERSION = 1.08;
+    our $VERSION = 1.09;
 
     # Functions and variables which can be optionally exported
-    our @EXPORT_OK =
-      qw{ parse_fastq_infiles parse_fastq_infiles_format parse_file_suffix parse_io_outfiles };
+    our @EXPORT_OK = qw{ parse_fastq_infiles parse_file_suffix parse_io_outfiles };
 
 }
 
@@ -203,10 +202,6 @@ sub parse_fastq_infiles {
             }
             else {
                 ## No regexp match i.e. file does not follow filename convention
-
-                $log->warn( q{Could not detect MIP file name convention for file: }
-                      . $file_name
-                      . q{.} );
                 $log->warn(q{Will try to find mandatory information from fastq header.});
 
                 ## Check that file name at least contains sample id
@@ -280,51 +275,6 @@ q{Will add fake date '20010101' to follow file convention since this is not reco
 
     }
     return;
-}
-
-sub parse_fastq_infiles_format {
-
-## Function : Parse infile according to MIP filename convention
-## Returns  : %infile_info or undef
-## Arguments: $file_name => File name
-
-    my ($arg_href) = @_;
-
-    ## Flatten argument(s)
-    my $file_name;
-
-    my $tmpl = {
-        file_name => {
-            defined     => 1,
-            required    => 1,
-            store       => \$file_name,
-            strict_type => 1,
-        },
-    };
-
-    check( $tmpl, $arg_href, 1 ) or croak q{Could not parse arguments!};
-
-    use MIP::File::Format::Mip qw{ fastq_file_name_regexp };
-
-    # Store file name features
-    my %file_info;
-
-    ## Define MIP fastq file name formats matching regexp
-    my %mip_file_name_regexp = fastq_file_name_regexp();
-
-    # Parse file name
-    my @file_features = $file_name =~ /$mip_file_name_regexp{regexp}/sxm;
-
-  FEATURE:
-    while ( my ( $index, $feature ) = each @{ $mip_file_name_regexp{features} } ) {
-
-        ## Return undef if not all expected features found
-        return if ( not $file_features[$index] );
-
-        # Store feature
-        $file_info{$feature} = $file_features[$index];
-    }
-    return %file_info;
 }
 
 sub parse_file_suffix {


### PR DESCRIPTION
### This PR adds | fixes:

- Refactor sub parse_fastq_infiles_format

### How to test:

- Automatic and continuous test suite

### Expected outcome:
- [ ] Installation, unit and integration test suite pass

### Review:
- [ ] Code review
- [ ] Tests pass

This [version](https://semver.org/) is a:
- [ ] **MAJOR** - when you make incompatible API changes. If applicable record manual test results in PR header
- [ ] **MINOR** - when you add functionality in a backwards compatible manner. If applicable record manual test results in PR header
- [x] **PATCH** - when you make backwards compatible bug fixes or documentation/instructions
