### PR TITLE
feat(include_y): found_male --> include_y

### DIFF
--- a/lib/MIP/Active_parameter.pm
+++ b/lib/MIP/Active_parameter.pm
@@ -1834,7 +1834,7 @@ sub set_include_y {
         next GENDER if ( $gender eq q{females} );
 
         $active_parameter_href->{include_y} =
-          ( @{ $active_parameter_href->{gender}{$gender} } > 0 ) ? 1 : 0;
+          @{ $active_parameter_href->{gender}{$gender} } ? 1 : 0;
 
         last if $active_parameter_href->{include_y} == 1;
     }

--- a/lib/MIP/Check/Pipeline.pm
+++ b/lib/MIP/Check/Pipeline.pm
@@ -25,7 +25,7 @@ BEGIN {
     use base qw{ Exporter };
 
     # Set the version for version checking
-    our $VERSION = 1.33;
+    our $VERSION = 1.34;
 
     # Functions and variables which can be optionally exported
     our @EXPORT_OK =
@@ -239,7 +239,7 @@ sub check_dragen_rd_dna {
             consensus_analysis_type => $consensus_analysis_type,
             exclude_contigs_ref     => \@{ $active_parameter_href->{exclude_contigs} },
             file_info_href          => $file_info_href,
-            found_male              => $active_parameter_href->{found_male},
+            include_y               => $active_parameter_href->{include_y},
         }
     );
 
@@ -574,7 +574,7 @@ sub check_rd_dna {
             consensus_analysis_type => $consensus_analysis_type,
             exclude_contigs_ref     => \@{ $active_parameter_href->{exclude_contigs} },
             file_info_href          => $file_info_href,
-            found_male              => $active_parameter_href->{found_male},
+            include_y               => $active_parameter_href->{include_y},
         }
     );
 
@@ -1077,7 +1077,7 @@ sub check_rd_dna_vcf_rerun {
             consensus_analysis_type => $consensus_analysis_type,
             exclude_contigs_ref     => \@{ $active_parameter_href->{exclude_contigs} },
             file_info_href          => $file_info_href,
-            found_male              => $active_parameter_href->{found_male},
+            include_y               => $active_parameter_href->{include_y},
         }
     );
 
@@ -1298,7 +1298,7 @@ sub check_rd_rna {
             consensus_analysis_type => $consensus_analysis_type,
             exclude_contigs_ref     => \@{ $active_parameter_href->{exclude_contigs} },
             file_info_href          => $file_info_href,
-            found_male              => $active_parameter_href->{found_male},
+            include_y               => $active_parameter_href->{include_y},
         }
     );
 

