### PR TITLE
feat(refactor): Sub check_infile_contain_sample_id and parse_fastq_in…

### DIFF
--- a/lib/MIP/File_info.pm
+++ b/lib/MIP/File_info.pm
@@ -25,7 +25,7 @@ BEGIN {
     use base qw{ Exporter };
 
     # Set the version for version checking
-    our $VERSION = 1.10;
+    our $VERSION = 1.11;
 
     # Functions and variables which can be optionally exported
     our @EXPORT_OK = qw{
@@ -462,7 +462,12 @@ sub parse_sample_fastq_file_attributes {
     use MIP::Fastq qw{ check_interleaved get_read_length parse_fastq_infiles_format };
 
     ## Parse infile according to filename convention
-    my %infile_info = parse_fastq_infiles_format( { file_name => $file_name, } );
+    my %infile_info = parse_fastq_infiles_format(
+        {
+            file_name => $file_name,
+            sample_id => $sample_id,
+        }
+    );
 
     ## Parse compression features
     $infile_info{read_file_command} = parse_file_compression_features(

--- a/lib/MIP/Parse/File.pm
+++ b/lib/MIP/Parse/File.pm
@@ -25,7 +25,7 @@ BEGIN {
     use base qw{ Exporter };
 
     # Set the version for version checking
-    our $VERSION = 1.12;
+    our $VERSION = 1.13;
 
     # Functions and variables which can be optionally exported
     our @EXPORT_OK = qw{ parse_fastq_infiles parse_file_suffix parse_io_outfiles };
@@ -98,7 +98,6 @@ sub parse_fastq_infiles {
 
     check( $tmpl, $arg_href, 1 ) or croak q{Could not parse arguments!};
 
-    use MIP::Validate::Case qw{ check_infile_contain_sample_id };
     use MIP::Fastq qw{ get_fastq_file_header_info };
     use MIP::File_info qw{
       get_sample_file_attribute
@@ -138,29 +137,10 @@ sub parse_fastq_infiles {
             );
 
             ## If filename convention is followed
-            if ( exists $infile_info{date} ) {
+            if ( not exists $infile_info{date} ) {
 
-                ## Check that the sample_id provided and sample_id in infile name match.
-                check_infile_contain_sample_id(
-                    {
-                        infile_name      => $file_name,
-                        infile_sample_id => $infile_info{infile_sample_id},
-                        sample_id        => $sample_id,
-                        sample_ids_ref   => \@{ $active_parameter_href->{sample_ids} },
-                    }
-                );
-            }
-            else {
                 ## No regexp match i.e. file does not follow filename convention
-                $log->warn(q{Will try to find mandatory information from fastq header.});
-
-                ## Check that file name at least contains sample id
-                if ( $file_name !~ /$sample_id/sxm ) {
-
-                    $log->fatal(
-                        q{Please check that the file name contains the sample_id.});
-                    exit 1;
-                }
+                $log->warn(q{Will try to find mandatory information from fastq header});
 
                 ## Get run info from fastq file header
                 %fastq_info_header = get_fastq_file_header_info(

--- a/lib/MIP/Validate/Case.pm
+++ b/lib/MIP/Validate/Case.pm
@@ -23,7 +23,7 @@ BEGIN {
     use base qw{ Exporter };
 
     # Set the version for version checking
-    our $VERSION = 1.01;
+    our $VERSION = 1.02;
 
     # Functions and variables which can be optionally exported
     our @EXPORT_OK = qw{ check_infiles check_infile_contain_sample_id check_sample_ids };
@@ -100,11 +100,10 @@ q{Check that: '--sample_ids' and '--infile_dirs' contain the same sample_id and 
 sub check_infile_contain_sample_id {
 
 ## Function : Check that the sample_id provided and sample_id in infile name match
-## Returns  :
+## Returns  : 1
 ## Arguments: $infile_name      => Infile name
 ##          : $infile_sample_id => Sample_id collect with regexp from infile
 ##          : $sample_id        => Sample id from user
-##          : $sample_ids_ref   => Sample ids from user
 
     my ($arg_href) = @_;
 
@@ -112,7 +111,6 @@ sub check_infile_contain_sample_id {
     my $infile_name;
     my $infile_sample_id;
     my $sample_id;
-    my $sample_ids_ref;
 
     my $tmpl = {
         infile_name => {
@@ -133,13 +131,6 @@ sub check_infile_contain_sample_id {
             store       => \$sample_id,
             strict_type => 1,
         },
-        sample_ids_ref => {
-            default     => [],
-            defined     => 1,
-            required    => 1,
-            store       => \$sample_ids_ref,
-            strict_type => 1,
-        },
     };
 
     check( $tmpl, $arg_href, 1 ) or croak q{Could not parse arguments!};
@@ -147,24 +138,13 @@ sub check_infile_contain_sample_id {
     ## Retrieve logger object
     my $log = Log::Log4perl->get_logger($LOG_NAME);
 
-    # Track seen sample ids
-    my %seen;
+    return 1 if ( $sample_id eq $infile_sample_id );
 
-    ## Increment for all sample ids
-    map { $seen{$_}++ } ( @{$sample_ids_ref}, $infile_sample_id );
-
-    if ( not $seen{$infile_sample_id} > 1 ) {
-
-        $log->fatal( $sample_id
-              . q{ supplied and sample_id }
-              . $infile_sample_id
-              . q{ found in file : }
-              . $infile_name
-              . q{ does not match. Please rename file to match sample_id: }
-              . $sample_id );
-        exit 1;
-    }
-    return 1;
+    $log->fatal(
+qq{$sample_id supplied and sample_id $infile_sample_id found in file : $infile_name does not match}
+    );
+    $log->fatal(qq{Please rename file to match sample_id: $sample_id});
+    exit 1;
 }
 
 sub check_sample_ids {

--- a/t/check_infile_contain_sample_id.t
+++ b/t/check_infile_contain_sample_id.t
@@ -26,7 +26,7 @@ use MIP::Constants qw{ $COMMA $SPACE };
 use MIP::Test::Fixtures qw{ test_log test_standard_cli };
 
 my $VERBOSE = 1;
-our $VERSION = 1.02;
+our $VERSION = 1.03;
 
 $VERBOSE = test_standard_cli(
     {
@@ -66,7 +66,6 @@ my $log = test_log( {} );
 my $infile_sample_id = q{sample-1};
 my $sample_id        = q{sample-1};
 
-my %active_parameter = ( sample_ids => [ $sample_id, qw{ sample-2 }, ], );
 my %infile = ( $sample_id => { mip_infiles => [ $sample_id . q{.fastq} ], }, );
 
 my $is_ok = check_infile_contain_sample_id(
@@ -74,7 +73,6 @@ my $is_ok = check_infile_contain_sample_id(
         infile_name      => $infile{$sample_id}{mip_infiles}[0],
         infile_sample_id => $infile_sample_id,
         sample_id        => $sample_id,
-        sample_ids_ref   => \@{ $active_parameter{sample_ids} },
     }
 );
 ## Then return true
@@ -89,7 +87,6 @@ trap {
             infile_name      => $infile{q{sample-1}}{mip_infiles}[0],
             infile_sample_id => $infile_sample_id,
             sample_id        => $sample_id,
-            sample_ids_ref   => \@{ $active_parameter{sample_ids} },
         }
     )
 };


### PR DESCRIPTION
…files_format

- Moved sample id and infile sample id check to within parse_fastq_infiles_format
- Updated test to reflect this

### This PR adds | fixes:

- See above

### How to test:

- Automatic and continuous test suite

### Expected outcome:
- [ ] Installation, unit and integration test suite pass

### Review:
- [ ] Code review
- [ ] Tests pass

This [version](https://semver.org/) is a:
- [ ] **MAJOR** - when you make incompatible API changes. If applicable record manual test results in PR header
- [ ] **MINOR** - when you add functionality in a backwards compatible manner. If applicable record manual test results in PR header
- [x] **PATCH** - when you make backwards compatible bug fixes or documentation/instructions
