### PR TITLE
fix(exclude_contig_MT): In samtools_subsample_mt

### DIFF
--- a/lib/MIP/Recipes/Analysis/Samtools_subsample_mt.pm
+++ b/lib/MIP/Recipes/Analysis/Samtools_subsample_mt.pm
@@ -26,7 +26,7 @@ BEGIN {
     use base qw{ Exporter };
 
     # Set the version for version checking
-    our $VERSION = 1.15;
+    our $VERSION = 1.16;
 
     # Functions and variables which can be optionally exported
     our @EXPORT_OK = qw{ analysis_samtools_subsample_mt };
@@ -160,6 +160,14 @@ sub analysis_samtools_subsample_mt {
 
     ## Find Mitochondrial contig infile_path
     my $infile_path = first_value { / $infile_name_prefix [.]M|chrM /sxm } @infile_paths;
+
+    if ( not $infile_path ) {
+
+        $log->warn(
+qq{Mitochondrial contig is not part of analysis contig set - skipping $recipe_name}
+        );
+        return 1;
+    }
 
     my $job_id_chain = get_recipe_attributes(
         {

--- a/t/analysis_samtools_subsample_mt.t
+++ b/t/analysis_samtools_subsample_mt.t
@@ -17,7 +17,7 @@ use warnings qw{ FATAL utf8 };
 use autodie qw { :all };
 use Modern::Perl qw{ 2018 };
 use Readonly;
-use Test::Trap;
+use Test::Trap qw{ :stderr:output(systemsafe) };
 
 ## MIPs lib/
 use lib catdir( dirname($Bin), q{lib} );
@@ -25,7 +25,7 @@ use MIP::Constants qw{ $COLON $COMMA $SPACE };
 use MIP::Test::Fixtures qw{ test_log test_mip_hashes test_standard_cli };
 
 my $VERBOSE = 1;
-our $VERSION = 1.00;
+our $VERSION = 1.01;
 
 $VERBOSE = test_standard_cli(
     {
@@ -60,7 +60,7 @@ diag(   q{Test analysis_samtools_subsample_mt from Samtools_subsample_mt.pm v}
       . $SPACE
       . $EXECUTABLE_NAME );
 
-my $log = test_log( { log_name => q{MIP}, no_screen => 1, } );
+my $log = test_log( { log_name => q{MIP}, } );
 
 ## Given analysis parameters
 my $recipe_name    = q{samtools_subsample_mt};
@@ -100,20 +100,48 @@ my %parameter = test_mip_hashes(
 @{ $parameter{cache}{order_recipes_ref} } = ($recipe_name);
 my %sample_info;
 
-my $is_ok = analysis_samtools_subsample_mt(
-    {
-        active_parameter_href => \%active_parameter,
-        file_info_href        => \%file_info,
-        job_id_href           => \%job_id,
-        parameter_href        => \%parameter,
-        profile_base_command  => $slurm_mock_cmd,
-        recipe_name           => $recipe_name,
-        sample_id             => $sample_id,
-        sample_info_href      => \%sample_info,
-    }
-);
+my @returns = trap {
+    analysis_samtools_subsample_mt(
+        {
+            active_parameter_href => \%active_parameter,
+            file_info_href        => \%file_info,
+            job_id_href           => \%job_id,
+            parameter_href        => \%parameter,
+            profile_base_command  => $slurm_mock_cmd,
+            recipe_name           => $recipe_name,
+            sample_id             => $sample_id,
+            sample_info_href      => \%sample_info,
+        }
+    )
+};
 
 ## Then return TRUE
-ok( $is_ok, q{ Executed analysis recipe } . $recipe_name );
+ok( $returns[0], q{ Executed analysis recipe } . $recipe_name );
+
+## When MT contig is not part of analysis contig set
+delete $file_info{io}{TEST}{ADM1059A1}{samtools_subsample_mt}{in}{file_paths}[-1];
+
+@returns = trap {
+    analysis_samtools_subsample_mt(
+        {
+            active_parameter_href => \%active_parameter,
+            file_info_href        => \%file_info,
+            job_id_href           => \%job_id,
+            parameter_href        => \%parameter,
+            profile_base_command  => $slurm_mock_cmd,
+            recipe_name           => $recipe_name,
+            sample_id             => $sample_id,
+            sample_info_href      => \%sample_info,
+        }
+    )
+};
+
+## Then log a warning and carry on
+like(
+    $trap->stderr,
+    qr/Mitochondrial \s+ contig \s+ is \s+ not \s+ part \s+ of/xms,
+    q{ Throw warning when no Mitochondrial contig}
+);
+ok( $returns[0], qq{ Skipped analysis recipe $recipe_name when no Mitochondrial contig} );
 
 done_testing();


### PR DESCRIPTION
### This PR fixes #1554 :

- MIP crashing when using running a wgs analysis and excluding the MT contig

### How to test:

- Automatic and continuous test suite

### Expected outcome:
- [ ] Installation, unit and integration test suite pass
- [ ] MIP throws a warning and carries on ✅ 

### Review:
- [ ] Code review
- [ ] Tests pass

This [version](https://semver.org/) is a:
- [ ] **MAJOR** - when you make incompatible API changes. If applicable record manual test results in PR header
- [ ] **MINOR** - when you add functionality in a backwards compatible manner. If applicable record manual test results in PR header
- [x] **PATCH** - when you make backwards compatible bug fixes or documentation/instructions
