### PR TITLE
fix(multiqc): updates multiqc

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 All notable changes to this project will be documented in this file.
 This project adheres to [Semantic Versioning](http://semver.org/).
 
+## [8.2.6]
+- Updates multiqc 
+
+**Tools**
+- multiqc: 1.7 -> 1.9
+
 ## [8.2.5]
 - Adds output files to store for gatk_combinevariants, sambamba depth, chromograph recipes
 - Use MIPs bcftools singularity image in the conda env when checking references 

--- a/lib/MIP/Constants.pm
+++ b/lib/MIP/Constants.pm
@@ -20,7 +20,7 @@ BEGIN {
     use base qw{ Exporter };
 
     # Set the version for version checking
-    our $VERSION = 1.21;
+    our $VERSION = 1.22;
 
     # Functions and variables which can be optionally exported
 
@@ -80,7 +80,7 @@ Readonly our %ANALYSIS => (
 );
 
 ## Set MIP version
-Readonly our $MIP_VERSION => q{v8.2.5};
+Readonly our $MIP_VERSION => q{v8.2.6};
 
 ## Cli
 Readonly our $MOOSEX_APP_SCEEN_WIDTH => 160;

--- a/templates/mip_install_rd_dna_config_-1.0-.yaml
+++ b/templates/mip_install_rd_dna_config_-1.0-.yaml
@@ -86,7 +86,7 @@ singularity:
   multiqc:
     executable:
       multiqc:
-    uri: docker://ewels/multiqc:v1.7
+    uri: docker://ewels/multiqc:v1.9
   peddy:
     executable:
       peddy: "python -m peddy"

--- a/templates/mip_install_rd_dna_config_-1.0-.yaml
+++ b/templates/mip_install_rd_dna_config_-1.0-.yaml
@@ -86,7 +86,7 @@ singularity:
   multiqc:
     executable:
       multiqc:
-    uri: docker://ewels/multiqc:v1.9
+    uri: docker://ewels/multiqc:1.9
   peddy:
     executable:
       peddy: "python -m peddy"

--- a/templates/mip_install_rd_rna_config_-1.0-.yaml
+++ b/templates/mip_install_rd_rna_config_-1.0-.yaml
@@ -60,7 +60,7 @@ singularity:
   multiqc:
     executable:
       multiqc:
-    uri: docker://ewels/multiqc:v1.9
+    uri: docker://ewels/multiqc:1.9
   picard:
     executable:
       picard: "no_executable_in_image"

--- a/templates/mip_install_rd_rna_config_-1.0-.yaml
+++ b/templates/mip_install_rd_rna_config_-1.0-.yaml
@@ -60,7 +60,7 @@ singularity:
   multiqc:
     executable:
       multiqc:
-    uri: docker://ewels/multiqc:v1.7
+    uri: docker://ewels/multiqc:v1.9
   picard:
     executable:
       picard: "no_executable_in_image"


### PR DESCRIPTION
### This PR adds | fixes:

- Updates multiqc to version 1.9. This fixes a known bug in multiqc which causes the program to crash with a ZeroDivisionError

### How to test:

- Automatic and continuous test suite

### Expected outcome:
- [ ] Installation, unit and integration test suite pass

### Review:
- [ ] Code review
- [ ] Tests pass

This [version](https://semver.org/) is a:
- [ ] **MAJOR** - when you make incompatible API changes. If applicable record manual test results in PR header
- [ ] **MINOR** - when you add functionality in a backwards compatible manner. If applicable record manual test results in PR header
- [x] **PATCH** - when you make backwards compatible bug fixes or documentation/instructions
