### PR TITLE
fix(dragen_analysis_test): sets picardtools_path

### DIFF
--- a/definitions/dragen_rd_dna_parameters.yaml
+++ b/definitions/dragen_rd_dna_parameters.yaml
@@ -72,11 +72,9 @@ infile_dirs:
   update_path: absolute_path
 picardtools_path:
   associated_recipe:
-    - prepareforvariantannotationblock
+    - sv_reformat
   data_type: SCALAR
-  exists_check: directory
   type: path
-  update_path: absolute_path
 #### Bash
 recipe_core_number:
   associated_recipe:

--- a/templates/mip_dragen_rd_dna_config.yaml
+++ b/templates/mip_dragen_rd_dna_config.yaml
@@ -47,6 +47,7 @@ fqf_annotations:
   - GNOMADAF
   - GNOMADAF_popmax
   - SWEGENAF
+picardtools_path: /usr/picard
 sv_genmod_models_case_type: cmms
 sv_vep_plugin:
   ExACpLI:


### PR DESCRIPTION
### This PR adds | fixes:

- sets picardtools_path for the dragen pipe. This wasn't set previously which caused a 'use of unintialized parameter' warning when thesting 

### How to test:

- Automatic and continuous test suite

### Expected outcome:
- [ ] Installation, unit and integration test suite pass

### Review:
- [ ] Code review
- [ ] Tests pass

This [version](https://semver.org/) is a:
- [ ] **MAJOR** - when you make incompatible API changes. If applicable record manual test results in PR header
- [ ] **MINOR** - when you add functionality in a backwards compatible manner. If applicable record manual test results in PR header
- [ ] **PATCH** - when you make backwards compatible bug fixes or documentation/instructions
