### PR TITLE
feat(vcfanno_config): renaming config

### DIFF
--- a/definitions/download_rd_dna_parameters.yaml
+++ b/definitions/download_rd_dna_parameters.yaml
@@ -126,13 +126,6 @@ expansionhunter:
   data_type: SCALAR
   default: 1
   type: recipe
-vta_vcfanno_config:
-  analysis_mode: case
-  associated_recipe:
-    - mip
-  data_type: SCALAR
-  default: 1
-  type: recipe
 genbank_haplogroup:
   analysis_mode: case
   associated_recipe:
@@ -232,7 +225,7 @@ recipe_core_number:
     dbsnp: 1
     delly_exclude: 1
     expansionhunter: 1
-    vta_vcfanno_config: 1
+    vcfanno_config: 1
     genbank_haplogroup: 1
     genomic_superdups: 1
     giab: 1
@@ -248,7 +241,7 @@ recipe_core_number:
     reduced_penetrance: 1
     scout_exons: 1
     svrank_model: 1
-    sv_vta_vcfanno_config: 1
+    sv_vcfanno_config: 1
     vcf2cytosure_blacklist_regions: 1
     vcfanno_functions: 1
   type: mip
@@ -282,7 +275,7 @@ recipe_time:
     dbsnp: 1
     delly_exclude: 1
     expansionhunter: 1
-    vta_vcfanno_config: 1
+    vcfanno_config: 1
     genbank_haplogroup: 1
     genomic_superdups: 1
     giab: 1
@@ -298,7 +291,7 @@ recipe_time:
     runstatus: 1
     scout_exons: 1
     svrank_model: 1
-    sv_vta_vcfanno_config: 1
+    sv_vcfanno_config: 1
     vcf2cytosure_blacklist_regions: 1
     vcfanno_functions: 1
   type: mip
@@ -335,7 +328,7 @@ svrank_model:
   data_type: SCALAR
   default: 1
   type: recipe
-sv_vta_vcfanno_config:
+sv_vcfanno_config:
   analysis_mode: case
   associated_recipe:
     - mip
@@ -343,6 +336,13 @@ sv_vta_vcfanno_config:
   default: 1
   type: recipe
 vcf2cytosure_blacklist_regions:
+  analysis_mode: case
+  associated_recipe:
+    - mip
+  data_type: SCALAR
+  default: 1
+  type: recipe
+vcfanno_config:
   analysis_mode: case
   associated_recipe:
     - mip

--- a/definitions/dragen_rd_dna_parameters.yaml
+++ b/definitions/dragen_rd_dna_parameters.yaml
@@ -25,8 +25,8 @@ decompose_normalize_references:
     - mip
   data_type: ARRAY
   default:
-    - vta_vcfanno_config
-    - sv_vta_vcfanno_config
+    - sv_vcfanno_config
+    - vcfanno_config
   type: mip
 gatk_logging_level:
   associated_recipe:
@@ -204,14 +204,6 @@ sv_fqa_annotations:
     - GNOMADAF
     - GNOMADAF_POPMAX
   type: recipe_argument
-sv_vta_vcfanno_config:
-  associated_recipe:
-    - sv_annotate
-  data_type: SCALAR
-  exists_check: file
-  is_reference: 1
-  reference: reference_dir
-  type: path
 sv_bcftools_view_filter:
   associated_recipe:
     - sv_annotate
@@ -234,6 +226,14 @@ sv_svdb_query_db_files:
   associated_recipe:
     - sv_annotate
   data_type: HASH
+  exists_check: file
+  is_reference: 1
+  reference: reference_dir
+  type: path
+sv_vcfanno_config:
+  associated_recipe:
+    - sv_annotate
+  data_type: SCALAR
   exists_check: file
   is_reference: 1
   reference: reference_dir
@@ -518,7 +518,7 @@ variant_annotation:
     - bcftools
     - vcfanno
   type: recipe
-vta_vcfanno_config:
+vcfanno_config:
   associated_recipe:
     - variant_annotation
   data_type: SCALAR

--- a/definitions/rd_dna_panel_parameters.yaml
+++ b/definitions/rd_dna_panel_parameters.yaml
@@ -26,12 +26,12 @@ decompose_normalize_references:
     - mip
   data_type: ARRAY
   default:
-    - vta_vcfanno_config
     - gatk_baserecalibration_known_sites
     - gatk_haplotypecaller_snp_known_set
-    - gatk_variantrecalibration_resource_indel
-    - gatk_varianteval_gold
     - gatk_varianteval_dbsnp
+    - gatk_varianteval_gold
+    - gatk_variantrecalibration_resource_indel
+    - vcfanno_config
   type: mip
 exome_target_bed:
   associated_recipe:
@@ -797,7 +797,7 @@ variant_annotation:
     - bcftools
     - vcfanno
   type: recipe
-vta_vcfanno_config:
+vcfanno_config:
   associated_recipe:
     - variant_annotation
   data_type: SCALAR

--- a/definitions/rd_dna_parameters.yaml
+++ b/definitions/rd_dna_parameters.yaml
@@ -27,13 +27,13 @@ decompose_normalize_references:
     - mip
   data_type: ARRAY
   default:
-    - vta_vcfanno_config
     - gatk_baserecalibration_known_sites
     - gatk_haplotypecaller_snp_known_set
-    - gatk_variantrecalibration_resource_indel
-    - gatk_varianteval_gold
     - gatk_varianteval_dbsnp
-    - sv_vta_vcfanno_config
+    - gatk_varianteval_gold
+    - gatk_variantrecalibration_resource_indel
+    - sv_vcfanno_config
+    - vcfanno_config
   type: mip
 exome_target_bed:
   associated_recipe:
@@ -802,14 +802,6 @@ sv_annotate:
     - bcftools
     - svdb
   type: recipe
-sv_vta_vcfanno_config:
-  associated_recipe:
-    - sv_annotate
-  data_type: SCALAR
-  exists_check: file
-  is_reference: 1
-  reference: reference_dir
-  type: path
 sv_fqa_annotations:
   associated_recipe:
     - sv_annotate
@@ -840,6 +832,14 @@ sv_svdb_query_db_files:
   associated_recipe:
     - sv_annotate
   data_type: HASH
+  exists_check: file
+  is_reference: 1
+  reference: reference_dir
+  type: path
+sv_vcfanno_config:
+  associated_recipe:
+    - sv_annotate
+  data_type: SCALAR
   exists_check: file
   is_reference: 1
   reference: reference_dir
@@ -1481,7 +1481,7 @@ variant_annotation:
     - bcftools
     - vcfanno
   type: recipe
-vta_vcfanno_config:
+vcfanno_config:
   associated_recipe:
     - variant_annotation
   data_type: SCALAR

--- a/definitions/rd_dna_vcf_rerun_parameters.yaml
+++ b/definitions/rd_dna_vcf_rerun_parameters.yaml
@@ -25,8 +25,8 @@ decompose_normalize_references:
     - mip
   data_type: ARRAY
   default:
-    - vta_vcfanno_config
-    - sv_vta_vcfanno_config
+    - sv_vcfanno_config
+    - vcfanno_config
   type: mip
 gatk_logging_level:
   associated_recipe:
@@ -162,14 +162,6 @@ sv_annotate:
     - bcftools
     - svdb
   type: recipe
-sv_vta_vcfanno_config:
-  associated_recipe:
-    - sv_annotate
-  data_type: SCALAR
-  exists_check: file
-  is_reference: 1
-  reference: reference_dir
-  type: path
 sv_fqa_annotations:
   associated_recipe:
     - sv_annotate
@@ -200,6 +192,14 @@ sv_svdb_query_db_files:
   associated_recipe:
     - sv_annotate
   data_type: HASH
+  exists_check: file
+  is_reference: 1
+  reference: reference_dir
+  type: path
+sv_vcfanno_config:
+  associated_recipe:
+    - sv_annotate
+  data_type: SCALAR
   exists_check: file
   is_reference: 1
   reference: reference_dir
@@ -502,7 +502,7 @@ variant_annotation:
     - bcftools
     - vcfanno
   type: recipe
-vta_vcfanno_config:
+vcfanno_config:
   associated_recipe:
     - variant_annotation
   data_type: SCALAR