--- a/lib/MIP/Config.pm
+++ b/lib/MIP/Config.pm
@@ -23,7 +23,7 @@ BEGIN {
     use base qw{ Exporter };
 
     # Set the version for version checking
-    our $VERSION = 1.05;
+    our $VERSION = 1.06;
 
     # Functions and variables which can be optionally exported
     our @EXPORT_OK = qw{ check_cmd_config_vs_definition_file
@@ -131,8 +131,7 @@ sub parse_config {
 
     ## Constants
     ## Remove previous analysis specific info not relevant for current run e.g. log file, which is read from pedigree or cmd
-    my @REMOVE_KEYS =
-      qw{ binary_path found_female found_male found_other gender log_file dry_run_all };
+    my @REMOVE_KEYS = qw{ binary_path include_y gender log_file dry_run_all };
 
     ## Loads a YAML file into an arbitrary hash and returns it.
     my %config_parameter = read_from_file(

--- a/lib/MIP/Contigs.pm
+++ b/lib/MIP/Contigs.pm
@@ -24,7 +24,7 @@ BEGIN {
     use base qw{ Exporter };
 
     # Set the version for version checking
-    our $VERSION = 1.09;
+    our $VERSION = 1.10;
 
     # Functions and variables which can be optionally exported
     our @EXPORT_OK = qw{
@@ -219,13 +219,13 @@ sub delete_male_contig {
 ## Function : Delete contig chrY | Y from contigs array if no male or other found
 ## Returns  : @contigs
 ## Arguments: $contigs_ref => Contigs array to update {REF}
-##          : $found_male  => Male(s) was included in the analysis
+##          : $include_y   => Male(s) was included in the analysis
 
     my ($arg_href) = @_;
 
     ## Flatten argument(s)
     my $contigs_ref;
-    my $found_male;
+    my $include_y;
 
     my $tmpl = {
         contigs_ref => {
@@ -235,18 +235,18 @@ sub delete_male_contig {
             store       => \$contigs_ref,
             strict_type => 1,
         },
-        found_male => {
-            allow       => qr{\A \d+ \z}sxm,
+        include_y => {
+            allow       => [ 0, 1 ],
             defined     => 1,
             required    => 1,
-            store       => \$found_male,
+            store       => \$include_y,
             strict_type => 1,
         },
     };
 
     check( $tmpl, $arg_href, 1 ) or croak q{Could not parse arguments!};
 
-    return @{$contigs_ref} if ($found_male);
+    return @{$contigs_ref} if ($include_y);
 
     ## Removes contig Y | chrY from contigs if no males or 'other' found in analysis
     my @contigs = delete_contig_elements(
@@ -441,7 +441,7 @@ sub update_contigs_for_run {
 ## Arguments: $consensus_analysis_type => Consensus analysis_type
 ##          : $exclude_contigs_ref     => Exclude contigs from analysis {REF}
 ##          : $file_info_href          => File info hash {REF}
-##          : $found_male              => Male was included in the analysis
+##          : $include_y               => Male was included in the analysis
 
     my ($arg_href) = @_;
 
@@ -449,7 +449,7 @@ sub update_contigs_for_run {
     my $consensus_analysis_type;
     my $exclude_contigs_ref;
     my $file_info_href;
-    my $found_male;
+    my $include_y;
 
     my $tmpl = {
         consensus_analysis_type => {
@@ -471,11 +471,11 @@ sub update_contigs_for_run {
             store       => \$file_info_href,
             strict_type => 1,
         },
-        found_male => {
-            allow       => qr{\A \d+ \z}sxm,
+        include_y => {
+            allow       => [ 0, 1 ],
             defined     => 1,
             required    => 1,
-            store       => \$found_male,
+            store       => \$include_y,
             strict_type => 1,
         },
     };
@@ -523,7 +523,7 @@ sub update_contigs_for_run {
         @{$male_contigs_ref} = delete_male_contig(
             {
                 contigs_ref => $male_contigs_ref,
-                found_male  => $found_male,
+                include_y   => $include_y,
             }
         );
     }

--- a/lib/MIP/Main/Analyse.pm
+++ b/lib/MIP/Main/Analyse.pm
@@ -77,7 +77,7 @@ BEGIN {
     require Exporter;
 
     # Set the version for version checking
-    our $VERSION = 1.54;
+    our $VERSION = 1.55;
 
     # Functions and variables which can be optionally exported
     our @EXPORT_OK = qw{ mip_analyse };
@@ -433,7 +433,7 @@ sub mip_analyse {
         }
     );
 
-    ## Set the gender(s) included in current analysisa and count them
+    ## Set the gender(s) included in current analysis and count them
     set_gender_sample_ids(
         {
             active_parameter_href => \%active_parameter,

--- a/lib/MIP/Parse/Gender.pm
+++ b/lib/MIP/Parse/Gender.pm
@@ -329,7 +329,9 @@ sub parse_fastq_for_gender {
     use MIP::Program::Bwa qw{ bwa_mem };
 
     ## All sample ids have a gender - non need to continue
-    return if ( not $active_parameter_href->{found_other} );
+    return
+      if ( not $active_parameter_href->{gender}{others}
+        or not @{ $active_parameter_href->{gender}{others} } );
 
     ## Unpack
     my $log                = Log::Log4perl->get_logger($LOG_NAME);
@@ -502,7 +504,7 @@ sub update_gender_info {
 
     ## Remove sample_id from others
     @{ $active_parameter_href->{gender}{others} } =
-      grep { !/$sample_id/xms } @{ $active_parameter_href->{gender}{others} };
+      grep { not /$sample_id/xms } @{ $active_parameter_href->{gender}{others} };
 
     set_include_y(
         {

--- a/lib/MIP/Recipes/Analysis/Plink.pm
+++ b/lib/MIP/Recipes/Analysis/Plink.pm
@@ -25,7 +25,7 @@ BEGIN {
     use base qw{ Exporter };
 
     # Set the version for version checking
-    our $VERSION = 1.20;
+    our $VERSION = 1.21;
 
     # Functions and variables which can be optionally exported
     our @EXPORT_OK = qw{ analysis_plink };
@@ -212,14 +212,14 @@ sub analysis_plink {
       PLINK_PROGRAM:
         while ( my ( $file_name_prefix, $file_suffix ) = each %{$program_href} ) {
 
-            if ( scalar @sample_ids > 1 and $mode eq q{multiple_samples} ) {
+            if ( @sample_ids > 1 and $mode eq q{multiple_samples} ) {
 
                 $plink_outanalysis_prefix{$file_name_prefix} = $file_name_prefix;
                 push @plink_outfiles, $file_name_prefix . $DOT . $file_suffix;
                 next;
             }
-            if (    defined $active_parameter_href->{found_other}
-                and $active_parameter_href->{found_other} ne scalar @sample_ids
+            if (    defined $active_parameter_href->{gender}{others}
+                and @{ $active_parameter_href->{gender}{others} } != @sample_ids
                 and $mode eq q{check_for_sex} )
             {
                 $plink_outanalysis_prefix{$file_name_prefix} = $file_name_prefix;
@@ -229,7 +229,7 @@ sub analysis_plink {
     }
 
     ## No eligible test to run
-    if ( not scalar @plink_outfiles ) {
+    if ( not @plink_outfiles ) {
         $log->warn(
             q{No eligible Plink test to run for pedigree and sample(s) - skipping 'plink'}
         );
@@ -371,7 +371,9 @@ sub analysis_plink {
     my $allow_no_sex;
 
     ## If not all samples have a known sex
-    if ( $active_parameter_href->{found_other} ) {
+    if ( $active_parameter_href->{gender}{others}
+        and @{ $active_parameter_href->{gender}{others} } )
+    {
 
         $allow_no_sex = 1;
     }
@@ -392,7 +394,7 @@ sub analysis_plink {
     say {$filehandle} $NEWLINE;
 
     # Only perform if more than 1 sample
-    if ( scalar @sample_ids > 1 ) {
+    if ( @sample_ids > 1 ) {
 
         my $inbreeding_outfile_prefix_hets =
           $binary_fileset_prefix . $DOT . $plink_outanalysis_prefix{inbreeding_factor};
@@ -427,8 +429,8 @@ sub analysis_plink {
         say {$filehandle} $NEWLINE;
     }
 
-    if ( defined $active_parameter_href->{found_other}
-        and $active_parameter_href->{found_other} ne scalar @sample_ids )
+    if ( defined $active_parameter_href->{gender}{others}
+        and @{ $active_parameter_href->{gender}{others} } != @sample_ids )
     {
 
         ## Only if not all samples have unknown sex
@@ -468,7 +470,7 @@ sub analysis_plink {
         my $extract_file;
         my $read_freqfile_path;
 
-        if ( scalar @sample_ids > 1 ) {
+        if ( @sample_ids > 1 ) {
 
             $extract_file       = $binary_fileset_prefix . $DOT . q{prune.in};
             $read_freqfile_path = $binary_fileset_prefix . $DOT . q{frqx};

--- a/t/analysis_plink.t
+++ b/t/analysis_plink.t
@@ -25,7 +25,7 @@ use MIP::Constants qw{ $COLON $COMMA $SPACE };
 use MIP::Test::Fixtures qw{ test_log test_mip_hashes test_standard_cli };
 
 my $VERBOSE = 1;
-our $VERSION = 1.04;
+our $VERSION = 1.05;
 
 $VERBOSE = test_standard_cli(
     {
@@ -79,7 +79,7 @@ $active_parameter{$recipe_name}                     = 1;
 $active_parameter{recipe_core_number}{$recipe_name} = 1;
 $active_parameter{recipe_time}{$recipe_name}        = 1;
 my $case_id = $active_parameter{case_id};
-$active_parameter{found_other} = 1;
+$active_parameter{gender}{others} = [qw{ ADM1059A3 }];
 
 my %file_info = test_mip_hashes(
     {

--- a/t/delete_male_contig.t
+++ b/t/delete_male_contig.t
@@ -23,7 +23,7 @@ use MIP::Constants qw{ $COMMA $SPACE };
 use MIP::Test::Fixtures qw{ test_log test_standard_cli };
 
 my $VERBOSE = 1;
-our $VERSION = 1.01;
+our $VERSION = 1.02;
 
 $VERBOSE = test_standard_cli(
     {
@@ -62,12 +62,12 @@ my $log = test_log( {} );
 ## Given contigs, when male not present
 my @contigs = qw{ 1 2 3 4 Y};
 
-my $is_male = 0;
+my $include_y = 0;
 
 my @no_male_contigs = delete_male_contig(
     {
         contigs_ref => \@contigs,
-        found_male  => $is_male,
+        include_y   => $include_y,
     }
 );
 
@@ -78,12 +78,12 @@ my @expected_contigs = qw{ 1 2 3 4 };
 is_deeply( \@no_male_contigs, \@expected_contigs, q{Removed male contig} );
 
 ## Given contigs, when male is presnt
-$is_male = 1;
+$include_y = 1;
 
 my @has_male_contigs = delete_male_contig(
     {
         contigs_ref => \@contigs,
-        found_male  => $is_male,
+        include_y   => $include_y,
     }
 );
 

--- a/t/parse_fastq_for_gender.t
+++ b/t/parse_fastq_for_gender.t
@@ -24,7 +24,7 @@ use MIP::Constants qw{ $COMMA $SPACE };
 use MIP::Test::Fixtures qw{ test_log test_mip_hashes test_standard_cli };
 
 my $VERBOSE = 1;
-our $VERSION = 1.01;
+our $VERSION = 1.02;
 
 $VERBOSE = test_standard_cli(
     {
@@ -105,8 +105,6 @@ my $is_gender_other = parse_fastq_for_gender(
 is( $is_gender_other, undef, q{No unknown gender} );
 
 ## Given a sample when gender unknown
-$active_parameter{found_other}    = 1;
-$active_parameter{found_male}     = 1;
 $active_parameter{gender}{others} = [$sample_id];
 
 $is_gender_other = parse_fastq_for_gender(

--- a/t/parse_fastq_for_gender.t
+++ b/t/parse_fastq_for_gender.t
@@ -69,8 +69,7 @@ my %active_parameter = test_mip_hashes(
 );
 my $consensus_analysis_type = q{wgs};
 my $sample_id               = $active_parameter{sample_ids}[2];
-$active_parameter{found_other} = 0;
-my %file_info = test_mip_hashes(
+my %file_info               = test_mip_hashes(
     {
         mip_hash_name => q{file_info},
     }

--- a/t/set_gender_sample_ids.t
+++ b/t/set_gender_sample_ids.t
@@ -23,7 +23,7 @@ use MIP::Constants qw{ $COMMA $SPACE };
 use MIP::Test::Fixtures qw{ test_standard_cli };
 
 my $VERBOSE = 1;
-our $VERSION = 1.04;
+our $VERSION = 1.05;
 
 $VERBOSE = test_standard_cli(
     {
@@ -39,8 +39,8 @@ BEGIN {
 ### Check all internal dependency modules and imports
 ## Modules with import
     my %perl_module = (
-        q{MIP::Active_parameter}       => [qw{ set_gender_sample_ids }],
-        q{MIP::Test::Fixtures} => [qw{ test_standard_cli }],
+        q{MIP::Active_parameter} => [qw{ set_gender_sample_ids }],
+        q{MIP::Test::Fixtures}   => [qw{ test_standard_cli }],
     );
 
     test_import( { perl_module_href => \%perl_module, } );
@@ -68,45 +68,29 @@ my %sample_info = (
     },
 );
 
-  set_gender_sample_ids(
+set_gender_sample_ids(
     {
         active_parameter_href => \%active_parameter,
         sample_info_href      => \%sample_info,
     }
-  );
-
-my %expected_result = (
-    found_male   => 2,
-    found_female => 1,
-    found_other  => 1,
 );
 
 my %expected_gender_info = (
-    gender => {
-        males   => [qw{ sample_1 }],
-        females => [qw{ sample_2 }],
-        others  => [qw{ sample_3 }],
-    }
+    males   => [qw{ sample_1 }],
+    females => [qw{ sample_2 }],
+    others  => [qw{ sample_3 }],
 );
-
-GENDER:
-foreach my $found_gender ( keys %expected_result ) {
-
-## Then all genders count should be one
-    is( $active_parameter{$found_gender}, $expected_result{$found_gender},
-        $found_gender );
-}
 
 ## Then sample_ids should be added to each gender category
-is_deeply(
-    $active_parameter{gender},
-    $expected_gender_info{gender},
-    q{Added gender info to active parameter}
-);
+is_deeply( $active_parameter{gender},
+    \%expected_gender_info, q{Added gender info to active parameter} );
+is( $active_parameter{include_y}, 1, q{Set_include y} );
 
 ## Given no males or females
 # Clear data from previous test
-map { $active_parameter{$_} = 0 } (qw{ found_male found_female found_other });
+delete $active_parameter{gender};
+
+#map { $active_parameter{$_} = 0 } (qw{ found_male found_female found_other });
 
 %sample_info = (
     sample => {
@@ -116,25 +100,16 @@ map { $active_parameter{$_} = 0 } (qw{ found_male found_female found_other });
     },
 );
 
-%expected_result = (
-    found_male   => 3,
-    found_female => 0,
-    found_other  => 3,
-);
-
 set_gender_sample_ids(
     {
         active_parameter_href => \%active_parameter,
         sample_info_href      => \%sample_info,
     }
-  );
+);
 
-GENDER:
-foreach my $found_gender ( keys %expected_result ) {
-
-## Then one male should be found and a other count of three
-    is( $active_parameter{$found_gender}, $expected_result{$found_gender},
-        $found_gender );
-}
+%expected_gender_info = ( others => [qw{ sample_1 sample_2 sample_3 }], );
+## Then sample_ids should be added to each gender category
+is_deeply( $active_parameter{gender},
+    \%expected_gender_info, q{Added gender info to active parameter} );
 
 done_testing();

--- a/t/set_gender_sample_ids.t
+++ b/t/set_gender_sample_ids.t
@@ -90,8 +90,6 @@ is( $active_parameter{include_y}, 1, q{Set_include y} );
 # Clear data from previous test
 delete $active_parameter{gender};
 
-#map { $active_parameter{$_} = 0 } (qw{ found_male found_female found_other });
-
 %sample_info = (
     sample => {
         sample_1 => { sex => q{xyz}, },

--- a/t/set_include_y.t
+++ b/t/set_include_y.t
@@ -1,0 +1,89 @@
+#!/usr/bin/env perl
+
+use 5.026;
+use Carp;
+use charnames qw{ :full :short };
+use English qw{ -no_match_vars };
+use File::Basename qw{ dirname };
+use File::Spec::Functions qw{ catdir };
+use FindBin qw{ $Bin };
+use open qw{ :encoding(UTF-8) :std };
+use Params::Check qw{ allow check last_error };
+use Test::More;
+use utf8;
+use warnings qw{ FATAL utf8 };
+
+## CPANM
+use autodie qw { :all };
+use Modern::Perl qw{ 2018 };
+
+## MIPs lib/
+use lib catdir( dirname($Bin), q{lib} );
+use MIP::Constants qw{ $COMMA $SPACE };
+use MIP::Test::Fixtures qw{ test_standard_cli };
+
+my $VERBOSE = 1;
+our $VERSION = 1.00;
+
+$VERBOSE = test_standard_cli(
+    {
+        verbose => $VERBOSE,
+        version => $VERSION,
+    }
+);
+
+BEGIN {
+
+    use MIP::Test::Fixtures qw{ test_import };
+
+### Check all internal dependency modules and imports
+## Modules with import
+    my %perl_module = (
+        q{MIP::Active_parameter} => [qw{ set_include_y }],
+        q{MIP::Test::Fixtures}   => [qw{ test_standard_cli }],
+    );
+
+    test_import( { perl_module_href => \%perl_module, } );
+}
+
+use MIP::Active_parameter qw{ set_include_y };
+
+diag(   q{Test set_include_y from Active_parameter.pm v}
+      . $MIP::Active_parameter::VERSION
+      . $COMMA
+      . $SPACE . q{Perl}
+      . $SPACE
+      . $PERL_VERSION
+      . $SPACE
+      . $EXECUTABLE_NAME );
+
+## Given a gender hash with males and others
+my %active_parameter = (
+    gender => {
+        males   => [qw{ id_1 id_2 }],
+        females => [qw{ id_3 }],
+        others  => [qw{ id_4 }],
+    },
+);
+
+## Then set include_y to 1
+set_include_y(
+    {
+        active_parameter_href => \%active_parameter,
+    }
+);
+is( $active_parameter{include_y}, 1, q{Set include_y to 1} );
+
+## Given no males or other
+delete $active_parameter{gender}{males};
+delete $active_parameter{gender}{others};
+
+## Then set include_y to 0
+set_include_y(
+    {
+        active_parameter_href => \%active_parameter,
+    }
+);
+is( $active_parameter{include_y}, 0, q{Set include_y to 0} );
+
+done_testing();

--- a/t/update_contigs_for_run.t
+++ b/t/update_contigs_for_run.t
@@ -24,7 +24,7 @@ use MIP::Constants qw{ $COMMA $SPACE };
 use MIP::Test::Fixtures qw{ test_log test_standard_cli };
 
 my $VERBOSE = 1;
-our $VERSION = 1.03;
+our $VERSION = 1.04;
 
 $VERBOSE = test_standard_cli(
     {
@@ -65,7 +65,7 @@ diag(   q{Test update_contigs_for_run from Contigs.pm v}
 my $log = test_log( {} );
 
 ## Given some contigs to remove
-my $found_male      = 0;
+my $include_y       = 0;
 my @exclude_contigs = qw{ 1 2 3 4};
 
 my %file_info = (
@@ -81,7 +81,7 @@ update_contigs_for_run(
         consensus_analysis_type => q{wes},
         exclude_contigs_ref     => \@exclude_contigs,
         file_info_href          => \%file_info,
-        found_male              => $found_male,
+        include_y               => $include_y,
     }
 );
 

--- a/t/update_gender_info.t
+++ b/t/update_gender_info.t
@@ -98,7 +98,7 @@ is( $active_parameter{include_y}, 1, q{Include y} );
 is( $active_parameter{gender_estimation}{$sample_id},
     q{male}, q{Added estimated gender male} );
 is_deeply( $active_parameter{gender}{males}, [$sample_id], q{Add to males sample_id} );
-is_deeply( $active_parameter{gender}{others}, [], q{Remove from others sample_id} );
+is( @{ $active_parameter{gender}{others} }, 0, q{Remove from others sample_id} );
 
 ## Given a y read count when female
 $y_read_count = $FEMALE_THRESHOLD;
@@ -121,6 +121,6 @@ is( $active_parameter{gender_estimation}{$sample_id},
     q{female}, q{Added estimated gender female} );
 is_deeply( $active_parameter{gender}{females}, [$sample_id],
     q{Add to females sample_id} );
-is_deeply( $active_parameter{gender}{others}, [], q{Remove from others sample_id} );
+is( @{ $active_parameter{gender}{others} }, 0, q{Remove from others sample_id} );
 
 done_testing();


### PR DESCRIPTION
### This PR adds | fixes:

- Removes the counters: 'found_female', 'found_male', 'found_other' from active_parameters and replaces it with the bolean 'include_y'


### How to test:

- Automatic and continuous test suite

### Expected outcome:
- [ ] Installation, unit and integration test suite pass

### Review:
- [ ] Code review
- [ ] Tests pass

This [version](https://semver.org/) is a:
- [ ] **MAJOR** - when you make incompatible API changes. If applicable record manual test results in PR header
- [ ] **MINOR** - when you add functionality in a backwards compatible manner. If applicable record manual test results in PR header
- [x] **PATCH** - when you make backwards compatible bug fixes or documentation/instructions
