### PR TITLE
feat(refactor): set_infile_info and get_fastq_file_header_info

### DIFF
--- a/lib/MIP/Fastq.pm
+++ b/lib/MIP/Fastq.pm
@@ -239,7 +239,7 @@ sub get_fastq_file_header_info {
 ## Function : Get run info from fastq file header
 ## Returns  : @fastq_info_headers
 ## Arguments: $file_info_href    => File info hash {REF}
-##          : $file_name      => Fast file name
+##          : $file_name         => Fast file name
 ##          : $file_path         => File path to parse
 ##          : $read_file_command => Command used to read file
 ##          : $sample_id         => Sample id

--- a/lib/MIP/File_info.pm
+++ b/lib/MIP/File_info.pm
@@ -25,10 +25,11 @@ BEGIN {
     use base qw{ Exporter };
 
     # Set the version for version checking
-    our $VERSION = 1.11;
+    our $VERSION = 1.12;
 
     # Functions and variables which can be optionally exported
     our @EXPORT_OK = qw{
+      add_sample_fastq_file_lanes
       check_parameter_metafiles
       get_is_sample_files_compressed
       get_sample_file_attribute
@@ -47,6 +48,65 @@ BEGIN {
       set_sample_file_attribute
       set_select_file_contigs
     };
+}
+
+## Constants
+Readonly my $INTERLEAVED_READ_DIRECTION = 3;
+
+sub add_sample_fastq_file_lanes {
+
+## Function : Add sample fastq file lane to lanes
+## Returns  :
+## Arguments: $direction      => Read direction
+##          : $file_info_href => File info hash {REF}
+##          : $lane           => Fast file name
+##          : $sample_id      => Sample id
+
+    my ($arg_href) = @_;
+
+    ## Flatten argument(s)
+    my $direction;
+    my $file_info_href;
+    my $lane;
+    my $sample_id;
+
+    my $tmpl = {
+        direction => {
+            allow       => [ undef, 1, 2, $INTERLEAVED_READ_DIRECTION, ],
+            required    => 1,
+            store       => \$direction,
+            strict_type => 1,
+        },
+        file_info_href => {
+            default     => {},
+            defined     => 1,
+            required    => 1,
+            store       => \$file_info_href,
+            strict_type => 1,
+        },
+        lane => {
+            required    => 1,
+            store       => \$lane,
+            strict_type => 1,
+        },
+        sample_id => {
+            defined     => 1,
+            required    => 1,
+            store       => \$sample_id,
+            strict_type => 1,
+        },
+    };
+
+    check( $tmpl, $arg_href, 1 ) or croak q{Could not parse arguments!};
+
+    return if ( not $lane );
+
+    return if ( not $direction == 1 );
+
+    ## Add lane
+    push @{ $file_info_href->{$sample_id}{lanes} }, $lane;
+
+    return;
 }
 
 sub check_parameter_metafiles {
@@ -491,6 +551,15 @@ sub parse_sample_fastq_file_attributes {
         {
             file_path         => catfile( $infiles_dir, $file_name ),
             read_file_command => $infile_info{read_file_command},
+        }
+    );
+
+    add_sample_fastq_file_lanes(
+        {
+            direction      => $infile_info{direction},
+            file_info_href => $file_info_href,
+            lane           => $infile_info{lane},
+            sample_id      => $sample_id,
         }
     );
 

--- a/lib/MIP/File_info.pm
+++ b/lib/MIP/File_info.pm
@@ -51,7 +51,7 @@ BEGIN {
 }
 
 ## Constants
-Readonly my $INTERLEAVED_READ_DIRECTION = 3;
+Readonly my $INTERLEAVED_READ_DIRECTION => 3;
 
 sub add_sample_fastq_file_lanes {
 

--- a/lib/MIP/Parse/File.pm
+++ b/lib/MIP/Parse/File.pm
@@ -25,7 +25,7 @@ BEGIN {
     use base qw{ Exporter };
 
     # Set the version for version checking
-    our $VERSION = 1.13;
+    our $VERSION = 1.14;
 
     # Functions and variables which can be optionally exported
     our @EXPORT_OK = qw{ parse_fastq_infiles parse_file_suffix parse_io_outfiles };
@@ -145,66 +145,15 @@ sub parse_fastq_infiles {
                 ## Get run info from fastq file header
                 %fastq_info_header = get_fastq_file_header_info(
                     {
+                        file_info_href    => $file_info_href,
+                        file_name         => $file_name,
                         file_path         => catfile( $infiles_dir, $file_name ),
                         read_file_command => $infile_info{read_file_command},
+                        sample_id         => $sample_id,
                     }
                 );
-
-                if ( not exists $fastq_info_header{index} ) {
-
-                    # Special case since index is not present in fast headers casaava 1.4
-                    $fastq_info_header{index} = $EMPTY_STR;
-                }
-            }
-            if ( exists $infile_info{date} ) {
 
                 ## Adds information derived from infile name to hashes
-                $lane_tracker = set_infile_info(
-                    {
-                        active_parameter_href => $active_parameter_href,
-                        date                  => $infile_info{date},
-                        direction             => $infile_info{direction},
-                        file_info_href        => $file_info_href,
-                        file_index            => $file_index,
-                        flowcell              => $infile_info{flowcell},
-                        index                 => $infile_info{index},
-                        infile_both_strands_prefix_href =>
-                          $infile_both_strands_prefix_href,
-                        infile_lane_prefix_href => $infile_lane_prefix_href,
-                        is_interleaved          => $infile_info{is_interleaved},
-                        lane                    => $infile_info{lane},
-                        lane_tracker            => $lane_tracker,
-                        read_length             => $infile_info{read_length},
-                        sample_id               => $infile_info{infile_sample_id},
-                        sample_info_href        => $sample_info_href,
-                    }
-                );
-            }
-            else {
-                ## Adds information derived from infile name to hashes
-                $lane_tracker = set_infile_info(
-                    {
-                        active_parameter_href => $active_parameter_href,
-                        ## fastq format does not contain a date of the run,
-                        ## so fake it with constant impossible date
-                        date           => q{000101},
-                        direction      => $fastq_info_header{direction},
-                        file_index     => $file_index,
-                        file_info_href => $file_info_href,
-                        flowcell       => $fastq_info_header{flowcell},
-                        index          => $fastq_info_header{index},
-                        infile_both_strands_prefix_href =>
-                          $infile_both_strands_prefix_href,
-                        infile_lane_prefix_href => $infile_lane_prefix_href,
-                        is_interleaved          => $infile_info{is_interleaved},
-                        lane                    => $fastq_info_header{lane},
-                        lane_tracker            => $lane_tracker,
-                        read_length             => $infile_info{read_length},
-                        sample_id               => $sample_id,
-                        sample_info_href        => $sample_info_href,
-                    }
-                );
-
                 $log->info(
                         q{Found following information from fastq header: lane=}
                       . $fastq_info_header{lane}
@@ -219,6 +168,21 @@ sub parse_fastq_infiles {
 q{Will add fake date '20010101' to follow file convention since this is not recorded in fastq header}
                 );
             }
+
+            ## Adds information derived from infile name to hashes
+            $lane_tracker = set_infile_info(
+                {
+                    active_parameter_href           => $active_parameter_href,
+                    file_index                      => $file_index,
+                    file_info_href                  => $file_info_href,
+                    file_name                       => $file_name,
+                    infile_both_strands_prefix_href => $infile_both_strands_prefix_href,
+                    infile_lane_prefix_href         => $infile_lane_prefix_href,
+                    lane_tracker                    => $lane_tracker,
+                    sample_id                       => $sample_id,
+                    sample_info_href                => $sample_info_href,
+                }
+            );
 
             parse_files_compression_status(
                 {

--- a/t/add_sample_fastq_file_lanes.t
+++ b/t/add_sample_fastq_file_lanes.t
@@ -1,0 +1,96 @@
+#!/usr/bin/env perl
+
+use 5.026;
+use Carp;
+use charnames qw{ :full :short };
+use English qw{ -no_match_vars };
+use File::Basename qw{ dirname };
+use File::Spec::Functions qw{ catdir };
+use FindBin qw{ $Bin };
+use open qw{ :encoding(UTF-8) :std };
+use Params::Check qw{ allow check last_error };
+use Test::More;
+use utf8;
+use warnings qw{ FATAL utf8 };
+
+## CPANM
+use autodie qw { :all };
+use Modern::Perl qw{ 2018 };
+
+## MIPs lib/
+use lib catdir( dirname($Bin), q{lib} );
+use MIP::Constants qw{ $COMMA $SPACE };
+use MIP::Test::Fixtures qw{ test_standard_cli };
+
+my $VERBOSE = 1;
+our $VERSION = 1.00;
+
+$VERBOSE = test_standard_cli(
+    {
+        verbose => $VERBOSE,
+        version => $VERSION,
+    }
+);
+
+BEGIN {
+
+    use MIP::Test::Fixtures qw{ test_import };
+
+### Check all internal dependency modules and imports
+## Modules with import
+    my %perl_module = (
+        q{MIP::File_info}      => [qw{ add_sample_fastq_file_lanes }],
+        q{MIP::Test::Fixtures} => [qw{ test_standard_cli }],
+    );
+
+    test_import( { perl_module_href => \%perl_module, } );
+}
+
+use MIP::File_info qw{ add_sample_fastq_file_lanes };
+
+diag(   q{Test add_sample_fastq_file_lanes from File_info.pm v}
+      . $MIP::File_info::VERSION
+      . $COMMA
+      . $SPACE . q{Perl}
+      . $SPACE
+      . $PERL_VERSION
+      . $SPACE
+      . $EXECUTABLE_NAME );
+
+## Given a sample_id and lane
+my %file_info;
+my $lane      = 1;
+my $sample_id = q{sample_id};
+
+## When direction is not one
+my $direction = 2;
+
+add_sample_fastq_file_lanes(
+    {
+        direction      => $direction,
+        file_info_href => \%file_info,
+        lane           => $lane,
+        sample_id      => $sample_id,
+    }
+);
+
+## Then do not add lanes
+is( @{ $file_info{$sample_id}{lanes} },
+    0, q{Did not add lane for direction other than 1} );
+
+## When direction is one
+$direction = 1;
+
+add_sample_fastq_file_lanes(
+    {
+        direction      => $direction,
+        file_info_href => \%file_info,
+        lane           => $lane,
+        sample_id      => $sample_id,
+    }
+);
+
+## Then do not add lanes
+is( @{ $file_info{$sample_id}{lanes} }, 1, q{Added lane for direction equals 1} );
+
+done_testing();

--- a/t/add_sample_fastq_file_lanes.t
+++ b/t/add_sample_fastq_file_lanes.t
@@ -90,7 +90,7 @@ add_sample_fastq_file_lanes(
     }
 );
 
-## Then do not add lanes
+## Then add lanes
 is( @{ $file_info{$sample_id}{lanes} }, 1, q{Added lane for direction equals 1} );
 
 done_testing();

--- a/t/get_fastq_file_header_info.t
+++ b/t/get_fastq_file_header_info.t
@@ -21,7 +21,7 @@ use Test::Trap;
 
 ## MIPs lib/
 use lib catdir( dirname($Bin), q{lib} );
-use MIP::Constants qw{ $COMMA $NEWLINE $SPACE };
+use MIP::Constants qw{ $COMMA $EMPTY_STR $NEWLINE $SPACE };
 use MIP::Test::Fixtures qw{ test_log test_standard_cli };
 
 my $VERBOSE = 1;
@@ -60,6 +60,7 @@ diag(   q{Test get_fastq_file_header_info from Fastq.pm v}
       . $EXECUTABLE_NAME );
 
 ## Constants
+Readonly my $FAKE_DATE        => q{000101};
 Readonly my $LANE             => 7;
 Readonly my $LANE_V_1_8       => 8;
 Readonly my $RUN_NUMBER       => 41;
@@ -77,17 +78,24 @@ my $log = test_log( {} );
 ## Given file, when format is lesser than Casava 1.4
 my $directory = catfile( $Bin, qw{ data 643594-miptest test_data ADM1059A1 fastq} );
 my $file_format_illumina_v1_4 = q{1_161011_TestFilev2_ADM1059A1_TCCGGAGA_1.fastq.gz};
-my $read_file_command         = q{gzip -d -c};
+my %file_info;
+my $read_file_command = q{gzip -d -c};
+my $sample_id         = q{ADM1059A1};
 
 my %fastq_info_header = get_fastq_file_header_info(
     {
+        file_info_href    => \%file_info,
+        file_name         => $file_format_illumina_v1_4,
         file_path         => catfile( $directory, $file_format_illumina_v1_4 ),
         read_file_command => $read_file_command,
+        sample_id         => $sample_id,
     }
 );
 my %expected_header_element_v1_4 = (
+    date          => $FAKE_DATE,
     direction     => 1,
     flowcell      => q{H2V7FCCXX},
+    index         => $EMPTY_STR,
     instrument_id => q{@ST-E00266},
     lane          => $LANE,
     run_number    => $RUN_NUMBER,
@@ -108,12 +116,16 @@ my $file_format_illumina_v1_8 = q{8_161011_HHJJCCCXY_ADM1059A1_NAATGCGC_1.fastq.
 
 %fastq_info_header = get_fastq_file_header_info(
     {
+        file_info_href    => \%file_info,
+        file_name         => $file_format_illumina_v1_8,
         file_path         => catfile( $directory, $file_format_illumina_v1_8 ),
         read_file_command => $read_file_command,
+        sample_id         => $sample_id,
     }
 );
 my %expected_header_element_v1_8 = (
     control_bit   => 0,
+    date          => $FAKE_DATE,
     direction     => 1,
     filtered      => q{N},
     flowcell      => q{HHJJCCCXY},
@@ -140,8 +152,11 @@ my $file_bad_format = q{643594-miptest_pedigree.yaml};
 trap {
     get_fastq_file_header_info(
         {
+            file_info_href    => \%file_info,
+            file_name         => $file_bad_format,
             file_path         => catfile( $directory, $file_bad_format ),
             read_file_command => q{cat},
+            sample_id         => $sample_id,
         }
     )
 };

--- a/t/parse_sample_fastq_file_attributes.t
+++ b/t/parse_sample_fastq_file_attributes.t
@@ -24,7 +24,7 @@ use MIP::Constants qw{ $COMMA $SPACE };
 use MIP::Test::Fixtures qw{ test_log test_standard_cli };
 
 my $VERBOSE = 1;
-our $VERSION = 1.00;
+our $VERSION = 1.01;
 
 $VERBOSE = test_standard_cli(
     {
@@ -93,9 +93,13 @@ my %expected_infile_info = (
     read_file_command => q{gzip -d -c},
     read_length       => $READ_LENGTH,
 );
+my @expected_lanes = (1);
 
 ## Then file info for sample fastq should be collected
 is_deeply( \%infile_info, \%expected_infile_info,
     q{Set and returned file info for sample fastq file} );
+
+is_deeply( $file_info{$sample_id}{lanes},
+    \@expected_lanes, q{Set sample lanes in file_info} );
 
 done_testing();

--- a/t/set_infile_info.t
+++ b/t/set_infile_info.t
@@ -70,8 +70,6 @@ diag(   q{Test set_infile_info from Sample_info.pm v}
 my $log = test_log( {} );
 
 ## Set file info parameters
-
-# Interleaved files
 my $fastq_file_read_one = q{file-1};
 my $fastq_file_read_two = q{file-2};
 my $sample_id           = q{sample-1};
@@ -164,7 +162,7 @@ for my $sample_id ( keys %file_info ) {
         each @{ $file_info{$sample_id}{mip_infiles} } )
     {
 
-        my %file_attribute = get_sample_file_attribute(
+        get_sample_file_attribute(
             {
                 file_info_href => \%file_info,
                 file_name      => $file_name,

--- a/t/set_infile_info.t
+++ b/t/set_infile_info.t
@@ -27,7 +27,7 @@ use MIP::Constants qw{ $COMMA $SPACE };
 use MIP::Test::Fixtures qw{ test_log test_standard_cli };
 
 my $VERBOSE = 1;
-our $VERSION = 1.05;
+our $VERSION = 1.06;
 
 $VERBOSE = test_standard_cli(
     {
@@ -54,6 +54,7 @@ BEGIN {
 }
 
 use MIP::Fastq qw{ define_mip_fastq_file_features };
+use MIP::File_info qw{ get_sample_file_attribute };
 use MIP::Sample_info qw{ set_infile_info };
 
 diag(   q{Test set_infile_info from Sample_info.pm v}
@@ -71,70 +72,115 @@ my $log = test_log( {} );
 ## Set file info parameters
 
 # Interleaved files
-my $is_interleaved;
-
-my $read_length = $READ_LENGTH;
-my $sample_id   = q{sample-1};
+my $fastq_file_read_one = q{file-1};
+my $fastq_file_read_two = q{file-2};
+my $sample_id           = q{sample-1};
 
 my %active_parameter = ( case_id => q{Adams}, );
-my %file_info = ( $sample_id => { mip_infiles => [qw{ file-1 }], }, );
-my %infile_both_strands_prefix;
-my %infile_info = (
-    date             => q{150703},
-    direction        => 1,
-    flowcell         => q{Undetermined-flow-rider},
-    index            => q{ATCG},
-    infile_sample_id => $sample_id,
-    lane             => 1,
+my %file_info        = (
+    $sample_id => {
+        $fastq_file_read_one => {
+            date             => q{150703},
+            direction        => 1,
+            flowcell         => q{Undetermined-flow-rider},
+            index            => q{ATCG},
+            infile_sample_id => $sample_id,
+            is_interleaved   => 0,
+            lane             => 1,
+            read_length      => $READ_LENGTH,
+        },
+        $fastq_file_read_two => {
+            date             => q{150703},
+            direction        => 2,
+            flowcell         => q{Undetermined-flow-rider},
+            index            => q{ATCG},
+            infile_sample_id => $sample_id,
+            lane             => 1,
+            read_length      => $READ_LENGTH,
+        },
+        lanes       => [1],
+        mip_infiles => [ $fastq_file_read_one, $fastq_file_read_two ],
+    },
 );
+my %infile_both_strands_prefix;
 my %infile_lane_prefix;
 my %sample_info;
+
+my %attribute = get_sample_file_attribute(
+    {
+        file_info_href => \%file_info,
+        file_name      => $fastq_file_read_one,
+        sample_id      => $sample_id,
+    }
+);
 
 ## Define file formats
 my ( $mip_file_format, $mip_file_format_with_direction,
     $original_file_name_prefix, $run_barcode )
   = define_mip_fastq_file_features(
     {
-        date               => $infile_info{date},
-        direction          => $infile_info{direction},
-        flowcell           => $infile_info{flowcell},
-        index              => $infile_info{index},
-        lane               => $infile_info{lane},
-        original_file_name => $file_info{$sample_id}{mip_infiles}[0],
+        date               => $attribute{date},
+        direction          => $attribute{direction},
+        flowcell           => $attribute{flowcell},
+        index              => $attribute{index},
+        lane               => $attribute{lane},
+        original_file_name => $fastq_file_read_one,
         sample_id          => $sample_id,
     }
   );
 
-my $parsed_date = Time::Piece->strptime( $infile_info{date}, q{%y%m%d} );
+my %attribute_2 = get_sample_file_attribute(
+    {
+        file_info_href => \%file_info,
+        file_name      => $fastq_file_read_two,
+        sample_id      => $sample_id,
+    }
+);
+my ( $mip_file_format_2, $mip_file_format_with_direction_2 ) =
+  define_mip_fastq_file_features(
+    {
+        date               => $attribute_2{date},
+        direction          => $attribute_2{direction},
+        flowcell           => $attribute_2{flowcell},
+        index              => $attribute_2{index},
+        lane               => $attribute_2{lane},
+        original_file_name => $fastq_file_read_two,
+        sample_id          => $sample_id,
+    }
+  );
+
+my $parsed_date = Time::Piece->strptime( $attribute{date}, q{%y%m%d} );
 $parsed_date = $parsed_date->ymd;
+my $lane_tracker = 0;
 
 ## Given single file, when Undetermined in flowcell name
 SAMPLE_ID:
 for my $sample_id ( keys %file_info ) {
 
-    my $lane_tracker = 0;
+    $lane_tracker = 0;
 
   INFILE:
     while ( my ( $file_index, $file_name ) =
         each @{ $file_info{$sample_id}{mip_infiles} } )
     {
 
-        set_infile_info(
+        my %file_attribute = get_sample_file_attribute(
+            {
+                file_info_href => \%file_info,
+                file_name      => $file_name,
+                sample_id      => $sample_id,
+            }
+        );
+        $lane_tracker = set_infile_info(
             {
                 active_parameter_href           => \%active_parameter,
-                date                            => $infile_info{date},
-                direction                       => $infile_info{direction},
                 file_index                      => $file_index,
                 file_info_href                  => \%file_info,
-                flowcell                        => $infile_info{flowcell},
-                index                           => $infile_info{index},
+                file_name                       => $file_name,
                 infile_both_strands_prefix_href => \%infile_both_strands_prefix,
                 infile_lane_prefix_href         => \%infile_lane_prefix,
-                is_interleaved                  => $is_interleaved,
-                lane                            => $infile_info{lane},
                 lane_tracker                    => $lane_tracker,
-                read_length                     => $read_length,
-                sample_id                       => $infile_info{infile_sample_id},
+                sample_id                       => $sample_id,
                 sample_info_href                => \%sample_info,
             }
         );
@@ -148,27 +194,40 @@ my %expected_result = (
             lanes => [1],
         },
     },
-    infile_both_strands_prefix => { $sample_id => [ $mip_file_format_with_direction, ], },
-    infile_lane_prefix         => {
-        $sample_id => [ $mip_file_format, ],
+    infile_both_strands_prefix => {
+        $sample_id =>
+          [ $mip_file_format_with_direction, $mip_file_format_with_direction_2 ],
+    },
+    infile_lane_prefix => {
+        $sample_id => [$mip_file_format],
     },
     sample_info => {
         sample => {
             $sample_id => {
                 file => {
                     $mip_file_format => {
-                        sequence_run_type   => q{single-end},
+                        sequence_run_type   => q{paired-end},
                         sequence_length     => $READ_LENGTH,
-                        interleaved         => undef,
+                        interleaved         => 0,
                         read_direction_file => {
                             $mip_file_format_with_direction => {
                                 date                      => $parsed_date,
-                                original_file_name        => q{file-1},
+                                original_file_name        => $fastq_file_read_one,
                                 original_file_name_prefix => $original_file_name_prefix,
-                                read_direction            => $infile_info{direction},
-                                lane                      => $infile_info{lane},
-                                flowcell                  => $infile_info{flowcell},
-                                sample_barcode            => $infile_info{index},
+                                read_direction            => $attribute{direction},
+                                lane                      => $attribute{lane},
+                                flowcell                  => $attribute{flowcell},
+                                sample_barcode            => $attribute{index},
+                                run_barcode               => $run_barcode,
+                            },
+                            $mip_file_format_with_direction_2 => {
+                                date                      => $parsed_date,
+                                original_file_name        => $fastq_file_read_two,
+                                original_file_name_prefix => $original_file_name_prefix,
+                                read_direction            => $attribute_2{direction},
+                                lane                      => $attribute_2{lane},
+                                flowcell                  => $attribute_2{flowcell},
+                                sample_barcode            => $attribute_2{index},
                                 run_barcode               => $run_barcode,
                             },
                         },
@@ -178,6 +237,9 @@ my %expected_result = (
         },
     },
 );
+
+## Then lane tracker should be one
+is( $lane_tracker, 1, q{Tracked lane} );
 
 ## Then add the lane info
 is_deeply(
@@ -197,148 +259,10 @@ is_deeply(
 is_deeply(
     \%infile_both_strands_prefix,
     \%{ $expected_result{infile_both_strands_prefix} },
-    q{Added MIP file format with direction for single-end read}
-);
-
-## Then add single-end read info from file name
-is_deeply(
-    \%sample_info,
-    \%{ $expected_result{sample_info} },
-    q{Added sample info for single-end read}
-);
-
-## Clear results
-%expected_result = ();
-
-## Given another file to mimic read direction 2
-%file_info = ( $sample_id => { mip_infiles => [qw{ file-1 file-2}], }, );
-
-my $lane_tracker = 0;
-
-SAMPLE_ID:
-for my $sample_id ( keys %file_info ) {
-
-    $lane_tracker = 0;
-
-  INFILE:
-    while ( my ( $file_index, $file_name ) =
-        each @{ $file_info{$sample_id}{mip_infiles} } )
-    {
-
-        if ( $file_index == 1 ) {
-
-            ## Update infile info to mimic second read direction
-            $infile_info{direction} = 2;
-
-            ## Redefine file format for new direction
-            (
-                $mip_file_format, $mip_file_format_with_direction,
-                $original_file_name_prefix, $run_barcode
-              )
-              = define_mip_fastq_file_features(
-                {
-                    date      => $infile_info{date},
-                    direction => $infile_info{direction},
-                    flowcell  => $infile_info{flowcell},
-                    index     => $infile_info{index},
-                    lane      => $infile_info{lane},
-                    original_file_name =>
-                      $file_info{$sample_id}{mip_infiles}[$file_index],
-                    sample_id => $sample_id,
-                }
-              );
-
-            ## Add second read to infile lane prefix
-            push @{ $expected_result{infile_lane_prefix}{$sample_id} }, $mip_file_format;
-        }
-
-        ## Add the infile both strands prefix
-        push @{ $expected_result{infile_both_strands_prefix}{$sample_id} },
-          $mip_file_format_with_direction;
-
-        $lane_tracker = set_infile_info(
-            {
-                active_parameter_href           => \%active_parameter,
-                date                            => $infile_info{date},
-                direction                       => $infile_info{direction},
-                file_index                      => $file_index,
-                file_info_href                  => \%file_info,
-                flowcell                        => $infile_info{flowcell},
-                index                           => $infile_info{index},
-                infile_both_strands_prefix_href => \%infile_both_strands_prefix,
-                infile_lane_prefix_href         => \%infile_lane_prefix,
-                is_interleaved                  => $is_interleaved,
-                lane                            => $infile_info{lane},
-                lane_tracker                    => $lane_tracker,
-                read_length                     => $read_length,
-                sample_id                       => $infile_info{infile_sample_id},
-                sample_info_href                => \%sample_info,
-            }
-        );
-
-        ## Define what to expect
-        my %direction_one_metric = (
-            interleaved     => $is_interleaved,
-            sequence_length => $READ_LENGTH,
-        );
-
-        ## Alias
-        my $file_level_href =
-          \%{ $expected_result{sample_info}{sample}{$sample_id}{file}{$mip_file_format} };
-      INFO:
-        while ( my ( $file_key, $file_value ) = each %direction_one_metric ) {
-
-            $file_level_href->{$file_key} = $file_value;
-        }
-
-        my %both_directions_metric = (
-            date                      => $parsed_date,
-            flowcell                  => $infile_info{flowcell},
-            lane                      => $infile_info{lane},
-            original_file_name        => $file_info{$sample_id}{mip_infiles}[$file_index],
-            original_file_name_prefix => $original_file_name_prefix,
-            read_direction            => $infile_info{direction},
-            run_barcode               => $run_barcode,
-            sample_barcode            => $infile_info{index},
-        );
-
-        ## Alias
-        my $direction_level_href =
-          \%{ $expected_result{sample_info}{sample}{$sample_id}{file}
-              {$mip_file_format}{read_direction_file}{$mip_file_format_with_direction} };
-
-      INFO:
-        while ( my ( $file_key, $file_value ) = each %both_directions_metric ) {
-
-            $direction_level_href->{$file_key} = $file_value;
-        }
-    }
-}
-
-$expected_result{lane}{$sample_id}{lanes} = [ 1, ];
-
-$expected_result{sample_info}{sample}{$sample_id}{file}{$mip_file_format}
-  {sequence_run_type} = q{paired-end};
-
-is( $lane_tracker, 1, q{Tracked lane} );
-
-is_deeply(
-    \@{ $file_info{$sample_id}{lanes} },
-    \@{ $expected_result{lane}{$sample_id}{lanes} },
-    q{Added lane info for paired-end read}
-);
-
-is_deeply(
-    \%infile_lane_prefix,
-    \%{ $expected_result{infile_lane_prefix} },
-    q{Added MIP file format for paired-end read}
-);
-is_deeply(
-    \%infile_both_strands_prefix,
-    \%{ $expected_result{infile_both_strands_prefix} },
     q{Added MIP file format with direction for paired-end read}
 );
 
+## Then add single-end read info from file name
 is_deeply(
     \%sample_info,
     \%{ $expected_result{sample_info} },


### PR DESCRIPTION
- Added new sub add_sample_fastq_file_lanes and use it parse_sample_fastq_file_attributes
- Set file sample file info data in get_fastq_file_header_info
- Modify call to set_infile_info

### This PR adds | fixes:

- See above

### How to test:

- Automatic and continuous test suite

### Expected outcome:
- [ ] Installation, unit and integration test suite pass

### Review:
- [ ] Code review
- [ ] Tests pass

This [version](https://semver.org/) is a:
- [ ] **MAJOR** - when you make incompatible API changes. If applicable record manual test results in PR header
- [ ] **MINOR** - when you add functionality in a backwards compatible manner. If applicable record manual test results in PR header
- [x] **PATCH** - when you make backwards compatible bug fixes or documentation/instructions