--- a/lib/MIP/Check/Reference.pm
+++ b/lib/MIP/Check/Reference.pm
@@ -24,7 +24,7 @@ BEGIN {
     use base qw{ Exporter };
 
     # Set the version for version checking
-    our $VERSION = 1.16;
+    our $VERSION = 1.17;
 
     # Functions and variables which can be optionally exported
     our @EXPORT_OK = qw{
@@ -206,8 +206,8 @@ sub check_references_for_vt {
 
     ## TOML parameters
     my %toml = (
-        vta_vcfanno_config    => 1,
-        sv_vta_vcfanno_config => 1,
+        sv_vcfanno_config => 1,
+        vcfanno_config    => 1,
     );
 
   PARAMETER_NAME:

--- a/lib/MIP/Cli/Mip/Analyse/Dragen_rd_dna.pm
+++ b/lib/MIP/Cli/Mip/Analyse/Dragen_rd_dna.pm
@@ -17,7 +17,7 @@ use Moose::Util::TypeConstraints;
 ## MIPs lib
 use MIP::Main::Analyse qw{ mip_analyse };
 
-our $VERSION = 1.15;
+our $VERSION = 1.16;
 
 extends(qw{ MIP::Cli::Mip::Analyse });
 
@@ -257,7 +257,7 @@ q{gatk_baserecalibration_known_sites, gatk_haplotypecaller_snp_known_set, gatk_v
     );
 
     option(
-        q{sv_vta_vcfanno_config} => (
+        q{sv_vcfanno_config} => (
             cmd_aliases   => [qw{ svfqav }],
             documentation => q{Frequency vcfanno toml config},
             is            => q{rw},
@@ -586,7 +586,7 @@ q{Prepare for variant annotation block by copying and splitting files per contig
     );
 
     option(
-        q{vta_vcfanno_config} => (
+        q{vcfanno_config} => (
             cmd_aliases   => [qw{ vtacvac }],
             documentation => q{Frequency vcfanno toml config},
             is            => q{rw},

--- a/lib/MIP/Cli/Mip/Analyse/Dragen_rd_dna.pm
+++ b/lib/MIP/Cli/Mip/Analyse/Dragen_rd_dna.pm
@@ -258,8 +258,8 @@ q{gatk_baserecalibration_known_sites, gatk_haplotypecaller_snp_known_set, gatk_v
 
     option(
         q{sv_vcfanno_config} => (
-            cmd_aliases   => [qw{ svfqav }],
-            documentation => q{Frequency vcfanno toml config},
+            cmd_aliases   => [qw{ svvac }],
+            documentation => q{Structural variant vcfanno toml config},
             is            => q{rw},
             isa           => Str,
         )
@@ -587,8 +587,8 @@ q{Prepare for variant annotation block by copying and splitting files per contig
 
     option(
         q{vcfanno_config} => (
-            cmd_aliases   => [qw{ vtacvac }],
-            documentation => q{Frequency vcfanno toml config},
+            cmd_aliases   => [qw{ vac }],
+            documentation => q{SNV/Indel vcfanno toml config},
             is            => q{rw},
             isa           => Str,
         )

--- a/lib/MIP/Cli/Mip/Analyse/Rd_dna.pm
+++ b/lib/MIP/Cli/Mip/Analyse/Rd_dna.pm
@@ -168,8 +168,8 @@ q{gatk_baserecalibration_known_sites, gatk_haplotypecaller_snp_known_set, gatk_v
 
     option(
         q{vcfanno_config} => (
-            cmd_aliases   => [qw{ vtavac }],
-            documentation => q{Frequency vcfanno toml config},
+            cmd_aliases   => [qw{ vac }],
+            documentation => q{SNV/Indel vcfanno toml config},
             is            => q{rw},
             isa           => Str,
         )
@@ -801,8 +801,8 @@ q{Default: grch37_dbsnp_-138-.vcf, grch37_1000g_indels_-phase1-.vcf, grch37_mill
 
     option(
         q{sv_vcfanno_config} => (
-            cmd_aliases   => [qw{ svfqav }],
-            documentation => q{Frequency vcfanno toml config},
+            cmd_aliases   => [qw{ svvac }],
+            documentation => q{Structural variants vcfanno toml config},
             is            => q{rw},
             isa           => Str,
         )

--- a/lib/MIP/Cli/Mip/Analyse/Rd_dna.pm
+++ b/lib/MIP/Cli/Mip/Analyse/Rd_dna.pm
@@ -17,7 +17,7 @@ use Moose::Util::TypeConstraints;
 ## MIPs lib
 use MIP::Main::Analyse qw{ mip_analyse };
 
-our $VERSION = 1.53;
+our $VERSION = 1.54;
 
 extends(qw{ MIP::Cli::Mip::Analyse });
 
@@ -167,7 +167,7 @@ q{gatk_baserecalibration_known_sites, gatk_haplotypecaller_snp_known_set, gatk_v
     );
 
     option(
-        q{vta_vcfanno_config} => (
+        q{vcfanno_config} => (
             cmd_aliases   => [qw{ vtavac }],
             documentation => q{Frequency vcfanno toml config},
             is            => q{rw},
@@ -800,7 +800,7 @@ q{Default: grch37_dbsnp_-138-.vcf, grch37_1000g_indels_-phase1-.vcf, grch37_mill
     );
 
     option(
-        q{sv_vta_vcfanno_config} => (
+        q{sv_vcfanno_config} => (
             cmd_aliases   => [qw{ svfqav }],
             documentation => q{Frequency vcfanno toml config},
             is            => q{rw},

--- a/lib/MIP/Cli/Mip/Analyse/Rd_dna_panel.pm
+++ b/lib/MIP/Cli/Mip/Analyse/Rd_dna_panel.pm
@@ -170,8 +170,8 @@ q{gatk_baserecalibration_known_sites, gatk_haplotypecaller_snp_known_set, gatk_v
 
     option(
         q{vcfanno_config} => (
-            cmd_aliases   => [qw{ vtavac }],
-            documentation => q{Variant vcfanno toml config},
+            cmd_aliases   => [qw{ vac }],
+            documentation => q{SNV/Indel vcfanno toml config},
             is            => q{rw},
             isa           => Str,
         )

--- a/lib/MIP/Cli/Mip/Analyse/Rd_dna_panel.pm
+++ b/lib/MIP/Cli/Mip/Analyse/Rd_dna_panel.pm
@@ -17,7 +17,7 @@ use Moose::Util::TypeConstraints;
 ## MIPs lib
 use MIP::Main::Analyse qw{ mip_analyse };
 
-our $VERSION = 1.06;
+our $VERSION = 1.07;
 
 extends(qw{ MIP::Cli::Mip::Analyse });
 
@@ -169,7 +169,7 @@ q{gatk_baserecalibration_known_sites, gatk_haplotypecaller_snp_known_set, gatk_v
     );
 
     option(
-        q{vta_vcfanno_config} => (
+        q{vcfanno_config} => (
             cmd_aliases   => [qw{ vtavac }],
             documentation => q{Variant vcfanno toml config},
             is            => q{rw},

--- a/lib/MIP/Cli/Mip/Analyse/Rd_dna_vcf_rerun.pm
+++ b/lib/MIP/Cli/Mip/Analyse/Rd_dna_vcf_rerun.pm
@@ -17,7 +17,7 @@ use Moose::Util::TypeConstraints;
 ## MIPs lib
 use MIP::Main::Analyse qw{ mip_analyse };
 
-our $VERSION = 1.29;
+our $VERSION = 1.30;
 
 extends(qw{ MIP::Cli::Mip::Analyse });
 
@@ -209,7 +209,7 @@ q{gatk_baserecalibration_known_sites, gatk_haplotypecaller_snp_known_set, gatk_v
     );
 
     option(
-        q{sv_vta_vcfanno_config} => (
+        q{sv_vcfanno_config} => (
             cmd_aliases   => [qw{ svfqav }],
             documentation => q{Frequency vcfanno toml config},
             is            => q{rw},
@@ -569,7 +569,7 @@ q{Prepare for variant annotation block by copying and splitting files per contig
     );
 
     option(
-        q{vta_vcfanno_config} => (
+        q{vcfanno_config} => (
             cmd_aliases   => [qw{ vtavac }],
             documentation => q{Frequency vcfanno toml config},
             is            => q{rw},

--- a/lib/MIP/Cli/Mip/Analyse/Rd_dna_vcf_rerun.pm
+++ b/lib/MIP/Cli/Mip/Analyse/Rd_dna_vcf_rerun.pm
@@ -210,8 +210,8 @@ q{gatk_baserecalibration_known_sites, gatk_haplotypecaller_snp_known_set, gatk_v
 
     option(
         q{sv_vcfanno_config} => (
-            cmd_aliases   => [qw{ svfqav }],
-            documentation => q{Frequency vcfanno toml config},
+            cmd_aliases   => [qw{ svvac }],
+            documentation => q{Structural variants vcfanno toml config},
             is            => q{rw},
             isa           => Str,
         )
@@ -570,8 +570,8 @@ q{Prepare for variant annotation block by copying and splitting files per contig
 
     option(
         q{vcfanno_config} => (
-            cmd_aliases   => [qw{ vtavac }],
-            documentation => q{Frequency vcfanno toml config},
+            cmd_aliases   => [qw{ vac }],
+            documentation => q{SNV/Indel vcfanno toml config},
             is            => q{rw},
             isa           => Str,
         )

--- a/lib/MIP/Recipes/Analysis/Frequency_filter.pm
+++ b/lib/MIP/Recipes/Analysis/Frequency_filter.pm
@@ -27,7 +27,7 @@ BEGIN {
     use base qw{ Exporter };
 
     # Set the version for version checking
-    our $VERSION = 1.14;
+    our $VERSION = 1.15;
 
     # Functions and variables which can be optionally exported
     our @EXPORT_OK = qw{ analysis_frequency_filter analysis_frequency_filter_panel };
@@ -264,7 +264,7 @@ sub analysis_frequency_filter {
                 fqf_annotations_ref => $active_parameter_href->{fqf_annotations},
                 fqf_bcftools_filter_threshold =>
                   $active_parameter_href->{fqf_bcftools_filter_threshold},
-                vcfanno_file_toml => $active_parameter_href->{vta_vcfanno_config},
+                vcfanno_file_toml => $active_parameter_href->{vcfanno_config},
             }
         );
 
@@ -510,7 +510,7 @@ sub analysis_frequency_filter_panel {
             fqf_annotations_ref => $active_parameter_href->{fqf_annotations},
             fqf_bcftools_filter_threshold =>
               $active_parameter_href->{fqf_bcftools_filter_threshold},
-            vcfanno_file_toml => $active_parameter_href->{vta_vcfanno_config},
+            vcfanno_file_toml => $active_parameter_href->{vcfanno_config},
         }
     );
 

--- a/lib/MIP/Recipes/Analysis/Sv_annotate.pm
+++ b/lib/MIP/Recipes/Analysis/Sv_annotate.pm
@@ -27,7 +27,7 @@ BEGIN {
     use base qw{ Exporter };
 
     # Set the version for version checking
-    our $VERSION = 1.23;
+    our $VERSION = 1.24;
 
     # Functions and variables which can be optionally exported
     our @EXPORT_OK = qw{ analysis_sv_annotate };
@@ -389,9 +389,9 @@ sub analysis_sv_annotate {
             {
                 filehandle   => $filehandle,
                 infile_path  => $outfile_path_prefix . $alt_file_tag . $outfile_suffix,
-                luafile_path => $active_parameter_href->{sv_fqa_vcfanno_functions},
+                luafile_path => $active_parameter_href->{vcfanno_functions},
                 stderrfile_path_append => $stderrfile_path,
-                toml_configfile_path   => $active_parameter_href->{sv_vta_vcfanno_config},
+                toml_configfile_path   => $active_parameter_href->{sv_vcfanno_config},
             }
         );
         print {$filehandle} $PIPE . $SPACE;
@@ -402,22 +402,22 @@ sub analysis_sv_annotate {
         my %vcfanno_config = read_from_file(
             {
                 format => q{toml},
-                path   => $active_parameter_href->{sv_vta_vcfanno_config},
+                path   => $active_parameter_href->{sv_vcfanno_config},
             }
         );
 
-        ## Store vcf anno annotations
-        my @vcf_anno_annotations;
+        ## Store vcfanno annotations
+        my @vcfanno_annotations;
 
       ANNOTATION:
         foreach my $annotation_href ( @{ $vcfanno_config{annotation} } ) {
 
-            push @vcf_anno_annotations, @{ $annotation_href->{names} };
+            push @vcfanno_annotations, @{ $annotation_href->{names} };
         }
         ## Build the exclude filter command
         my $exclude_filter = _build_bcftools_filter(
             {
-                annotations_ref => \@vcf_anno_annotations,
+                annotations_ref => \@vcfanno_annotations,
                 fqf_bcftools_filter_threshold =>
                   $active_parameter_href->{fqf_bcftools_filter_threshold},
             }

--- a/lib/MIP/Recipes/Analysis/Variant_annotation.pm
+++ b/lib/MIP/Recipes/Analysis/Variant_annotation.pm
@@ -26,7 +26,7 @@ BEGIN {
     use base qw{ Exporter };
 
     # Set the version for version checking
-    our $VERSION = 1.06;
+    our $VERSION = 1.07;
 
     # Functions and variables which can be optionally exported
     our @EXPORT_OK = qw{ analysis_variant_annotation analysis_variant_annotation_panel };
@@ -240,9 +240,9 @@ sub analysis_variant_annotation {
             {
                 filehandle           => $xargsfilehandle,
                 infile_path          => $infile_path{$contig},
-                luafile_path         => $active_parameter_href->{vta_vcfanno_functions},
+                luafile_path         => $active_parameter_href->{vcfanno_functions},
                 stderrfile_path      => $stderrfile_path,
-                toml_configfile_path => $active_parameter_href->{vta_vcfanno_config},
+                toml_configfile_path => $active_parameter_href->{vcfanno_config},
             }
         );
 
@@ -531,8 +531,8 @@ sub analysis_variant_annotation_panel {
         {
             filehandle           => $filehandle,
             infile_path          => $infile_path,
-            luafile_path         => $active_parameter_href->{vta_vcfanno_functions},
-            toml_configfile_path => $active_parameter_href->{vta_vcfanno_config},
+            luafile_path         => $active_parameter_href->{vcfanno_functions},
+            toml_configfile_path => $active_parameter_href->{vcfanno_config},
         }
     );
     print {$filehandle} $PIPE . $SPACE;

--- a/lib/MIP/Recipes/Download/Sv_vcfanno_config.pm
+++ b/lib/MIP/Recipes/Download/Sv_vcfanno_config.pm
@@ -1,4 +1,4 @@
-package MIP::Recipes::Download::Sv_vta_vcfanno_config;
+package MIP::Recipes::Download::Sv_vcfanno_config;
 
 use 5.026;
 use Carp;
@@ -26,14 +26,14 @@ BEGIN {
     use base qw{ Exporter };
 
     # Set the version for version checking
-    our $VERSION = 1.00;
+    our $VERSION = 1.01;
 
     # Functions and variables which can be optionally exported
-    our @EXPORT_OK = qw{ download_sv_vta_vcfanno_config };
+    our @EXPORT_OK = qw{ download_sv_vcfanno_config };
 
 }
 
-sub download_sv_vta_vcfanno_config {
+sub download_sv_vcfanno_config {
 
 ## Function : Download SV frequency vcfanno config
 ## Returns  :

--- a/lib/MIP/Recipes/Download/Vcfanno_config.pm
+++ b/lib/MIP/Recipes/Download/Vcfanno_config.pm
@@ -1,4 +1,4 @@
-package MIP::Recipes::Download::Vta_vcfanno_config;
+package MIP::Recipes::Download::Vcfanno_config;
 
 use 5.026;
 use Carp;
@@ -27,16 +27,16 @@ BEGIN {
     use base qw{ Exporter };
 
     # Set the version for version checking
-    our $VERSION = 1.00;
+    our $VERSION = 1.01;
 
     # Functions and variables which can be optionally exported
-    our @EXPORT_OK = qw{ download_vta_vcfanno_config };
+    our @EXPORT_OK = qw{ download_vcfanno_config };
 
 }
 
-sub download_vta_vcfanno_config {
+sub download_vcfanno_config {
 
-## Function : Download vta_vcfanno_config
+## Function : Download vcfanno_config
 ## Returns  :
 ## Arguments: $active_parameter_href => Active parameters for this download hash {REF}
 ##          : $genome_version        => Human genome version

--- a/lib/MIP/Recipes/Pipeline/Download_rd_dna.pm
+++ b/lib/MIP/Recipes/Pipeline/Download_rd_dna.pm
@@ -25,7 +25,7 @@ BEGIN {
     use base qw{ Exporter };
 
     # Set the version for version checking
-    our $VERSION = 1.19;
+    our $VERSION = 1.20;
 
     # Functions and variables which can be optionally exported
     our @EXPORT_OK = qw{ pipeline_download_rd_dna };
@@ -117,12 +117,11 @@ sub pipeline_download_rd_dna {
     use MIP::Recipes::Download::Runstatus qw{ download_runstatus };
     use MIP::Recipes::Download::Scout_exons qw{ download_scout_exons };
     use MIP::Recipes::Download::Svrank_model qw{ download_svrank_model };
-    use MIP::Recipes::Download::Sv_vta_vcfanno_config
-      qw{ download_sv_vta_vcfanno_config };
+    use MIP::Recipes::Download::Sv_vcfanno_config qw{ download_sv_vcfanno_config };
     use MIP::Recipes::Download::Vcf2cytosure_blacklist_regions
       qw{ download_vcf2cytosure_blacklist_regions };
+    use MIP::Recipes::Download::Vcfanno_config qw{ download_vcfanno_config };
     use MIP::Recipes::Download::Vcfanno_functions qw{ download_vcfanno_functions };
-    use MIP::Recipes::Download::Vta_vcfanno_config qw{ download_vta_vcfanno_config };
 
     ## Retrieve logger object now that log_file has been set
     my $log = Log::Log4perl->get_logger( uc q{mip_download} );
@@ -163,10 +162,10 @@ sub pipeline_download_rd_dna {
         reduced_penetrance             => \&download_reduced_penetrance,
         scout_exons                    => \&download_scout_exons,
         svrank_model                   => \&download_svrank_model,
-        sv_vta_vcfanno_config          => \&download_sv_vta_vcfanno_config,
+        sv_vcfanno_config              => \&download_sv_vcfanno_config,
         vcf2cytosure_blacklist_regions => \&download_vcf2cytosure_blacklist_regions,
+        vcfanno_config                 => \&download_vcfanno_config,
         vcfanno_functions              => \&download_vcfanno_functions,
-        vta_vcfanno_config             => \&download_vta_vcfanno_config,
     );
 
     # Storing job_ids from SLURM, however currently all are independent

--- a/lib/MIP/Vcfanno.pm
+++ b/lib/MIP/Vcfanno.pm
@@ -22,7 +22,7 @@ BEGIN {
     use base qw{ Exporter };
 
     # Set the version for version checking
-    our $VERSION = 1.03;
+    our $VERSION = 1.04;
 
     # Functions and variables which can be optionally exported
     our @EXPORT_OK = qw{ check_vcfanno_toml parse_toml_config_parameters };
@@ -169,8 +169,8 @@ sub parse_toml_config_parameters {
 
     ## Check that the supplied vcfanno toml config has mandatory keys and file exists for annotation array
     my %toml_config_parameter = (
-        variant_annotation => [qw{ vta_vcfanno_config vta_vcfanno_functions }],
-        sv_annotate        => [qw{ sv_vta_vcfanno_config sv_vta_vcfanno_functions }],
+        variant_annotation => [qw{ vcfanno_config vcfanno_functions }],
+        sv_annotate        => [qw{ sv_vcfanno_config sv_vcfanno_functions }],
     );
 
   RECIPE:

--- a/mip-test-suite
+++ b/mip-test-suite
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 
 ## Unit and integration
-prove t -r -j 8
+prove t -r -j 2
 
 ## Install
 perl t/mip_install.test

--- a/t/analysis_frequency_annotation.t
+++ b/t/analysis_frequency_annotation.t
@@ -25,7 +25,7 @@ use MIP::Constants qw{ $COLON $COMMA $SPACE };
 use MIP::Test::Fixtures qw{ test_log test_mip_hashes test_standard_cli };
 
 my $VERBOSE = 1;
-our $VERSION = 1.01;
+our $VERSION = 1.02;
 
 $VERBOSE = test_standard_cli(
     {
@@ -76,7 +76,7 @@ $active_parameter{$recipe_name}                     = 1;
 $active_parameter{recipe_core_number}{$recipe_name} = 1;
 $active_parameter{recipe_time}{$recipe_name}        = 1;
 my $case_id = $active_parameter{case_id};
-$active_parameter{vta_vcfanno_config} = catfile( $Bin,
+$active_parameter{vcfanno_config} = catfile( $Bin,
     qw{ data references grch37_frequency_vcfanno_annotation_config_-v1.0-.toml } );
 
 my %file_info = test_mip_hashes(

--- a/t/analysis_frequency_annotation_panel.t
+++ b/t/analysis_frequency_annotation_panel.t
@@ -25,7 +25,7 @@ use MIP::Constants qw{ $COLON $COMMA $SPACE };
 use MIP::Test::Fixtures qw{ test_log test_mip_hashes test_standard_cli };
 
 my $VERBOSE = 1;
-our $VERSION = 1.01;
+our $VERSION = 1.02;
 
 $VERBOSE = test_standard_cli(
     {
@@ -76,7 +76,7 @@ $active_parameter{$recipe_name}                     = 1;
 $active_parameter{recipe_core_number}{$recipe_name} = 1;
 $active_parameter{recipe_time}{$recipe_name}        = 1;
 my $case_id = $active_parameter{case_id};
-$active_parameter{vta_vcfanno_config} = catfile( $Bin,
+$active_parameter{vcfanno_config} = catfile( $Bin,
     qw{ data references grch37_frequency_vcfanno_annotation_config_-v1.0-.toml } );
 
 my %file_info = test_mip_hashes(

--- a/t/analysis_frequency_filter.t
+++ b/t/analysis_frequency_filter.t
@@ -25,7 +25,7 @@ use MIP::Constants qw{ $COLON $COMMA $SPACE };
 use MIP::Test::Fixtures qw{ test_log test_mip_hashes test_standard_cli };
 
 my $VERBOSE = 1;
-our $VERSION = 1.04;
+our $VERSION = 1.05;
 
 $VERBOSE = test_standard_cli(
     {
@@ -75,7 +75,7 @@ $active_parameter{$recipe_name}                     = 1;
 $active_parameter{recipe_core_number}{$recipe_name} = 1;
 $active_parameter{recipe_time}{$recipe_name}        = 1;
 my $case_id = $active_parameter{case_id};
-$active_parameter{vta_vcfanno_config} = catfile( $Bin,
+$active_parameter{vcfanno_config} = catfile( $Bin,
     qw{ data references grch37_frequency_vcfanno_filter_config_-v1.0-.toml } );
 $active_parameter{fqf_annotations}               = [qw{ GNOMADAF }];
 $active_parameter{fqf_bcftools_filter_threshold} = 1;

--- a/t/analysis_frequency_filter_panel.t
+++ b/t/analysis_frequency_filter_panel.t
@@ -25,7 +25,7 @@ use MIP::Constants qw{ $COLON $COMMA $SPACE };
 use MIP::Test::Fixtures qw{ test_log test_mip_hashes test_standard_cli };
 
 my $VERBOSE = 1;
-our $VERSION = 1.01;
+our $VERSION = 1.02;
 
 $VERBOSE = test_standard_cli(
     {
@@ -76,7 +76,7 @@ $active_parameter{$recipe_name}                     = 1;
 $active_parameter{recipe_core_number}{$recipe_name} = 1;
 $active_parameter{recipe_time}{$recipe_name}        = 1;
 my $case_id = $active_parameter{case_id};
-$active_parameter{vta_vcfanno_config} = catfile( $Bin,
+$active_parameter{vcfanno_config} = catfile( $Bin,
     qw{ data references grch37_frequency_vcfanno_filter_config_-v1.0-.toml } );
 $active_parameter{fqf_annotations}               = [qw{ GNOMADAF }];
 $active_parameter{fqf_bcftools_filter_threshold} = 1;

--- a/t/analysis_sv_annotate.t
+++ b/t/analysis_sv_annotate.t
@@ -25,7 +25,7 @@ use MIP::Constants qw{ $COLON $COMMA $SPACE };
 use MIP::Test::Fixtures qw{ test_log test_mip_hashes test_standard_cli };
 
 my $VERBOSE = 1;
-our $VERSION = 1.05;
+our $VERSION = 1.06;
 
 $VERBOSE = test_standard_cli(
     {
@@ -80,7 +80,7 @@ $active_parameter{recipe_time}{$recipe_name}        = 1;
 my $case_id = $active_parameter{case_id};
 $active_parameter{sv_frequency_filter}           = 1;
 $active_parameter{fqf_bcftools_filter_threshold} = $FREQ_CUTOFF;
-$active_parameter{sv_vta_vcfanno_config}         = catfile( $Bin,
+$active_parameter{sv_vcfanno_config}             = catfile( $Bin,
     qw{ data references grch37_frequency_vcfanno_filter_config_-v1.0-.toml } );
 $active_parameter{sv_svdb_query} = 1;
 $active_parameter{sv_svdb_query_db_files} =

--- a/t/check_references_for_vt.t
+++ b/t/check_references_for_vt.t
@@ -24,7 +24,7 @@ use MIP::Constants qw{ $COLON $COMMA $SPACE };
 use MIP::Test::Fixtures qw{ test_log test_standard_cli };
 
 my $VERBOSE = 1;
-our $VERSION = 1.08;
+our $VERSION = 1.09;
 
 $VERBOSE = test_standard_cli(
     {
@@ -62,11 +62,7 @@ diag(   q{Test check_references_for_vt from Reference.pm v}
 my $log = test_log( { log_name => q{MIP}, no_screen => 1, } );
 
 my %active_parameter_test = (
-    binary_path => {bcftools => q{bcftools},},
-    vta_vcfanno_config => catfile(
-        $Bin, qw{ data references grch37_frequency_vcfanno_filter_config_-v1.0-.toml }
-    ),
-    variant_annotation                 => 1,
+    binary_path                        => { bcftools => q{bcftools}, },
     gatk_baserecalibration             => 1,
     gatk_baserecalibration_known_sites => [
         catfile( $Bin, qw{ data references grch37_dbsnp_-138-.vcf } ),
@@ -86,13 +82,13 @@ my %active_parameter_test = (
         q{grch37_mills_and_1000g_-gold_standard_indels-.vcf} =>
           q{mills,known=false,training=true,truth=true,prior=12.0},
     },
+    variant_annotation => 1,
+    vcfanno_config     => catfile(
+        $Bin, qw{ data references grch37_frequency_vcfanno_filter_config_-v1.0-.toml }
+    ),
 );
 
 my %parameter_test = (
-    vta_vcfanno_config => {
-        associated_recipe => [qw{ variant_annotation }],
-        data_type         => q{SCALAR},
-    },
     gatk_baserecalibration_known_sites => {
         associated_recipe => [qw{ gatk_baserecalibration }],
         data_type         => q{ARRAY},
@@ -103,10 +99,14 @@ my %parameter_test = (
     },
     gatk_variantrecalibration_resource_indel =>
       { associated_recipe => [qw{ gatk_variantrecalibration }], data_type => q{HASH}, },
+    vcfanno_config => {
+        associated_recipe => [qw{ variant_annotation }],
+        data_type         => q{SCALAR},
+    },
 );
 
 my @vt_references_test =
-  qw{ vta_vcfanno_config gatk_baserecalibration_known_sites gatk_varianteval_dbsnp gatk_varianteval_dbsnp gatk_variantrecalibration_resource_indel };
+  qw{ gatk_baserecalibration_known_sites gatk_varianteval_dbsnp gatk_varianteval_dbsnp gatk_variantrecalibration_resource_indel vcfanno_config };
 
 my @refs_to_process = check_references_for_vt(
     {

--- a/t/check_vcfanno_toml.t
+++ b/t/check_vcfanno_toml.t
@@ -26,7 +26,7 @@ use MIP::Constants qw{ $COMMA $SPACE };
 use MIP::Test::Fixtures qw{ test_log test_standard_cli };
 
 my $VERBOSE = 1;
-our $VERSION = 1.06;
+our $VERSION = 1.07;
 
 $VERBOSE = test_standard_cli(
     {
@@ -51,9 +51,9 @@ BEGIN {
     test_import( { perl_module_href => \%perl_module, } );
 }
 
-use MIP::Vcfanno qw{ check_vcfanno_toml };
 use MIP::Environment::Child_process qw{ child_process };
 use MIP::Toml qw{ load_toml write_toml };
+use MIP::Vcfanno qw{ check_vcfanno_toml };
 
 diag(   q{Test check_vcfanno_toml from Vcfanno.pm v}
       . $MIP::Vcfanno::VERSION
@@ -71,17 +71,17 @@ my $log = test_log( {} );
 my $test_reference_dir = catfile( $Bin, qw{ data references } );
 
 ### Prepare temporary file for testing
-my $vta_vcfanno_config =
+my $vcfanno_config =
   catfile( $test_reference_dir,
     qw{ grch37_frequency_vcfanno_filter_config_-v1.0-.toml  } );
 
 # For the actual test
-my $test_vta_vcfanno_config = catfile( $test_reference_dir,
+my $test_vcfanno_config = catfile( $test_reference_dir,
     qw{ grch37_frequency_vcfanno_filter_config_test_check_vcfanno_-v1.0-.toml  } );
 
 my $toml_href = load_toml(
     {
-        path => $vta_vcfanno_config,
+        path => $vcfanno_config,
     }
 );
 
@@ -98,18 +98,18 @@ $toml_href->{annotation}[2]{file} =
 write_toml(
     {
         data_href => $toml_href,
-        path      => $test_vta_vcfanno_config,
+        path      => $test_vcfanno_config,
     }
 );
 
-my %active_parameter = ( vta_vcfanno_config => $test_vta_vcfanno_config, );
+my %active_parameter = ( vcfanno_config => $test_vcfanno_config, );
 
 ## Given a toml config file with a file path
 my $is_ok = check_vcfanno_toml(
     {
         active_parameter_href => \%active_parameter,
-        vcfanno_config_name => q{vta_vcfanno_config},
-        vcfanno_functions => q{vta_vcfanno_functions},
+        vcfanno_config_name   => q{vcfanno_config},
+        vcfanno_functions     => q{vcfanno_functions},
     }
 );
 
@@ -117,19 +117,19 @@ my $is_ok = check_vcfanno_toml(
 ok( $is_ok, q{Passed check for toml file} );
 
 ## Clean-up
-rmtree($test_vta_vcfanno_config);
+rmtree($test_vcfanno_config);
 
 ## Given a toml config file, when mandatory features are absent
-my $faulty_vta_vcfanno_config_file = catfile( $Bin,
+my $faulty_vcfanno_config_file = catfile( $Bin,
     qw{ data references grch37_frequency_vcfanno_filter_config_bad_data_-v1.0-.toml } );
 
-$active_parameter{vta_vcfanno_config} = $faulty_vta_vcfanno_config_file;
+$active_parameter{vcfanno_config} = $faulty_vcfanno_config_file;
 trap {
     check_vcfanno_toml(
         {
             active_parameter_href => \%active_parameter,
-            vcfanno_config_name => q{vta_vcfanno_config},
-            vcfanno_functions => q{vta_vcfanno_functions},
+            vcfanno_config_name   => q{vcfanno_config},
+            vcfanno_functions     => q{vcfanno_functions},
         }
     )
 };

--- a/t/data/test_data/download_active_parameters.yaml
+++ b/t/data/test_data/download_active_parameters.yaml
@@ -113,14 +113,14 @@ reference:
     - 201701
   svrank_model:
     - v1.8
-  sv_vta_vcfanno_config:
+  sv_vcfanno_config:
     - v1.2
   vcf2cytosure_blacklist_regions:
     - 1.0
+  vcfanno_config:
+    - v1.2
   vcfanno_functions:
     - v1.0
-  vta_vcfanno_config:
-    - v1.2
 reference_feature:
   1000g_all_sv:
     grch37:
@@ -709,7 +709,7 @@ reference_feature:
         outfile_check: svrank_model_cmms_-v1.8-.ini.md5
         outfile_check_method: md5sum
         url_prefix: https://raw.githubusercontent.com/Clinical-Genomics/reference-files/master/rare-disease/rank_model/
-  sv_vta_vcfanno_config:
+  sv_vcfanno_config:
     grch37:
       v1.2:
         file: grch37_frequency_vcfanno_filter_config_-v1.2-.toml
@@ -727,6 +727,15 @@ reference_feature:
         outfile_check: grch37_cytosure_blacklist_-1.0-.bed.md5
         outfile_check_method: md5sum
         url_prefix: https://raw.githubusercontent.com/Clinical-Genomics/reference-files/master/rare-disease/region/
+  vcfanno_config:
+    grch37:
+      v1.2:
+        file: grch37_frequency_vcfanno_filter_config_-v1.2-.toml
+        file_check: grch37_frequency_vcfanno_filter_config_-v1.2-.toml.md5
+        outfile: grch37_frequency_vcfanno_filter_config_-v1.2-.toml
+        outfile_check: grch37_frequency_vcfanno_filter_config_-v1.2-.toml.md5
+        outfile_check_method: md5sum
+        url_prefix: https://raw.githubusercontent.com/Clinical-Genomics/reference-files/master/rare-disease/annotation/
   vcfanno_functions:
     grch37:
       v1.0:
@@ -734,15 +743,6 @@ reference_feature:
         file_check: vcfanno_functions_-v1.0-.lua.md5
         outfile: vcfanno_functions_-v1.0-.lua
         outfile_check: vcfanno_functions_-v1.0-.lua.md5
-        outfile_check_method: md5sum
-        url_prefix: https://raw.githubusercontent.com/Clinical-Genomics/reference-files/master/rare-disease/annotation/
-  vta_vcfanno_config:
-    grch37:
-      v1.2:
-        file: grch37_frequency_vcfanno_filter_config_-v1.2-.toml
-        file_check: grch37_frequency_vcfanno_filter_config_-v1.2-.toml.md5
-        outfile: grch37_frequency_vcfanno_filter_config_-v1.2-.toml
-        outfile_check: grch37_frequency_vcfanno_filter_config_-v1.2-.toml.md5
         outfile_check_method: md5sum
         url_prefix: https://raw.githubusercontent.com/Clinical-Genomics/reference-files/master/rare-disease/annotation/
 reference_genome_versions:

--- a/t/download_sv_vcfanno_config.t
+++ b/t/download_sv_vcfanno_config.t
@@ -25,7 +25,7 @@ use MIP::Constants qw{ $COMMA $SPACE };
 use MIP::Test::Fixtures qw{ test_log test_mip_hashes test_standard_cli };
 
 my $VERBOSE = 1;
-our $VERSION = 1.02;
+our $VERSION = 1.03;
 
 $VERBOSE = test_standard_cli(
     {
@@ -41,18 +41,18 @@ BEGIN {
 ### Check all internal dependency modules and imports
 ## Modules with import
     my %perl_module = (
-        q{MIP::Recipes::Download::Sv_vta_vcfanno_config} =>
-          [qw{ download_sv_vta_vcfanno_config }],
+        q{MIP::Recipes::Download::Sv_vcfanno_config} =>
+          [qw{ download_sv_vcfanno_config }],
         q{MIP::Test::Fixtures} => [qw{ test_log test_mip_hashes test_standard_cli }],
     );
 
     test_import( { perl_module_href => \%perl_module, } );
 }
 
-use MIP::Recipes::Download::Sv_vta_vcfanno_config qw{ download_sv_vta_vcfanno_config };
+use MIP::Recipes::Download::Sv_vcfanno_config qw{ download_sv_vcfanno_config };
 
-diag(   q{Test download_sv_vta_vcfanno_config from Sv_vta_vcfanno_config.pm v}
-      . $MIP::Recipes::Download::Sv_vta_vcfanno_config::VERSION
+diag(   q{Test download_sv_vcfanno_config from Sv_vcfanno_config.pm v}
+      . $MIP::Recipes::Download::Sv_vcfanno_config::VERSION
       . $COMMA
       . $SPACE . q{Perl}
       . $SPACE
@@ -66,7 +66,7 @@ my $log       = test_log( { log_name => uc q{mip_download}, no_screen => 1, } );
 
 ## Given download parameters for recipe
 my $genome_version    = q{grch37};
-my $recipe_name       = q{sv_vta_vcfanno_config};
+my $recipe_name       = q{sv_vcfanno_config};
 my $reference_version = q{v1.2};
 my $slurm_mock_cmd    = catfile( $Bin, qw{ data modules slurm-mock.pl } );
 
@@ -85,7 +85,7 @@ my $reference_href =
 
 my %job_id;
 
-my $is_ok = download_sv_vta_vcfanno_config(
+my $is_ok = download_sv_vcfanno_config(
     {
         active_parameter_href => \%active_parameter,
         genome_version        => $genome_version,

--- a/t/download_vcfanno_config.t
+++ b/t/download_vcfanno_config.t
@@ -25,7 +25,7 @@ use MIP::Constants qw{ $COMMA $SPACE };
 use MIP::Test::Fixtures qw{ test_log test_mip_hashes test_standard_cli };
 
 my $VERBOSE = 1;
-our $VERSION = 1.01;
+our $VERSION = 1.02;
 
 $VERBOSE = test_standard_cli(
     {
@@ -41,18 +41,17 @@ BEGIN {
 ### Check all internal dependency modules and imports
 ## Modules with import
     my %perl_module = (
-        q{MIP::Recipes::Download::Vta_vcfanno_config} =>
-          [qw{ download_vta_vcfanno_config }],
+        q{MIP::Recipes::Download::Vcfanno_config} => [qw{ download_vcfanno_config }],
         q{MIP::Test::Fixtures} => [qw{ test_log test_mip_hashes test_standard_cli }],
     );
 
     test_import( { perl_module_href => \%perl_module, } );
 }
 
-use MIP::Recipes::Download::Vta_vcfanno_config qw{ download_vta_vcfanno_config };
+use MIP::Recipes::Download::Vcfanno_config qw{ download_vcfanno_config };
 
-diag(   q{Test download_vta_vcfanno_config from Vta_vcfanno_config.pm v}
-      . $MIP::Recipes::Download::Vta_vcfanno_config::VERSION
+diag(   q{Test download_vcfanno_config from Vcfanno_config.pm v}
+      . $MIP::Recipes::Download::Vcfanno_config::VERSION
       . $COMMA
       . $SPACE . q{Perl}
       . $SPACE
@@ -66,7 +65,7 @@ my $log       = test_log( { log_name => uc q{mip_download}, no_screen => 1, } );
 
 ## Given download parameters for recipe
 my $genome_version    = q{grch37};
-my $recipe_name       = q{vta_vcfanno_config};
+my $recipe_name       = q{vcfanno_config};
 my $reference_version = q{v1.2};
 my $slurm_mock_cmd    = catfile( $Bin, qw{ data modules slurm-mock.pl } );
 
@@ -85,7 +84,7 @@ my $reference_href =
 
 my %job_id;
 
-my $is_ok = download_vta_vcfanno_config(
+my $is_ok = download_vcfanno_config(
     {
         active_parameter_href => \%active_parameter,
         genome_version        => $genome_version,

--- a/t/mip_analyse_dragen_rd_dna.test
+++ b/t/mip_analyse_dragen_rd_dna.test
@@ -31,7 +31,7 @@ use MIP::Test::Writefile qw{ write_toml_config };
 our $USAGE = build_usage( {} );
 
 my $VERBOSE = 1;
-our $VERSION = 1.04;
+our $VERSION = 1.05;
 
 ## Set paths
 my $conda_path            = catdir( dirname($Bin), qw{ t data modules miniconda} );
@@ -115,7 +115,7 @@ my $cmds_ref = [
         $cluster_constant_path, qw{ 643594-miptest test_data ADM1059A3 fastq=ADM1059A3 }
     ),
     qw{ --dra --vb },
-    q{--vta_vcfanno_config},
+    q{--vcfanno_config},
     $toml_config_path,
 ];
 

--- a/t/mip_analyse_rd_dna.test
+++ b/t/mip_analyse_rd_dna.test
@@ -31,7 +31,7 @@ use MIP::Test::Writefile qw{ write_toml_config };
 our $USAGE = build_usage( {} );
 
 my $VERBOSE = 1;
-our $VERSION = 1.12;
+our $VERSION = 1.13;
 
 ## Set paths
 my $conda_path            = catdir( dirname($Bin), qw{ t data modules miniconda} );
@@ -112,7 +112,7 @@ my $cmds_ref = [
         $cluster_constant_path, qw{ 643594-miptest test_data ADM1059A3 fastq=ADM1059A3 }
     ),
     qw{ --dra --svv 0 --vb },
-    q{--vta_vcfanno_config},
+    q{--vcfanno_config},
     $toml_config_path,
     q{--varg_ar},
     $DRY_RUN_MODE,

--- a/t/mip_analyse_rd_dna_panel.test
+++ b/t/mip_analyse_rd_dna_panel.test
@@ -31,7 +31,7 @@ use MIP::Test::Writefile qw{ write_toml_config };
 our $USAGE = build_usage( {} );
 
 my $VERBOSE = 1;
-our $VERSION = 1.01;
+our $VERSION = 1.02;
 
 ## Set paths
 my $conda_path            = catdir( dirname($Bin), qw{ t data modules miniconda} );
@@ -110,7 +110,7 @@ my $cmds_ref = [
         $cluster_constant_path, qw{ 643594-miptest test_data ADM1059A3 fastq=ADM1059A3 }
     ),
     qw{ --dra --vb },
-    q{--vta_vcfanno_config},
+    q{--vcfanno_config},
     $toml_config_path,
     q{--pedigree},
     catfile( $cluster_constant_path, qw{ 643594-miptest 643594-panel_pedigree.yaml } ),

--- a/t/mip_analyse_rd_dna_vcf_rerun.test
+++ b/t/mip_analyse_rd_dna_vcf_rerun.test
@@ -31,7 +31,7 @@ use MIP::Test::Writefile qw{ write_toml_config };
 our $USAGE = build_usage( {} );
 
 my $VERBOSE = 1;
-our $VERSION = 1.08;
+our $VERSION = 1.09;
 
 ## Set paths
 my $conda_path            = catdir( dirname($Bin), qw{ t data modules miniconda} );
@@ -113,7 +113,7 @@ my $cmds_ref = [
         qw{ test_data 643594-miptest_sorted_md_brecal_comb_SV.vcf.gz }
     ),
     qw{ --dra --vb },
-    q{--vta_vcfanno_config},
+    q{--vcfanno_config},
     $toml_config_path,
 ];
 

--- a/t/mip_analysis.test
+++ b/t/mip_analysis.test
@@ -53,7 +53,7 @@ BEGIN {
 my ( $config_file, $infile );
 my ( %active_parameter, %parameter, %pedigree, %vcfparser_data, );
 
-our $VERSION = 2.09;
+our $VERSION = 2.10;
 
 if ( scalar @ARGV == 0 ) {
 
@@ -296,7 +296,7 @@ sub test_modules {
     push @ARGV, qw{ -verbose 2 };
     my $verbose = 1;
     ok( GetOptions( q{verbose:n} => \$verbose ), q{Getopt::Long: Get options call} );
-    ok( $verbose == 2, q{Getopt::Long: Get options modified} );
+    ok( $verbose == 2,                           q{Getopt::Long: Get options modified} );
 
     return;
 }
@@ -441,7 +441,7 @@ sub read_infile_vcf {
                 {
                     fqf_annotations_ref => $active_parameter_href->{fqf_annotations},
                     recipe_mode         => $active_parameter_href->{frequency_filter},
-                    toml_file_path      => $active_parameter_href->{vta_vcfanno_config},
+                    toml_file_path      => $active_parameter_href->{vcfanno_config},
                     vcf_header_href     => \%vcf_header,
                 }
             );
@@ -709,8 +709,8 @@ sub read_sv_infile_vcf {
                 {
                     fqf_annotations_ref => $active_parameter_href->{sv_fqa_annotations},
                     recipe_mode         => $active_parameter_href->{sv_annotate},
-                    toml_file_path  => $active_parameter_href->{sv_vta_vcfanno_config},
-                    vcf_header_href => \%vcf_header,
+                    toml_file_path      => $active_parameter_href->{sv_vcfanno_config},
+                    vcf_header_href     => \%vcf_header,
                 }
             );
 

--- a/t/parse_toml_config_parameters.t
+++ b/t/parse_toml_config_parameters.t
@@ -26,7 +26,7 @@ use MIP::Constants qw{ $COMMA $SPACE };
 use MIP::Test::Fixtures qw{ test_log test_standard_cli };
 
 my $VERBOSE = 1;
-our $VERSION = 1.05;
+our $VERSION = 1.06;
 
 $VERBOSE = test_standard_cli(
     {
@@ -71,17 +71,17 @@ my $log = test_log( {} );
 my $test_reference_dir = catfile( $Bin, qw{ data references } );
 
 ### Prepare temporary file for testing
-my $vta_vcfanno_config =
+my $vcfanno_config =
   catfile( $test_reference_dir,
     qw{ grch37_frequency_vcfanno_filter_config_-v1.0-.toml  } );
 
 # For the actual test
-my $test_vta_vcfanno_config = catfile( $test_reference_dir,
+my $test_vcfanno_config = catfile( $test_reference_dir,
     qw{ grch37_frequency_vcfanno_filter_config_test_parse_toml_-v1.0-.toml  } );
 
 my $toml_href = load_toml(
     {
-        path => $vta_vcfanno_config,
+        path => $vcfanno_config,
     }
 );
 
@@ -96,14 +96,14 @@ $toml_href->{annotation}[2]{file} =
 write_toml(
     {
         data_href => $toml_href,
-        path      => $test_vta_vcfanno_config,
+        path      => $test_vcfanno_config,
     }
 );
 
 ## Given a toml config file
 my %active_parameter = (
-    frequency_filter   => 1,
-    vta_vcfanno_config => $test_vta_vcfanno_config,
+    frequency_filter => 1,
+    vcfanno_config   => $test_vcfanno_config,
 );
 
 my $is_ok = parse_toml_config_parameters(
@@ -116,6 +116,6 @@ my $is_ok = parse_toml_config_parameters(
 ok( $is_ok, q{Passed parsing for toml file} );
 
 ## Clean-up
-rmtree($test_vta_vcfanno_config);
+rmtree($test_vcfanno_config);
 
 done_testing();

--- a/t/set_default_to_active_parameter.t
+++ b/t/set_default_to_active_parameter.t
@@ -25,7 +25,7 @@ use MIP::Constants qw{ $COMMA $SPACE };
 use MIP::Test::Fixtures qw{ test_log test_standard_cli };
 
 my $VERBOSE = 1;
-our $VERSION = 1.11;
+our $VERSION = 1.12;
 
 $VERBOSE = test_standard_cli(
     {
@@ -114,13 +114,13 @@ is( $active_parameter{bcftools_mpileup_filter_variant},
     0, q{Set default for scalar parameter} );
 
 my @expected_decompose_normalize_references = qw{
-  vta_vcfanno_config
   gatk_baserecalibration_known_sites
   gatk_haplotypecaller_snp_known_set
-  gatk_variantrecalibration_resource_indel
-  gatk_varianteval_gold
   gatk_varianteval_dbsnp
-  sv_vta_vcfanno_config
+  gatk_varianteval_gold
+  gatk_variantrecalibration_resource_indel
+  sv_vcfanno_config
+  vcfanno_config
 };
 is_deeply(
     \@{ $active_parameter{decompose_normalize_references} },

--- a/templates/mip_download_rd_dna_config_-1.0-.yaml
+++ b/templates/mip_download_rd_dna_config_-1.0-.yaml
@@ -111,18 +111,18 @@ reference:
     - 2017
   scout_exons:
     - 201701
+  sv_vcfanno_config:
+    - v1.2
+    - v1.3
   svrank_model:
     - v1.8
-  sv_vta_vcfanno_config:
-    - v1.2
-  vcfanno_functions:
-    - v1.0
   vcf2cytosure_blacklist_regions:
     - 1.0
-  vta_vcfanno_config:
-    - v1.4
-    - v1.5
+  vcfanno_config:
     - v1.6
+    - v1.7
+  vcfanno_functions:
+    - v1.0
 reference_feature:
   human_reference:
     grch37:
@@ -805,13 +805,20 @@ reference_feature:
         outfile: grch37_scout_exons_-2017-01-.bed
         outfile_check: grch37_scout_exons_-2017-01-.bed.md5
         url_prefix: https://raw.githubusercontent.com/Clinical-Genomics/reference-files/master/rare-disease/gene_panel/
-  sv_vta_vcfanno_config:
+  sv_vcfanno_config:
     grch37:
       v1.2:
         file: grch37_sv_frequency_vcfanno_filter_config_-v1.2-.toml
         file_check: grch37_sv_frequency_vcfanno_filter_config_-v1.2-.toml.md5
         outfile: grch37_sv_frequency_vcfanno_filter_config_-v1.2-.toml
         outfile_check: grch37_sv_frequency_vcfanno_filter_config_-v1.2-.toml.md5
+        outfile_check_method: md5sum
+        url_prefix: https://raw.githubusercontent.com/Clinical-Genomics/reference-files/master/rare-disease/annotation/
+      v1.3:
+        file: grch37_sv_vcfanno_config_-v1.3-.toml
+        file_check: grch37_sv_vcfanno_config_-v1.3-.toml.md5
+        outfile: grch37_sv_vcfanno_config_-v1.3-.toml
+        outfile_check: grch37_sv_vcfanno_config_-v1.3-.toml.md5
         outfile_check_method: md5sum
         url_prefix: https://raw.githubusercontent.com/Clinical-Genomics/reference-files/master/rare-disease/annotation/
   svrank_model:
@@ -823,15 +830,6 @@ reference_feature:
         outfile_check: svrank_model_cmms_-v1.8-.ini.md5
         outfile_check_method: md5sum
         url_prefix: https://raw.githubusercontent.com/Clinical-Genomics/reference-files/master/rare-disease/rank_model/
-  vcfanno_functions:
-    grch37:
-      v1.0:
-        file: vcfanno_functions_-v1.0-.lua
-        file_check: vcfanno_functions_-v1.0-.lua.md5
-        outfile: vcfanno_functions_-v1.0-.lua
-        outfile_check: vcfanno_functions_-v1.0-.lua.md5
-        outfile_check_method: md5sum
-        url_prefix: https://raw.githubusercontent.com/Clinical-Genomics/reference-files/master/rare-disease/annotation/
   vcf2cytosure_blacklist_regions:
     grch37:
       1.0:
@@ -841,26 +839,28 @@ reference_feature:
         outfile_check: grch37_cytosure_blacklist_-1.0-.bed.md5
         outfile_check_method: md5sum
         url_prefix: https://raw.githubusercontent.com/Clinical-Genomics/reference-files/master/rare-disease/region/
-  vta_vcfanno_config:
+  vcfanno_config:
     grch37:
-      v1.4:
-        file: grch37_frequency_vcfanno_filter_config_-v1.4-.toml
-        file_check: grch37_frequency_vcfanno_filter_config_-v1.4-.toml.md5
-        outfile: grch37_frequency_vcfanno_filter_config_-v1.4-.toml
-        outfile_check: grch37_frequency_vcfanno_filter_config_-v1.4-.toml.md5
-        outfile_check_method: md5sum
-        url_prefix: https://raw.githubusercontent.com/Clinical-Genomics/reference-files/master/rare-disease/annotation/
-      v1.5:
-        file: grch37_frequency_vcfanno_filter_config_-v1.5-.toml
-        file_check: grch37_frequency_vcfanno_filter_config_-v1.5-.toml.md5
-        outfile: grch37_frequency_vcfanno_filter_config_-v1.5-.toml
-        outfile_check: grch37_frequency_vcfanno_filter_config_-v1.5-.toml.md5
-        outfile_check_method: md5sum
-        url_prefix: https://raw.githubusercontent.com/Clinical-Genomics/reference-files/master/rare-disease/annotation/
       v1.6:
         file: grch37_frequency_vcfanno_filter_config_-v1.6-.toml
         file_check: grch37_frequency_vcfanno_filter_config_-v1.6-.toml.md5
         outfile: grch37_frequency_vcfanno_filter_config_-v1.6-.toml
         outfile_check: grch37_frequency_vcfanno_filter_config_-v1.6-.toml.md5
+        outfile_check_method: md5sum
+        url_prefix: https://raw.githubusercontent.com/Clinical-Genomics/reference-files/master/rare-disease/annotation/
+      v1.7:
+        file: grch37_vcfanno_config_-v1.7-.toml
+        file_check: grch37_vcfanno_config_-v1.7-.toml.md5
+        outfile: grch37_vcfanno_config_-v1.7-.toml
+        outfile_check: grch37_vcfanno_config_-v1.7-.toml.md5
+        outfile_check_method: md5sum
+        url_prefix: https://raw.githubusercontent.com/Clinical-Genomics/reference-files/master/rare-disease/annotation/
+  vcfanno_functions:
+    grch37:
+      v1.0:
+        file: vcfanno_functions_-v1.0-.lua
+        file_check: vcfanno_functions_-v1.0-.lua.md5
+        outfile: vcfanno_functions_-v1.0-.lua
+        outfile_check: vcfanno_functions_-v1.0-.lua.md5
         outfile_check_method: md5sum
         url_prefix: https://raw.githubusercontent.com/Clinical-Genomics/reference-files/master/rare-disease/annotation/

--- a/templates/mip_dragen_rd_dna_config.yaml
+++ b/templates/mip_dragen_rd_dna_config.yaml
@@ -20,11 +20,9 @@ outdata_dir: cluster_constant_path!/case_id!/analysis_constant_path!
 outscript_dir: cluster_constant_path!/case_id!/analysis_constant_path!/scripts
 sample_info_file: cluster_constant_path!/case_id!/analysis_constant_path!/case_id!_qc_sample_info.yaml
 ## References
-vta_vcfanno_config: grch37_frequency_vcfanno_filter_config_-v1.6-.toml
 genmod_models_reduced_penetrance_file: grch37_cust003-cmms-red-pen_-2017-.tsv
 human_genome_reference: grch37_homo_sapiens_-d5-.fasta
 rank_model_file: rank_model_-v1.29-.ini
-sv_vta_vcfanno_config: grch37_frequency_vcfanno_filter_config_-v1.1-.toml
 sv_genmod_models_reduced_penetrance_file: grch37_cust003-cmms-red-pen_-2017-.tsv
 sv_rank_model_file: svrank_model_cmms_-v1.8-.ini
 sv_svdb_query_db_files:
@@ -36,6 +34,8 @@ sv_svdb_query_db_files:
   grch37_svdb_query_clingen_cgh_pathogenic_-v1.0.0-.vcf: clingen_cgh_pathogenic
   grch37_svdb_query_clingen_ngi_-v1.0.0-.vcf: clingen_ngi|AF|OCC|FRQ|OCC|1
   grch37_swegen_concat_sort_-20170830-.vcf: swegen|AF|OCC|FRQ|OCC|1
+sv_vcfanno_config: grch37_sv_vcfanno_config_-v1.3-.toml
+vcfanno_config: grch37_vcfanno_config_-v1.7-.toml
 ### Analysis
 ## Programs
 ## Parameters

--- a/templates/mip_rd_dna_config.yaml
+++ b/templates/mip_rd_dna_config.yaml
@@ -20,13 +20,12 @@ outdata_dir: cluster_constant_path!/case_id!/analysis_constant_path!
 outscript_dir: cluster_constant_path!/case_id!/analysis_constant_path!/scripts
 sample_info_file: cluster_constant_path!/case_id!/analysis_constant_path!/case_id!_qc_sample_info.yaml
 ## References
-vta_vcfanno_config: grch37_frequency_vcfanno_filter_config_-v1.6-.toml
 gatk_genotypegvcfs_ref_gvcf: grch37_gatk_merged_reference_samples.txt
 genmod_models_reduced_penetrance_file: grch37_cust003-cmms-red-pen_-2017-.tsv
 human_genome_reference: grch37_homo_sapiens_-d5-.fasta
 rank_model_file: rank_model_-v1.29-.ini
 sambamba_depth_bed: grch37_scout_exons_-2017-01-.bed
-sv_vta_vcfanno_config: grch37_sv_frequency_vcfanno_filter_config_-v1.2-.toml
+sv_vcfanno_config: grch37_sv_vcfanno_config_-v1.3-.toml
 sv_genmod_models_reduced_penetrance_file: grch37_cust003-cmms-red-pen_-2017-.tsv
 sv_rank_model_file: svrank_model_cmms_-v1.8-.ini
 sv_svdb_query_db_files:
@@ -42,6 +41,7 @@ sv_svdb_query_db_files:
 qccollect_eval_metric_file: qc_eval_metric_-v1.1-.yaml
 qccollect_regexp_file: qc_regexp_-v1.25-.yaml
 vcf2cytosure_blacklist: grch37_cytosure_blacklist_-1.0-.bed
+vcfanno_config: grch37_vcfanno_config_-v1.7-.toml
 ### Analysis
 ### Programs
 ## Parameters

--- a/templates/mip_rd_dna_panel_config.yaml
+++ b/templates/mip_rd_dna_panel_config.yaml
@@ -19,14 +19,14 @@ outdata_dir: cluster_constant_path!/case_id!/analysis_constant_path!
 outscript_dir: cluster_constant_path!/case_id!/analysis_constant_path!/scripts
 sample_info_file: cluster_constant_path!/case_id!/analysis_constant_path!/case_id!_qc_sample_info.yaml
 ## References
-vta_vcfanno_config: grch37_frequency_vcfanno_filter_config_-v1.6-.toml
 gatk_genotypegvcfs_ref_gvcf: grch37_gatk_merged_reference_samples.txt
 genmod_models_reduced_penetrance_file: grch37_cust003-cmms-red-pen_-2017-.tsv
 human_genome_reference: grch37_homo_sapiens_-d5-.fasta
-rank_model_file: rank_model_-v1.29-.ini
-sambamba_depth_bed: grch37_scout_exons_-2017-01-.bed
 qccollect_eval_metric_file: qc_eval_metric_-v1.1-.yaml
 qccollect_regexp_file: qc_regexp_-v1.25-.yaml
+rank_model_file: rank_model_-v1.29-.ini
+sambamba_depth_bed: grch37_scout_exons_-2017-01-.bed
+vcfanno_config: grch37_vcfanno_config_-v1.7-.toml
 ### Analysis
 ### Programs
 ## Parameters

--- a/templates/mip_rd_dna_vcf_rerun_config.yaml
+++ b/templates/mip_rd_dna_vcf_rerun_config.yaml
@@ -20,15 +20,13 @@ outdata_dir: cluster_constant_path!/case_id!/analysis_constant_path!
 outscript_dir: cluster_constant_path!/case_id!/analysis_constant_path!/scripts
 sample_info_file: cluster_constant_path!/case_id!/analysis_constant_path!/case_id!_qc_sample_info.yaml
 ## References
-vta_vcfanno_config: grch37_frequency_vcfanno_filter_config_-v1.6-.toml
 genmod_models_reduced_penetrance_file: grch37_cust003-cmms-red-pen_-2017-.tsv
 human_genome_reference: grch37_homo_sapiens_-d5-.fasta
 rank_model_file: rank_model_-v1.29-.ini
-sv_vta_vcfanno_config: grch37_sv_frequency_vcfanno_filter_config_-v1.2-.toml
 sv_genmod_models_reduced_penetrance_file: grch37_cust003-cmms-red-pen_-2017-.tsv
 sv_rank_model_file: svrank_model_cmms_-v1.8-.ini
+# FORMAT: filename|OUT_FREQUENCY_INFO_KEY|OUT_ALLELE_COUNT_INFO_KEY|IN_FREQUENCY_INFO_KEY|IN_ALLELE_COUNT_INFO_KEY|USE_IN_FREQUENCY_FILTER
 sv_svdb_query_db_files:
-  # FORMAT: filename|OUT_FREQUENCY_INFO_KEY|OUT_ALLELE_COUNT_INFO_KEY|IN_FREQUENCY_INFO_KEY|IN_ALLELE_COUNT_INFO_KEY|USE_IN_FREQUENCY_FILTER
   grch37_gnomad.genomes_-r2.1.1_sv-.vcf: gnomad_sv|AF|AC|AF|AC|1
   grch37_loqusdb_sv_-2020-04-20.vcf: clinical_genomics_loqus|Obs|Obs|Obs|Obs
   grch37_mip_sv_svdb_export_-2018-10-09-.vcf: clinical_genomics_mip|AF|OCC|FRQ|OCC|1
@@ -37,6 +35,8 @@ sv_svdb_query_db_files:
   grch37_svdb_query_clingen_cgh_pathogenic_-v1.0.0-.vcf: clingen_cgh_pathogenic
   grch37_svdb_query_clingen_ngi_-v1.0.0-.vcf: clingen_ngi|AF|OCC|FRQ|OCC|1
   grch37_swegen_concat_sort_-20170830-.vcf: swegen|AF|OCC|FRQ|OCC|1
+sv_vcfanno_config: grch37_sv_vcfanno_config_-v1.3-.toml
+vcfanno_config: grch37_vcfanno_config_-v1.7-.toml
 ### Analysis
 ## Programs
 ## Parameters


### PR DESCRIPTION
### This PR adds | fixes:

- Renames the vcfanno config parameter from:
  - vta_vcfanno_config --> vcfanno_config
  - sv_vta_vcfanno_config --> sv_vcfanno_config
- Updates download to reflect the name change in the reference repo https://github.com/Clinical-Genomics/reference-files/pull/24

- addresses #1479 

### How to test:

- Automatic and continuous test suite

### Expected outcome:
- [ ] Installation, unit and integration test suite pass

### Review:
- [ ] Code review
- [ ] Tests pass

This [version](https://semver.org/) is a:
- [ ] **MAJOR** - when you make incompatible API changes. If applicable record manual test results in PR header
- [ ] **MINOR** - when you add functionality in a backwards compatible manner. If applicable record manual test results in PR header
- [ ] **PATCH** - when you make backwards compatible bug fixes or documentation/instructions
