### PR TITLE
feat(refactor): Sub check_infile_contain_sample_id

### DIFF
--- a/lib/MIP/Check/Parameter.pm
+++ b/lib/MIP/Check/Parameter.pm
@@ -27,12 +27,11 @@ BEGIN {
     use base qw{ Exporter };
 
     # Set the version for version checking
-    our $VERSION = 1.44;
+    our $VERSION = 1.45;
 
     # Functions and variables which can be optionally exported
     our @EXPORT_OK = qw{
       check_active_installation_parameters
-      check_infile_contain_sample_id
       check_recipe_fastq_compatibility
     };
 }
@@ -72,80 +71,6 @@ sub check_active_installation_parameters {
         $log->fatal(
 q{The parameter "project_id" must be set when a sbatch installation has been requested}
         );
-        exit 1;
-    }
-    return 1;
-}
-
-sub check_infile_contain_sample_id {
-
-## Function : Check that the sample_id provided and sample_id in infile name match.
-## Returns  :
-## Arguments: $infile_name      => Infile name
-##          : $infile_sample_id => Sample_id collect with regexp from infile
-##          : $log              => Log object
-##          : $sample_id        => Sample id from user
-##          : $sample_ids_ref   => Sample ids from user
-
-    my ($arg_href) = @_;
-
-    ## Flatten argument(s)
-    my $infile_name;
-    my $infile_sample_id;
-    my $log;
-    my $sample_id;
-    my $sample_ids_ref;
-
-    my $tmpl = {
-        infile_name => {
-            defined     => 1,
-            required    => 1,
-            store       => \$infile_name,
-            strict_type => 1,
-        },
-        infile_sample_id => {
-            defined     => 1,
-            required    => 1,
-            store       => \$infile_sample_id,
-            strict_type => 1,
-        },
-        log => {
-            defined  => 1,
-            required => 1,
-            store    => \$log,
-        },
-        sample_id => {
-            defined     => 1,
-            required    => 1,
-            store       => \$sample_id,
-            strict_type => 1,
-        },
-        sample_ids_ref => {
-            default     => [],
-            defined     => 1,
-            required    => 1,
-            store       => \$sample_ids_ref,
-            strict_type => 1,
-        },
-    };
-
-    check( $tmpl, $arg_href, 1 ) or croak q{Could not parse arguments!};
-
-    # Track seen sample ids
-    my %seen;
-
-    ## Increment for all sample ids
-    map { $seen{$_}++ } ( @{$sample_ids_ref}, $infile_sample_id );
-
-    if ( not $seen{$infile_sample_id} > 1 ) {
-
-        $log->fatal( $sample_id
-              . q{ supplied and sample_id }
-              . $infile_sample_id
-              . q{ found in file : }
-              . $infile_name
-              . q{ does not match. Please rename file to match sample_id: }
-              . $sample_id );
         exit 1;
     }
     return 1;

--- a/t/check_infile_contain_sample_id.t
+++ b/t/check_infile_contain_sample_id.t
@@ -18,15 +18,15 @@ use warnings qw{ FATAL utf8 };
 ## CPANM
 use autodie qw { :all };
 use Modern::Perl qw{ 2018 };
-use Readonly;
 use Test::Trap;
 
 ## MIPs lib/
 use lib catdir( dirname($Bin), q{lib} );
+use MIP::Constants qw{ $COMMA $SPACE };
 use MIP::Test::Fixtures qw{ test_log test_standard_cli };
 
 my $VERBOSE = 1;
-our $VERSION = '1.0.1';
+our $VERSION = 1.02;
 
 $VERBOSE = test_standard_cli(
     {
@@ -35,10 +35,6 @@ $VERBOSE = test_standard_cli(
     }
 );
 
-## Constants
-Readonly my $COMMA => q{,};
-Readonly my $SPACE => q{ };
-
 BEGIN {
 
     use MIP::Test::Fixtures qw{ test_import };
@@ -46,17 +42,17 @@ BEGIN {
 ### Check all internal dependency modules and imports
 ## Modules with import
     my %perl_module = (
-        q{MIP::Check::Parameter} => [qw{ check_infile_contain_sample_id }],
-        q{MIP::Test::Fixtures}   => [qw{ test_log test_standard_cli }],
+        q{MIP::Validate::Case} => [qw{ check_infile_contain_sample_id }],
+        q{MIP::Test::Fixtures} => [qw{ test_log test_standard_cli }],
     );
 
     test_import( { perl_module_href => \%perl_module, } );
 }
 
-use MIP::Check::Parameter qw{ check_infile_contain_sample_id };
+use MIP::Validate::Case qw{ check_infile_contain_sample_id };
 
-diag(   q{Test check_infile_contain_sample_id from Parameter.pm v}
-      . $MIP::Check::Parameter::VERSION
+diag(   q{Test check_infile_contain_sample_id from Case.pm v}
+      . $MIP::Validate::Case::VERSION
       . $COMMA
       . $SPACE . q{Perl}
       . $SPACE
@@ -68,17 +64,15 @@ my $log = test_log( {} );
 
 ## Given proper input data
 my $infile_sample_id = q{sample-1};
-my $file_index       = 0;
 my $sample_id        = q{sample-1};
 
-my %active_parameter = ( sample_ids  => [ qw{ sample-1 sample-2 }, ], );
-my %infile           = ( q{sample-1} => { mip_infiles => [qw{ sample-1.fastq }], }, );
+my %active_parameter = ( sample_ids => [ $sample_id, qw{ sample-2 }, ], );
+my %infile = ( $sample_id => { mip_infiles => [ $sample_id . q{.fastq} ], }, );
 
 my $is_ok = check_infile_contain_sample_id(
     {
-        infile_name      => $infile{q{sample-1}}{mip_infiles}[0],
+        infile_name      => $infile{$sample_id}{mip_infiles}[0],
         infile_sample_id => $infile_sample_id,
-        log              => $log,
         sample_id        => $sample_id,
         sample_ids_ref   => \@{ $active_parameter{sample_ids} },
     }
@@ -94,7 +88,6 @@ trap {
         {
             infile_name      => $infile{q{sample-1}}{mip_infiles}[0],
             infile_sample_id => $infile_sample_id,
-            log              => $log,
             sample_id        => $sample_id,
             sample_ids_ref   => \@{ $active_parameter{sample_ids} },
         }
@@ -103,6 +96,10 @@ trap {
 
 ## Then exit and throw FATAL log message
 ok( $trap->exit, q{Exit if sample_id do not match} );
-like( $trap->stderr, qr/FATAL/xms, q{Throw fatal log message if sample_id do not match} );
+like(
+    $trap->stderr,
+    qr/supplied \s+ and \s+ sample_id/xms,
+    q{Throw fatal log message if sample_id do not match}
+);
 
 done_testing();


### PR DESCRIPTION
- Refactored parse_fastq_infiles to make the sub more coherent
- Moved sub check_infile_contain_sample_id

### This PR adds | fixes:

- See above

### How to test:

- Automatic and continuous test suite

### Expected outcome:
- [ ] Installation, unit and integration test suite pass

### Review:
- [ ] Code review
- [ ] Tests pass

This [version](https://semver.org/) is a:
- [ ] **MAJOR** - when you make incompatible API changes. If applicable record manual test results in PR header
- [ ] **MINOR** - when you add functionality in a backwards compatible manner. If applicable record manual test results in PR header
- [x] **PATCH** - when you make backwards compatible bug fixes or documentation/instructions
