### PR TITLE
Add to deliverables file

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [8.2.5]
 - Adds output files to store for gatk_combinevariants, sambamba depth, chromograph recipes
+- Use MIPs bcftools singularity image in the conda env when checking references 
 
 ## [8.2.4]
 - Chromograph patch

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 All notable changes to this project will be documented in this file.
 This project adheres to [Semantic Versioning](http://semver.org/).
 
+## [8.2.5]
+- Adds output files to store for gatk_combinevariants, sambamba depth, chromograph recipes
+
 ## [8.2.4]
 - Chromograph patch
 
@@ -129,7 +132,6 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [7.1.5]
 - Increased sv_varianteffectpredictor memory parameter 9 -> 18 Gb
->>>>>>> master
 
 ## [7.1.4]
 - Fix bug in outfile_path when mitochondria contig is not part of gene panel

--- a/lib/MIP/Check/Reference.pm
+++ b/lib/MIP/Check/Reference.pm
@@ -24,7 +24,7 @@ BEGIN {
     use base qw{ Exporter };
 
     # Set the version for version checking
-    our $VERSION = 1.11;
+    our $VERSION = 1.12;
 
     # Functions and variables which can be optionally exported
     our @EXPORT_OK = qw{
@@ -38,16 +38,24 @@ sub check_if_processed_by_vt {
 
 ## Function : Check if vt has processed references using regexp
 ## Returns  : @process_references
-## Arguments: $log                 => Log object
-##          : $reference_file_path => The reference file path
+## Arguments: $bcftools_binary_path => Path to bcftools binary
+##          : $log                  => Log object
+##          : $reference_file_path  => The reference file path
 
     my ($arg_href) = @_;
 
     ## Flatten argument(s)
+    my $bcftools_binary_path;
     my $log;
     my $reference_file_path;
 
     my $tmpl = {
+        bcftools_binary_path => {
+            defined     => 1,
+            required    => 1,
+            store       => \$bcftools_binary_path,
+            strict_type => 1,
+        },
         log => {
             defined  => 1,
             required => 1,
@@ -104,7 +112,8 @@ sub check_if_processed_by_vt {
         my $unset_cmd = join $SPACE, gnu_unset( { bash_variable => q{MIP_BIND}, } );
 
         ## Detect if vt program has processed reference
-        my $ret = `$export_cmd; bcftools view $reference_file_path | $regexp; $unset_cmd`;
+        my $ret =
+`$export_cmd; $bcftools_binary_path view $reference_file_path | $regexp; $unset_cmd`;
 
         ## No trace of vt processing found
         if ( not $ret ) {
@@ -380,6 +389,9 @@ sub check_references_for_vt {
     ## Avoid checking the same reference multiple times
     my %seen;
 
+    ## Use MIPs own bcftools
+    my $bcftools_binary_path = $active_parameter_href->{binary_path}{bcftools};
+
     ## TOML parameters
     my %toml = (
         fqa_vcfanno_config    => 1,
@@ -409,6 +421,7 @@ sub check_references_for_vt {
 
                     _parse_vcfanno_toml_path(
                         {
+                            bcftools_binary_path      => $bcftools_binary_path,
                             log                       => $log,
                             seen_href                 => \%seen,
                             toml_file_path            => $annotation_file,
@@ -421,8 +434,9 @@ sub check_references_for_vt {
                     ## Check if vt has processed references using regexp
                     @checked_references = check_if_processed_by_vt(
                         {
-                            log                 => $log,
-                            reference_file_path => $annotation_file,
+                            bcftools_binary_path => $bcftools_binary_path,
+                            log                  => $log,
+                            reference_file_path  => $annotation_file,
                         }
                     );
                     push @to_process_references, @checked_references;
@@ -442,8 +456,9 @@ sub check_references_for_vt {
                         ## Check if vt has processed references using regexp
                         @checked_references = check_if_processed_by_vt(
                             {
-                                log                 => $log,
-                                reference_file_path => $annotation_file,
+                                bcftools_binary_path => $bcftools_binary_path,
+                                log                  => $log,
+                                reference_file_path  => $annotation_file,
                             }
                         );
                     }
@@ -464,8 +479,9 @@ sub check_references_for_vt {
                         ## Check if vt has processed references using regexp
                         @checked_references = check_if_processed_by_vt(
                             {
-                                log                 => $log,
-                                reference_file_path => $annotation_file,
+                                bcftools_binary_path => $bcftools_binary_path,
+                                log                  => $log,
+                                reference_file_path  => $annotation_file,
                             }
                         );
                     }
@@ -482,7 +498,8 @@ sub _parse_vcfanno_toml_path {
 
 ## Function : Parse TOML config for path to check with vt
 ## Returns  :
-## Arguments: $log                       => Log object
+## Arguments: $bcftools_binary_path      => Path to bcftools binary
+##          : $log                       => Log object
 ##          : $seen_href                 => Avoid checking the same reference multiple times
 ##          : $toml_file_path            => Toml config file path
 ##          : $to_process_references_ref => Store references to process later
@@ -490,12 +507,19 @@ sub _parse_vcfanno_toml_path {
     my ($arg_href) = @_;
 
     ## Flatten argument(s)
+    my $bcftools_binary_path;
     my $log;
     my $seen_href;
     my $toml_file_path;
     my $to_process_references_ref;
 
     my $tmpl = {
+        bcftools_binary_path => {
+            defined     => 1,
+            required    => 1,
+            store       => \$bcftools_binary_path,
+            strict_type => 1,
+        },
         log       => { store => \$log, },
         seen_href => {
             default     => {},
@@ -543,8 +567,9 @@ sub _parse_vcfanno_toml_path {
             ## Check if vt has processed references using regexp
             my @checked_references = check_if_processed_by_vt(
                 {
-                    log                 => $log,
-                    reference_file_path => $annotation_file_path,
+                    bcftools_binary_path => $bcftools_binary_path,
+                    log                  => $log,
+                    reference_file_path  => $annotation_file_path,
                 }
             );
             push @{$to_process_references_ref}, @checked_references;

--- a/lib/MIP/Constants.pm
+++ b/lib/MIP/Constants.pm
@@ -80,7 +80,7 @@ Readonly our %ANALYSIS => (
 );
 
 ## Set MIP version
-Readonly our $MIP_VERSION => q{v8.2.4};
+Readonly our $MIP_VERSION => q{v8.2.5};
 
 ## Cli
 Readonly our $MOOSEX_APP_SCEEN_WIDTH => 160;

--- a/lib/MIP/Recipes/Analysis/Chromograph.pm
+++ b/lib/MIP/Recipes/Analysis/Chromograph.pm
@@ -25,7 +25,7 @@ BEGIN {
     use base qw{ Exporter };
 
     # Set the version for version checking
-    our $VERSION = 1.06;
+    our $VERSION = 1.07;
 
     # Functions and variables which can be optionally exported
     our @EXPORT_OK = qw{ analysis_chromograph analysis_chromograph_proband };
@@ -138,7 +138,7 @@ sub analysis_chromograph {
     use MIP::Program::Chromograph qw{ chromograph };
     use MIP::Parse::File qw{ parse_io_outfiles };
     use MIP::Processmanagement::Processes qw{ submit_recipe };
-    use MIP::Sample_info qw{ set_recipe_outfile_in_sample_info };
+    use MIP::Sample_info qw{ set_file_path_to_store set_recipe_outfile_in_sample_info };
     use MIP::Script::Setup_script qw{ setup_script };
 
     ### PREPROCESSING:
@@ -261,6 +261,16 @@ sub analysis_chromograph {
                 path             => $outfile_path,
                 recipe_name      => $recipe_name,
                 sample_id        => $sample_id,
+                sample_info_href => $sample_info_href,
+            }
+        );
+
+        set_file_path_to_store(
+            {
+                format           => q{tar},
+                id               => $sample_id,
+                path             => $outfile_path,
+                recipe_name      => $recipe_name,
                 sample_info_href => $sample_info_href,
             }
         );
@@ -391,7 +401,8 @@ sub analysis_chromograph_proband {
     use MIP::Program::Upd qw{ upd_call };
     use MIP::Parse::File qw{ parse_io_outfiles };
     use MIP::Processmanagement::Processes qw{ submit_recipe };
-    use MIP::Sample_info qw{ get_family_member_id set_recipe_outfile_in_sample_info };
+    use MIP::Sample_info
+      qw{ get_family_member_id set_file_path_to_store set_recipe_outfile_in_sample_info };
     use MIP::Script::Setup_script qw{ setup_script };
 
     ### PREPROCESSING:
@@ -581,6 +592,16 @@ sub analysis_chromograph_proband {
                 path             => $outfile_path,
                 recipe_name      => $recipe_name,
                 sample_id        => $sample_id,
+                sample_info_href => $sample_info_href,
+            }
+        );
+
+        set_file_path_to_store(
+            {
+                format           => q{tar},
+                id               => $sample_id,
+                path             => $outfile_path,
+                recipe_name      => $recipe_name,
                 sample_info_href => $sample_info_href,
             }
         );

--- a/lib/MIP/Recipes/Analysis/Gatk_combinevariantcallsets.pm
+++ b/lib/MIP/Recipes/Analysis/Gatk_combinevariantcallsets.pm
@@ -25,7 +25,7 @@ BEGIN {
     use base qw{ Exporter };
 
     # Set the version for version checking
-    our $VERSION = 1.13;
+    our $VERSION = 1.14;
 
     # Functions and variables which can be optionally exported
     our @EXPORT_OK = qw{ analysis_gatk_combinevariantcallsets };
@@ -140,7 +140,7 @@ sub analysis_gatk_combinevariantcallsets {
     use MIP::Program::Bcftools qw{ bcftools_view_and_index_vcf };
     use MIP::Program::Gatk qw{ gatk_combinevariants };
     use MIP::Sample_info
-      qw{ set_recipe_outfile_in_sample_info set_processing_metafile_in_sample_info };
+      qw{ set_file_path_to_store set_recipe_outfile_in_sample_info set_processing_metafile_in_sample_info };
     use MIP::Script::Setup_script qw{ setup_script };
 
     ### PREPROCESSING:
@@ -345,6 +345,16 @@ sub analysis_gatk_combinevariantcallsets {
                 {
                     metafile_tag     => $most_complete_bcf_key,
                     path             => $bcf_file_path,
+                    sample_info_href => $sample_info_href,
+                }
+            );
+            set_file_path_to_store(
+                {
+                    format           => q{bcf},
+                    id               => $case_id,
+                    path             => $bcf_file_path,
+                    path_index       => $bcf_file_path . $DOT . q{csi},
+                    recipe_name      => $recipe_name,
                     sample_info_href => $sample_info_href,
                 }
             );

--- a/lib/MIP/Recipes/Analysis/Sambamba_depth.pm
+++ b/lib/MIP/Recipes/Analysis/Sambamba_depth.pm
@@ -144,7 +144,7 @@ sub analysis_sambamba_depth {
     use MIP::Parse::File qw{ parse_io_outfiles };
     use MIP::Processmanagement::Processes qw{ submit_recipe };
     use MIP::Program::Sambamba qw{ sambamba_depth };
-    use MIP::Sample_info qw{ set_recipe_outfile_in_sample_info };
+    use MIP::Sample_info qw{ set_file_path_to_store set_recipe_outfile_in_sample_info };
     use MIP::Script::Setup_script qw{ setup_script};
 
     ### PREPROCESSING:
@@ -275,6 +275,17 @@ sub analysis_sambamba_depth {
                 recipe_name      => $recipe_name,
                 sample_id        => $sample_id,
                 sample_info_href => $sample_info_href,
+            }
+        );
+
+        set_file_path_to_store(
+            {
+                format           => q{bed},
+                id               => $sample_id,
+                path             => $outfile_path,
+                recipe_name      => $recipe_name,
+                sample_info_href => $sample_info_href,
+                tag              => q{coverage},
             }
         );
 

--- a/lib/MIP/Sample_info.pm
+++ b/lib/MIP/Sample_info.pm
@@ -27,7 +27,7 @@ BEGIN {
     use base qw{Exporter};
 
     # Set the version for version checking
-    our $VERSION = 1.23;
+    our $VERSION = 1.24;
 
     # Functions and variables which can be optionally exported
     our @EXPORT_OK = qw{
@@ -660,7 +660,7 @@ sub set_file_path_to_store {
 
     my $tmpl = {
         format => {
-            allow       => [qw{ fastq bam bcf cram meta vcf }],
+            allow       => [qw{ fastq bam bcf bed cram meta vcf }],
             defined     => 1,
             required    => 1,
             store       => \$format,

--- a/lib/MIP/Sample_info.pm
+++ b/lib/MIP/Sample_info.pm
@@ -660,7 +660,7 @@ sub set_file_path_to_store {
 
     my $tmpl = {
         format => {
-            allow       => [qw{ fastq bam bcf bed cram meta vcf }],
+            allow       => [qw{ fastq bam bcf bed cram meta tar vcf }],
             defined     => 1,
             required    => 1,
             store       => \$format,

--- a/t/check_if_processed_by_vt.t
+++ b/t/check_if_processed_by_vt.t
@@ -24,7 +24,7 @@ use MIP::Constants qw{ $COMMA $SPACE };
 use MIP::Test::Fixtures qw{ test_log test_standard_cli };
 
 my $VERBOSE = 1;
-our $VERSION = 1.02;
+our $VERSION = 1.03;
 
 $VERBOSE = test_standard_cli(
     {
@@ -61,10 +61,12 @@ diag(   q{Test check_if_processed_by_vt from Reference.pm v}
 my $log = test_log( { no_screen => 1, } );
 
 ## Given no reference path
-my $return = check_if_processed_by_vt(
+my $bcftools_binary_path = q{bcftools};
+my $return               = check_if_processed_by_vt(
     {
-        reference_file_path => q{file_does_not_exists},
-        log                 => $log,
+        bcftools_binary_path => $bcftools_binary_path,
+        reference_file_path  => q{file_does_not_exists},
+        log                  => $log,
     }
 );
 is( $return, undef, q{No reference file to check} );
@@ -76,8 +78,9 @@ my $reference_file_path_no_vt =
 ## Check if vt has processed references using regexp
 my @checked_references = check_if_processed_by_vt(
     {
-        reference_file_path => $reference_file_path_no_vt,
-        log                 => $log,
+        bcftools_binary_path => $bcftools_binary_path,
+        reference_file_path  => $reference_file_path_no_vt,
+        log                  => $log,
     }
 );
 
@@ -91,8 +94,9 @@ my $reference_file_path_vt =
 ## Check if vt has processed references using regexp
 @checked_references = check_if_processed_by_vt(
     {
-        reference_file_path => $reference_file_path_vt,
-        log                 => $log,
+        bcftools_binary_path => $bcftools_binary_path,
+        reference_file_path  => $reference_file_path_vt,
+        log                  => $log,
     }
 );
 

--- a/t/check_references_for_vt.t
+++ b/t/check_references_for_vt.t
@@ -24,7 +24,7 @@ use MIP::Constants qw{ $COLON $COMMA $SPACE };
 use MIP::Test::Fixtures qw{ test_log test_standard_cli };
 
 my $VERBOSE = 1;
-our $VERSION = 1.06;
+our $VERSION = 1.07;
 
 $VERBOSE = test_standard_cli(
     {
@@ -62,6 +62,7 @@ diag(   q{Test check_references_for_vt from Reference.pm v}
 my $log = test_log( { log_name => q{MIP}, no_screen => 1, } );
 
 my %active_parameter_test = (
+    binary_path        => { bcftools => q{bcftools}, },
     fqa_vcfanno_config => catfile(
         $Bin, qw{ data references grch37_frequency_vcfanno_filter_config_-v1.0-.toml }
     ),


### PR DESCRIPTION
### This PR adds | fixes:

- Adds output files to store for
  - gatk_combinevariants recipe
  - sambamba depth recipe
  - chromograph recipe
  - Use MIPs bcftools singularity image for processing VT references

### How to test:
1. Automatic and continuous test suite
#### Deliverables
1. Run `cg workflow mip-dna run -p low  vitalmouse`
#### Bcftools binary
1. Run `cg workflow mip-dna run -p low  vitalmouse`

### Expected outcome:
1. Installation, unit and integration test suite pass
1. gatk_combinevariants, sambamba depth and chromograph recipe outfiles should be in the deliverables file ✅ 
1. Reference are check for VT processing ✅ 

### Review:
- [ ] Code review
- [ ] Tests pass approved by @henrikstranneheim 

This [version](https://semver.org/) is a:
- [ ] **MAJOR** - when you make incompatible API changes. If applicable record manual test results in PR header
- [ ] **MINOR** - when you add functionality in a backwards compatible manner. If applicable record manual test results in PR header
- [x] **PATCH** - when you make backwards compatible bug fixes or documentation/instructions
