### PR TITLE
Feature/set infile info 2

### DIFF
--- a/lib/MIP/Fastq.pm
+++ b/lib/MIP/Fastq.pm
@@ -31,8 +31,8 @@ BEGIN {
       casava_header_features
       check_interleaved
       define_mip_fastq_file_features
-      parse_fastq_file_header_attributes
       get_read_length
+      parse_fastq_file_header_attributes
       parse_fastq_infiles_format };
 }
 

--- a/lib/MIP/Fastq.pm
+++ b/lib/MIP/Fastq.pm
@@ -17,21 +17,21 @@ use autodie qw{ :all };
 use Readonly;
 
 ## MIPs lib/
-use MIP::Constants qw{ $COMMA $DASH $EMPTY_STR $LOG_NAME $SPACE $UNDERSCORE };
+use MIP::Constants qw{ $COMMA $EMPTY_STR $LOG_NAME $SPACE $UNDERSCORE };
 
 BEGIN {
     require Exporter;
     use base qw{ Exporter };
 
     # Set the version for version checking
-    our $VERSION = 1.03;
+    our $VERSION = 1.04;
 
     # Functions and variables which can be optionally exported
     our @EXPORT_OK = qw{
       casava_header_features
       check_interleaved
       define_mip_fastq_file_features
-      get_fastq_file_header_info
+      parse_fastq_file_header_attributes
       get_read_length
       parse_fastq_infiles_format };
 }
@@ -234,7 +234,7 @@ sub define_mip_fastq_file_features {
       $original_file_name_prefix, $run_barcode;
 }
 
-sub get_fastq_file_header_info {
+sub parse_fastq_file_header_attributes {
 
 ## Function : Get run info from fastq file header
 ## Returns  : @fastq_info_headers
@@ -333,14 +333,14 @@ sub get_fastq_file_header_info {
         ## If successful regexp
         if ($fastq_info_header_string) {
 
-            # Get header features
-            my @features = @{ $casava_header_regexp{$casava_version} };
+            # Get header attributes
+            my @attributes = @{ $casava_header_regexp{$casava_version} };
 
             # Split header string into array
             my @fastq_info_headers = split $SPACE, $fastq_info_header_string;
 
             # Add to hash to be returned
-            @fastq_header_info{@features} = @fastq_info_headers;
+            @fastq_header_info{@attributes} = @fastq_info_headers;
             last REGEXP;
         }
     }
@@ -349,13 +349,15 @@ sub get_fastq_file_header_info {
 
         $log->fatal( q{Error parsing file header: } . $file_path );
         $log->fatal(
-q{Could not detect required sample sequencing run info from fastq file header }
-              . $DASH
-              . q{Please proved MIP file in MIP file convention format to proceed} );
+            q{Could not detect required sample sequencing run info from fastq file header}
+        );
+        $log->fatal(q{Please proved MIP file in MIP file convention format to proceed});
         exit 1;
     }
 
-    ## Add fake date since it is not part of the fastq header
+    $log->warn(
+q{Will add fake date '00010101' to follow file convention since this is not recorded in fastq header}
+    );
     $fastq_header_info{date} = q{000101};
 
     if ( not exists $fastq_header_info{index} ) {
@@ -378,7 +380,18 @@ q{Could not detect required sample sequencing run info from fastq file header }
             }
         );
     }
