### PR TITLE
fix(ase_recipes): set correct ase recipes

### DIFF
--- a/lib/MIP/Analysis.pm
+++ b/lib/MIP/Analysis.pm
@@ -29,7 +29,7 @@ BEGIN {
     use base qw{ Exporter };
 
     # Set the version for version checking
-    our $VERSION = 1.27;
+    our $VERSION = 1.28;
 
     # Functions and variables which can be optionally exported
     our @EXPORT_OK = qw{
@@ -597,13 +597,13 @@ sub set_ase_chain_recipes {
 
     use MIP::Active_parameter qw{ set_recipe_mode };
 
-    my @DNA_RECIPES  = (qw{ dna_vcf_reformat });
-    my @ASE_RECIPIES = (
+    my @DNA_VC_RECIPES = (qw{ dna_vcf_reformat });
+    my @RNA_VC_RECIPES = (
         qw{ gatk_baserecalibration gatk_haplotypecaller gatk_splitncigarreads gatk_variantfiltration }
     );
 
     my @recipes =
-      $active_parameter_href->{dna_vcf_file} < 1 ? @DNA_RECIPES : @ASE_RECIPIES;
+      $active_parameter_href->{dna_vcf_file} ? @RNA_VC_RECIPES : @DNA_VC_RECIPES;
 
     set_recipe_mode(
         {

--- a/t/build_perl_program_check_command.t
+++ b/t/build_perl_program_check_command.t
@@ -24,7 +24,7 @@ use MIP::Constants qw{ $COMMA $SPACE };
 use MIP::Test::Fixtures qw{ test_standard_cli };
 
 my $VERBOSE = 1;
-our $VERSION = 1.02;
+our $VERSION = 1.03;
 
 $VERBOSE = test_standard_cli(
     {
@@ -78,7 +78,7 @@ my @perl_commands = build_perl_program_check_command(
 my $perl_command = join $SPACE, @perl_commands;
 
 my $expected_return =
-q{perl -e ' use IPC::Cmd qw{ can_run run }; use Test::More; ok(run(command => q{program --version}, timeout => 20), q{Can execute: program}); done_testing; '};
+q{perl -e ' use IPC::Cmd qw{ can_run run }; use Test::More; ok(run(command => q{program --version}, timeout => 60), q{Can execute: program}); done_testing; '};
 is( $perl_command, $expected_return, q{Perl oneliner execution test built} );
 
 ## Given a program with only a path test

--- a/t/set_ase_chain_recipes.t
+++ b/t/set_ase_chain_recipes.t
@@ -5,7 +5,7 @@ use Carp;
 use charnames qw{ :full :short };
 use English qw{ -no_match_vars };
 use File::Basename qw{ dirname };
-use File::Spec::Functions qw{ catdir };
+use File::Spec::Functions qw{ catdir catfile };
 use FindBin qw{ $Bin };
 use open qw{ :encoding(UTF-8) :std };
 use Params::Check qw{ allow check last_error };
@@ -23,7 +23,7 @@ use MIP::Constants qw{ $COMMA $SPACE };
 use MIP::Test::Fixtures qw{ test_log test_standard_cli };
 
 my $VERBOSE = 1;
-our $VERSION = 1.00;
+our $VERSION = 1.01;
 
 $VERBOSE = test_standard_cli(
     {
@@ -69,8 +69,6 @@ my %active_parameter = (
 );
 
 ## When no DNA VCF file is supplied
-$active_parameter{dna_vcf_file} = 0;
-
 set_ase_chain_recipes( { active_parameter_href => \%active_parameter, } );
 
 ## Then turn off DNA VCF reformat recipe
@@ -80,12 +78,12 @@ is( $active_parameter{dna_vcf_reformat}, 0, q{Turn off DNA VCF reformat recipe} 
 $active_parameter{dna_vcf_reformat} = 1;
 
 ## When DNA VCF file is supplied
-$active_parameter{dna_vcf_file} = 1;
+$active_parameter{dna_vcf_file} = catfile(qw{ my dna_variants.vcf });
 
 set_ase_chain_recipes( { active_parameter_href => \%active_parameter, } );
 
 my %expected_recipe_mode = (
-    dna_vcf_file           => 1,
+    dna_vcf_file           => catfile(qw{ my dna_variants.vcf }),
     dna_vcf_reformat       => 1,
     gatk_baserecalibration => 0,
     gatk_haplotypecaller   => 0,


### PR DESCRIPTION
### This PR adds | fixes:

- Changes check for dna vcf from a count check to a defined and exists check since the variable will be undefined if the file is missing

### How to test:

- Automatic and continuous test suite

### Expected outcome:
- [ ] Installation, unit and integration test suite pass

### Review:
- [ ] Code review
- [ ] Tests pass

This [version](https://semver.org/) is a:
- [ ] **MAJOR** - when you make incompatible API changes. If applicable record manual test results in PR header
- [ ] **MINOR** - when you add functionality in a backwards compatible manner. If applicable record manual test results in PR header
- [x] **PATCH** - when you make backwards compatible bug fixes or documentation/instructions
