### PR TITLE
feat(refactor): reduce_dir_paths

### DIFF
--- a/lib/MIP/Constants.pm
+++ b/lib/MIP/Constants.pm
@@ -20,7 +20,7 @@ BEGIN {
     use base qw{ Exporter };
 
     # Set the version for version checking
-    our $VERSION = 1.21;
+    our $VERSION = 1.22;
 
     # Functions and variables which can be optionally exported
 
@@ -372,7 +372,7 @@ sub set_singularity_constants {
 
     check( $tmpl, $arg_href, 1 ) or croak q{Could not parse arguments!};
 
-    use MIP::Parse::Singularity qw{ reduce_dir_paths };
+    use MIP::Environment::Path qw{ reduce_dir_paths };
 
     ## Gather default bind paths for singularity
     my @singularity_bind_paths = (

--- a/lib/MIP/Environment/Path.pm
+++ b/lib/MIP/Environment/Path.pm
@@ -5,7 +5,7 @@ use Carp;
 use charnames qw{ :full :short };
 use English qw{ -no_match_vars };
 use File::Basename qw{ dirname };
-use File::Spec::Functions qw{ catdir catfile };
+use File::Spec::Functions qw{ catdir catfile splitdir };
 use open qw{ :encoding(UTF-8) :std };
 use Params::Check qw{ allow check last_error };
 use strict;
@@ -28,7 +28,7 @@ BEGIN {
     use base qw{ Exporter };
 
     # Set the version for version checking
-    our $VERSION = 1.01;
+    our $VERSION = 1.02;
 
     # Functions and variables which can be optionally exported
     our @EXPORT_OK = qw{
@@ -37,6 +37,7 @@ BEGIN {
       get_conda_bin_dir_path
       get_conda_path
       is_binary_in_path
+      reduce_dir_paths
     };
 }
 
@@ -343,6 +344,73 @@ sub is_binary_in_path {
     );
     exit 1;
 
+}
+
+sub reduce_dir_paths {
+
+## Function : Parses directory paths and reduces them to a non-overlapping array. No check for existing files or directories
+## Returns  : @reduced_dir_paths
+## Arguments: $dir_paths_ref => Directory paths to parse {REF}
+
+    my ($arg_href) = @_;
+
+    ## Flatten argument(s)
+    my $dir_paths_ref;
+
+    my $tmpl = {
+        dir_paths_ref => {
+            default     => [],
+            defined     => 1,
+            required    => 1,
+            store       => \$dir_paths_ref,
+            strict_type => 1,
+        },
+    };
+
+    check( $tmpl, $arg_href, 1 ) or croak q{Could not parse arguments!};
+
+    my @dir_paths;
+
+    ## Split to dir path to array
+  DIR_PATH:
+    foreach my $dir_path ( @{$dir_paths_ref} ) {
+
+        next DIR_PATH if ( not defined $dir_path );
+
+        push @dir_paths, [ splitdir($dir_path) ];
+    }
+
+    ## Sort according to size
+    @dir_paths = sort { @{$a} <=> @{$b} } @dir_paths;
+
+    ## Reformat to strings
+    @dir_paths = map { catdir( @{$_} ) } @dir_paths;
+
+    my @reduced_dir_paths;
+
+  BIND_PATH:
+    while (@dir_paths) {
+
+        ## Shift array
+        my $dir_path = shift @dir_paths;
+
+        ## Save path
+        push @reduced_dir_paths, $dir_path;
+
+        ## Get indexes of all the paths in the array that have an identical beginning to one we are testing
+        ## The \Q and \E in the regex turns of interpolation
+        my @match_idxs =
+          grep { $dir_paths[$_] =~ / ^\Q$dir_path\E.* /xms } 0 .. $#dir_paths;
+
+      MATCH_IDX:
+        foreach my $match_idx ( reverse @match_idxs ) {
+
+            ## Remove those paths with matching starts
+            splice @dir_paths, $match_idx, 1;
+        }
+    }
+
+    return @reduced_dir_paths;
 }
 
 sub _check_binary_broadcast_fail {

--- a/lib/MIP/Parse/Singularity.pm
+++ b/lib/MIP/Parse/Singularity.pm
@@ -4,7 +4,7 @@ use 5.026;
 use Carp;
 use charnames qw{ :full :short };
 use English qw{ -no_match_vars };
-use File::Spec::Functions qw{ catdir splitdir };
+use File::Spec::Functions qw{ catdir };
 use open qw{ :encoding(UTF-8) :std };
 use Params::Check qw{ allow check last_error };
 use strict;
@@ -14,7 +14,6 @@ use warnings qw{ FATAL utf8 };
 
 ## CPANM
 use autodie qw{ :all };
-use Readonly;
 
 ## MIPs lib/
 use MIP::Constants
@@ -25,10 +24,10 @@ BEGIN {
     use base qw{ Exporter };
 
     # Set the version for version checking
-    our $VERSION = 1.02;
+    our $VERSION = 1.03;
 
     # Functions and variables which can be optionally exported
-    our @EXPORT_OK = qw{ parse_sing_bind_paths reduce_dir_paths };
+    our @EXPORT_OK = qw{ parse_sing_bind_paths };
 }
 
 sub parse_sing_bind_paths {
@@ -71,6 +70,8 @@ sub parse_sing_bind_paths {
 
     check( $tmpl, $arg_href, 1 ) or croak q{Could not parse arguments!};
 
+    use MIP::Environment::Path qw{ reduce_dir_paths };
+
     return if not $WITH_SINGULARITY;
 
     my @export_bind_paths = @SINGULARITY_BIND_PATHS;
@@ -99,73 +100,6 @@ sub parse_sing_bind_paths {
     push @{$source_environment_cmds_ref}, $singularity_bind_var;
 
     return;
-}
-
-sub reduce_dir_paths {
-
-## Function : Parses directory paths and reduces them to a non-overlapping array. No check for existing files or directories
-## Returns  : @reduced_dir_paths
-## Arguments: $dir_paths_ref => Directory paths to parse {REF}
-
-    my ($arg_href) = @_;
-
-    ## Flatten argument(s)
-    my $dir_paths_ref;
-
-    my $tmpl = {
-        dir_paths_ref => {
-            default     => [],
-            defined     => 1,
-            required    => 1,
-            store       => \$dir_paths_ref,
-            strict_type => 1,
-        },
-    };
-
-    check( $tmpl, $arg_href, 1 ) or croak q{Could not parse arguments!};
-
-    my @dir_paths;
-
-    ## Split to dir path to array
-  DIR_PATH:
-    foreach my $dir_path ( @{$dir_paths_ref} ) {
-
-        next DIR_PATH if ( not defined $dir_path );
-
-        push @dir_paths, [ splitdir($dir_path) ];
-    }
-
-    ## Sort according to size
-    @dir_paths = sort { @{$a} <=> @{$b} } @dir_paths;
-
-    ## Reformat to strings
-    @dir_paths = map { catdir( @{$_} ) } @dir_paths;
-
-    my @reduced_dir_paths;
-
-  BIND_PATH:
-    while (@dir_paths) {
-
-        ## Shift array
-        my $dir_path = shift @dir_paths;
-
-        ## Save path
-        push @reduced_dir_paths, $dir_path;
-
-        ## Get indexes of all the paths in the array that have an identical beginning to one we are testing
-        ## The \Q and \E in the regex turns of interpolation
-        my @match_idxs =
-          grep { $dir_paths[$_] =~ / ^\Q$dir_path\E.* /xms } 0 .. $#dir_paths;
-
-      MATCH_IDX:
-        foreach my $match_idx ( reverse @match_idxs ) {
-
-            ## Remove those paths with matching starts
-            splice @dir_paths, $match_idx, 1;
-        }
-    }
-
-    return @reduced_dir_paths;
 }
 
 1;

--- a/t/check_vcf_variant_line.t
+++ b/t/check_vcf_variant_line.t
@@ -17,15 +17,15 @@ use warnings qw{ FATAL utf8 };
 use autodie qw { :all };
 use Modern::Perl qw{ 2018 };
 use Readonly;
+use Test::Trap;
 
 ## MIPs lib/
 use lib catdir( dirname($Bin), q{lib} );
 use MIP::Constants qw{ $COMMA $SPACE $TAB };
 use MIP::Test::Fixtures qw{ test_log test_standard_cli };
-use Test::Trap;
 
 my $VERBOSE = 1;
-our $VERSION = 1.00;
+our $VERSION = 1.01;
 
 $VERBOSE = test_standard_cli(
     {

--- a/t/reduce_dir_paths.t
+++ b/t/reduce_dir_paths.t
@@ -40,17 +40,17 @@ BEGIN {
 ### Check all internal dependency modules and imports
 ## Modules with import
     my %perl_module = (
-        q{MIP::Parse::Singularity} => [qw{ reduce_dir_paths }],
-        q{MIP::Test::Fixtures}     => [qw{ test_standard_cli }],
+        q{MIP::Environment::Path} => [qw{ reduce_dir_paths }],
+        q{MIP::Test::Fixtures}    => [qw{ test_standard_cli }],
     );
 
     test_import( { perl_module_href => \%perl_module, } );
 }
 
-use MIP::Parse::Singularity qw{ reduce_dir_paths };
+use MIP::Environment::Path qw{ reduce_dir_paths };
 
-diag(   q{Test reduce_dir_paths from Parse::Singularity.pm v}
-      . $MIP::Parse::Singularity::VERSION
+diag(   q{Test reduce_dir_paths from Path.pm v}
+      . $MIP::Environment::Path::VERSION
       . $COMMA
       . $SPACE . q{Perl}
       . $SPACE


### PR DESCRIPTION
- Import Test::Trap is now imported at the correct place in check_vcf_variant_line

### This PR adds | fixes:

- See above and mainly a move of the entire reduce_dir_paths sub

### How to test:

- Automatic and continuous test suite

### Expected outcome:
- [ ] Installation, unit and integration test suite pass

### Review:
- [ ] Code review
- [ ] Tests pass

This [version](https://semver.org/) is a:
- [ ] **MAJOR** - when you make incompatible API changes. If applicable record manual test results in PR header
- [ ] **MINOR** - when you add functionality in a backwards compatible manner. If applicable record manual test results in PR header
- [x] **PATCH** - when you make backwards compatible bug fixes or documentation/instructions