-    return %fastq_header_info;
+    ## Adds information derived from infile name to hashes
+    $log->info(
+            q{Found following information from fastq header: lane=}
+          . $fastq_header_info{lane}
+          . q{ flow-cell=}
+          . $fastq_header_info{flowcell}
+          . q{ index=}
+          . $fastq_header_info{index}
+          . q{ direction=}
+          . $fastq_header_info{direction},
+    );
+    return;
 }
 
 sub get_read_length {

--- a/lib/MIP/Parse/File.pm
+++ b/lib/MIP/Parse/File.pm
@@ -25,7 +25,7 @@ BEGIN {
     use base qw{ Exporter };
 
     # Set the version for version checking
-    our $VERSION = 1.14;
+    our $VERSION = 1.15;
 
     # Functions and variables which can be optionally exported
     our @EXPORT_OK = qw{ parse_fastq_infiles parse_file_suffix parse_io_outfiles };
@@ -34,7 +34,7 @@ BEGIN {
 
 sub parse_fastq_infiles {
 
-## Function : Parse fastq infiles for MIP processing.
+## Function : Parse fastq infiles for MIP processing
 ## Returns  :
 ## Arguments: $active_parameter_href           => Active parameters for this analysis hash {REF}
 ##          : $file_info_href                  => File info hash {REF}
@@ -98,7 +98,7 @@ sub parse_fastq_infiles {
 
     check( $tmpl, $arg_href, 1 ) or croak q{Could not parse arguments!};
 
-    use MIP::Fastq qw{ get_fastq_file_header_info };
+    use MIP::Fastq qw{ parse_fastq_file_header_attributes };
     use MIP::File_info qw{
       get_sample_file_attribute
       parse_files_compression_status
@@ -111,7 +111,6 @@ sub parse_fastq_infiles {
 
         # Needed to be able to track when lanes are finished
         my $lane_tracker = 0;
-        my %fastq_info_header;
 
         my %file_info_sample = get_sample_file_attribute(
             {
@@ -123,9 +122,7 @@ sub parse_fastq_infiles {
         my $infiles_dir = $file_info_sample{mip_infiles_dir};
 
       INFILE:
-        while ( my ( $file_index, $file_name ) =
-            each @{ $file_info_sample{mip_infiles} } )
-        {
+        foreach my $file_name ( @{ $file_info_sample{mip_infiles} } ) {
 
             my %infile_info = parse_sample_fastq_file_attributes(
                 {
@@ -143,7 +140,7 @@ sub parse_fastq_infiles {
                 $log->warn(q{Will try to find mandatory information from fastq header});
 
                 ## Get run info from fastq file header
-                %fastq_info_header = get_fastq_file_header_info(
+                parse_fastq_file_header_attributes(
                     {
                         file_info_href    => $file_info_href,
                         file_name         => $file_name,
@@ -152,28 +149,11 @@ sub parse_fastq_infiles {
                         sample_id         => $sample_id,
                     }
                 );
-
-                ## Adds information derived from infile name to hashes
-                $log->info(
-                        q{Found following information from fastq header: lane=}
-                      . $fastq_info_header{lane}
-                      . q{ flow-cell=}
-                      . $fastq_info_header{flowcell}
-                      . q{ index=}
-                      . $fastq_info_header{index}
-                      . q{ direction=}
-                      . $fastq_info_header{direction},
-                );
-                $log->warn(
-q{Will add fake date '20010101' to follow file convention since this is not recorded in fastq header}
-                );
             }
 
             ## Adds information derived from infile name to hashes
             $lane_tracker = set_infile_info(
                 {
-                    active_parameter_href           => $active_parameter_href,
-                    file_index                      => $file_index,
                     file_info_href                  => $file_info_href,
                     file_name                       => $file_name,
                     infile_both_strands_prefix_href => $infile_both_strands_prefix_href,

--- a/lib/MIP/Sample_info.pm
+++ b/lib/MIP/Sample_info.pm
@@ -1012,8 +1012,8 @@ sub set_infile_info {
         ## 2nd read direction
 
         # Alias
-        $mip_file_format = $infile_lane_prefix_href->{$sample_id}[ $lane_tracker - 1 ]
-          ;    # $lane_tracker -1 since it gets incremented after direction eq 1
+        $mip_file_format = $infile_lane_prefix_href->{$sample_id}[ $lane_tracker - 1 ];    
+        # $lane_tracker -1 since it gets incremented after direction eq 1
 
         my %direction_two_metric = ( sequence_run_type => q{paired-end}, );
 

--- a/t/add_sample_infile_both_strands_prefix.t
+++ b/t/add_sample_infile_both_strands_prefix.t
@@ -62,7 +62,6 @@ my %file_info;
 my $mip_file_format_with_direction = q{a_file_format_1};
 my $sample_id                      = q{sample_id};
 
-## When direction is not one
 add_sample_infile_both_strands_prefix(
     {
         file_info_href                 => \%file_info,
@@ -71,7 +70,7 @@ add_sample_infile_both_strands_prefix(
     }
 );
 
-## Then do add infile_both_strands_prefix
+## Then add infile_both_strands_prefix
 is( @{ $file_info{$sample_id}{infile_both_strands_prefix} },
     1, q{Added infile_both_strands_prefix to file_info} );
 

--- a/t/add_sample_infile_both_strands_prefix.t
+++ b/t/add_sample_infile_both_strands_prefix.t
@@ -1,0 +1,78 @@
+#!/usr/bin/env perl
+
+use 5.026;
+use Carp;
+use charnames qw{ :full :short };
+use English qw{ -no_match_vars };
+use File::Basename qw{ dirname };
+use File::Spec::Functions qw{ catdir };
+use FindBin qw{ $Bin };
+use open qw{ :encoding(UTF-8) :std };
+use Params::Check qw{ allow check last_error };
+use Test::More;
+use utf8;
+use warnings qw{ FATAL utf8 };
+
+## CPANM
+use autodie qw { :all };
+use Modern::Perl qw{ 2018 };
+
+## MIPs lib/
+use lib catdir( dirname($Bin), q{lib} );
+use MIP::Constants qw{ $COMMA $SPACE };
+use MIP::Test::Fixtures qw{ test_standard_cli };
+
+my $VERBOSE = 1;
+our $VERSION = 1.00;
+
+$VERBOSE = test_standard_cli(
+    {
+        verbose => $VERBOSE,
+        version => $VERSION,
+    }
+);
+
+BEGIN {
+
+    use MIP::Test::Fixtures qw{ test_import };
+
+### Check all internal dependency modules and imports
+## Modules with import
+    my %perl_module = (
+        q{MIP::File_info}      => [qw{ add_sample_infile_both_strands_prefix }],
+        q{MIP::Test::Fixtures} => [qw{ test_standard_cli }],
+    );
+
+    test_import( { perl_module_href => \%perl_module, } );
+}
+
+use MIP::File_info qw{ add_sample_infile_both_strands_prefix };
+
+diag(   q{Test add_sample_infile_both_strands_prefix from File_info.pm v}
+      . $MIP::File_info::VERSION
+      . $COMMA
+      . $SPACE . q{Perl}
+      . $SPACE
+      . $PERL_VERSION
+      . $SPACE
+      . $EXECUTABLE_NAME );
+
+## Given a sample_id
+my %file_info;
+my $mip_file_format_with_direction = q{a_file_format_1};
+my $sample_id                      = q{sample_id};
+
+## When direction is not one
+add_sample_infile_both_strands_prefix(
+    {
+        file_info_href                 => \%file_info,
+        mip_file_format_with_direction => $mip_file_format_with_direction,
+        sample_id                      => $sample_id,
+    }
+);
+
+## Then do add infile_both_strands_prefix
+is( @{ $file_info{$sample_id}{infile_both_strands_prefix} },
+    1, q{Added infile_both_strands_prefix to file_info} );
+
+done_testing();

--- a/t/parse_fastq_file_header_attributes.t
+++ b/t/parse_fastq_file_header_attributes.t
@@ -25,7 +25,7 @@ use MIP::Constants qw{ $COMMA $EMPTY_STR $NEWLINE $SPACE };
 use MIP::Test::Fixtures qw{ test_log test_standard_cli };
 
 my $VERBOSE = 1;
-our $VERSION = 1.02;
+our $VERSION = 1.03;
 
 $VERBOSE = test_standard_cli(
     {
@@ -41,16 +41,16 @@ BEGIN {
 ### Check all internal dependency modules and imports
 ## Modules with import
     my %perl_module = (
-        q{MIP::Fastq}          => [qw{ get_fastq_file_header_info }],
+        q{MIP::Fastq}          => [qw{ parse_fastq_file_header_attributes }],
         q{MIP::Test::Fixtures} => [qw{ test_log test_standard_cli }],
     );
 
     test_import( { perl_module_href => \%perl_module, } );
 }
 
-use MIP::Fastq qw{ get_fastq_file_header_info };
+use MIP::Fastq qw{ parse_fastq_file_header_attributes };
 
-diag(   q{Test get_fastq_file_header_info from Fastq.pm v}
+diag(   q{Test parse_fastq_file_header_attributes from Fastq.pm v}
       . $MIP::Fastq::VERSION
       . $COMMA
       . $SPACE . q{Perl}
@@ -82,7 +82,7 @@ my %file_info;
 my $read_file_command = q{gzip -d -c};
 my $sample_id         = q{ADM1059A1};
 
-my %fastq_info_header = get_fastq_file_header_info(
+parse_fastq_file_header_attributes(
     {
         file_info_href    => \%file_info,
         file_name         => $file_format_illumina_v1_4,
@@ -106,7 +106,7 @@ my %expected_header_element_v1_4 = (
 
 ## Then return expected_header_elements for < v1.4
 is_deeply(
-    \%fastq_info_header,
+    \%{$file_info{$sample_id}{$file_format_illumina_v1_4}},
     \%expected_header_element_v1_4,
     q{Found Illumina header format < v1.4}
 );
@@ -114,7 +114,7 @@ is_deeply(
 ## Given file, when format is greather than Casava 1.8
 my $file_format_illumina_v1_8 = q{8_161011_HHJJCCCXY_ADM1059A1_NAATGCGC_1.fastq.gz};
 
-%fastq_info_header = get_fastq_file_header_info(
+parse_fastq_file_header_attributes(
     {
         file_info_href    => \%file_info,
         file_name         => $file_format_illumina_v1_8,
@@ -140,7 +140,7 @@ my %expected_header_element_v1_8 = (
 
 ## Then return expected_header_elements for > v1.8
 is_deeply(
-    \%fastq_info_header,
+    \%{$file_info{$sample_id}{$file_format_illumina_v1_8}},
     \%expected_header_element_v1_8,
     q{Found Illumina header format > v1.8}
 );
@@ -150,7 +150,7 @@ $directory = catfile( $Bin, qw{ data 643594-miptest } );
 my $file_bad_format = q{643594-miptest_pedigree.yaml};
 
 trap {
-    get_fastq_file_header_info(
+    parse_fastq_file_header_attributes(
         {
             file_info_href    => \%file_info,
             file_name         => $file_bad_format,

--- a/t/set_infile_info.t
+++ b/t/set_infile_info.t
@@ -74,8 +74,7 @@ my $fastq_file_read_one = q{file-1};
 my $fastq_file_read_two = q{file-2};
 my $sample_id           = q{sample-1};
 
-my %active_parameter = ( case_id => q{Adams}, );
-my %file_info        = (
+my %file_info = (
     $sample_id => {
         $fastq_file_read_one => {
             date             => q{150703},
@@ -158,9 +157,7 @@ for my $sample_id ( keys %file_info ) {
     $lane_tracker = 0;
 
   INFILE:
-    while ( my ( $file_index, $file_name ) =
-        each @{ $file_info{$sample_id}{mip_infiles} } )
-    {
+    foreach my $file_name ( @{ $file_info{$sample_id}{mip_infiles} } ) {
 
         get_sample_file_attribute(
             {
@@ -171,8 +168,6 @@ for my $sample_id ( keys %file_info ) {
         );
         $lane_tracker = set_infile_info(
             {
-                active_parameter_href           => \%active_parameter,
-                file_index                      => $file_index,
                 file_info_href                  => \%file_info,
                 file_name                       => $file_name,
                 infile_both_strands_prefix_href => \%infile_both_strands_prefix,
@@ -210,22 +205,22 @@ my %expected_result = (
                         read_direction_file => {
                             $mip_file_format_with_direction => {
                                 date                      => $parsed_date,
+                                flowcell                  => $attribute{flowcell},
+                                lane                      => $attribute{lane},
                                 original_file_name        => $fastq_file_read_one,
                                 original_file_name_prefix => $original_file_name_prefix,
                                 read_direction            => $attribute{direction},
-                                lane                      => $attribute{lane},
-                                flowcell                  => $attribute{flowcell},
-                                sample_barcode            => $attribute{index},
                                 run_barcode               => $run_barcode,
+                                sample_barcode            => $attribute{index},
                             },
                             $mip_file_format_with_direction_2 => {
                                 date                      => $parsed_date,
+                                flowcell                  => $attribute_2{flowcell},
+                                lane                      => $attribute_2{lane},
                                 original_file_name        => $fastq_file_read_two,
                                 original_file_name_prefix => $original_file_name_prefix,
-                                read_direction            => $attribute_2{direction},
-                                lane                      => $attribute_2{lane},
-                                flowcell                  => $attribute_2{flowcell},
                                 sample_barcode            => $attribute_2{index},
+                                read_direction            => $attribute_2{direction},
                                 run_barcode               => $run_barcode,
                             },
                         },

--- a/t/set_sample_infile_lane_prefix.t
+++ b/t/set_sample_infile_lane_prefix.t
@@ -1,0 +1,100 @@
+#!/usr/bin/env perl
+
+use 5.026;
+use Carp;
+use charnames qw{ :full :short };
+use English qw{ -no_match_vars };
+use File::Basename qw{ dirname };
+use File::Spec::Functions qw{ catdir };
+use FindBin qw{ $Bin };
+use open qw{ :encoding(UTF-8) :std };
+use Params::Check qw{ allow check last_error };
+use Test::More;
+use utf8;
+use warnings qw{ FATAL utf8 };
+
+## CPANM
+use autodie qw { :all };
+use Modern::Perl qw{ 2018 };
+
+## MIPs lib/
+use lib catdir( dirname($Bin), q{lib} );
+use MIP::Constants qw{ $COMMA $SPACE };
+use MIP::Test::Fixtures qw{ test_standard_cli };
+
+my $VERBOSE = 1;
+our $VERSION = 1.00;
+
+$VERBOSE = test_standard_cli(
+    {
+        verbose => $VERBOSE,
+        version => $VERSION,
+    }
+);
+
+BEGIN {
+
+    use MIP::Test::Fixtures qw{ test_import };
+
+### Check all internal dependency modules and imports
+## Modules with import
+    my %perl_module = (
+        q{MIP::File_info}      => [qw{ set_sample_infile_lane_prefix }],
+        q{MIP::Test::Fixtures} => [qw{ test_standard_cli }],
+    );
+
+    test_import( { perl_module_href => \%perl_module, } );
+}
+
+use MIP::File_info qw{ set_sample_infile_lane_prefix };
+
+diag(   q{Test set_sample_infile_lane_prefix from File_info.pm v}
+      . $MIP::File_info::VERSION
+      . $COMMA
+      . $SPACE . q{Perl}
+      . $SPACE
+      . $PERL_VERSION
+      . $SPACE
+      . $EXECUTABLE_NAME );
+
+## Given a lane_tracker, sample_id and an infile_lane_prefix
+my %file_info;
+my $lane_tracker       = 0;
+my $infile_lane_prefix = q{infile_lane_prefix};
+my $sample_id          = q{sample_id};
+
+## When direction is not one
+my $direction = 2;
+
+## Then do not set infile_lane_prefix in file_info hash
+set_sample_infile_lane_prefix(
+    {
+        direction       => $direction,
+        file_info_href  => \%file_info,
+        lane_tracker    => $lane_tracker,
+        mip_file_format => $infile_lane_prefix,
+        sample_id       => $sample_id,
+    }
+);
+
+is( @{ $file_info{$sample_id}{infile_lane_prefix} },
+    0, q{Did not set infile_prefix for read direction two} );
+
+## When direction is one
+$direction = 1;
+
+## Then set infile_lane_prefix in file_info hash
+set_sample_infile_lane_prefix(
+    {
+        direction       => $direction,
+        file_info_href  => \%file_info,
+        lane_tracker    => $lane_tracker,
+        mip_file_format => $infile_lane_prefix,
+        sample_id       => $sample_id,
+    }
+);
+
+is( @{ $file_info{$sample_id}{infile_lane_prefix} },
+    1, q{Set infile_prefix for read direction one} );
+
+done_testing();


### PR DESCRIPTION
- Added infile_lane_prefix and infile_both_strands_prefix to file_info
- Added tests
- Moves sub parse_select_file_contigs into AB

### This PR adds | fixes:

- See above

### How to test:

- Automatic and continuous test suite

### Expected outcome:
- [ ] Installation, unit and integration test suite pass

### Review:
- [ ] Code review
- [ ] Tests pass

This [version](https://semver.org/) is a:
- [ ] **MAJOR** - when you make incompatible API changes. If applicable record manual test results in PR header
- [ ] **MINOR** - when you add functionality in a backwards compatible manner. If applicable record manual test results in PR header
- [x] **PATCH** - when you make backwards compatible bug fixes or documentation/instructions
