### PR TITLE
Feature/bwa mem2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 **Tools**
 - Arriba: 1.1.0 -> 1.2.0
 - bcftools: 1.9=ha228f0b_4 -> 1.10.2-hd2cd319_0 (DNA)
+- bwa-mem2: 2.0-he513fc3_0
 - CADD: v1.5 -> v1.6
 - expansionhunter: 3.1.2 -> 3.2.2
 - fastqc: 0.11.8-0 -> 0.11.9

--- a/containers/bwa-mem2/Dockerfile
+++ b/containers/bwa-mem2/Dockerfile
@@ -6,12 +6,12 @@ FROM clinicalgenomics/mip:2.0
 
 LABEL base_image="clinicalgenomics/mip:2.0"
 LABEL version="1"
-LABEL software="bwa"
-LABEL software.version="0.7.17"
-LABEL extra.binaries="bwa"
+LABEL software="bwa-mem2"
+LABEL software.version="2.0"
+LABEL extra.binaries="bwa-mem2"
 LABEL maintainer="Clinical-Genomics/MIP"
 
-RUN conda install bwa=0.7.17=ha92aebf_3
+RUN conda install bwa-mem2=2.0=he513fc3_0
 
 ## Clean up after conda
 RUN /opt/conda/bin/conda clean -tipsy

--- a/containers/bwa-mem2/Dockerfile
+++ b/containers/bwa-mem2/Dockerfile
@@ -6,12 +6,12 @@ FROM clinicalgenomics/mip:2.0
 
 LABEL base_image="clinicalgenomics/mip:2.0"
 LABEL version="1"
-LABEL software="bwa-mem2"
-LABEL software.version="2.0"
-LABEL extra.binaries="bwa-mem2"
+LABEL software="bwa"
+LABEL software.version="0.7.17"
+LABEL extra.binaries="bwa"
 LABEL maintainer="Clinical-Genomics/MIP"
 
-RUN conda install bwa-mem2=2.0=he513fc3_0
+RUN conda install bwa=0.7.17=ha92aebf_3
 
 ## Clean up after conda
 RUN /opt/conda/bin/conda clean -tipsy

--- a/containers/bwa/Dockerfile
+++ b/containers/bwa/Dockerfile
@@ -6,12 +6,12 @@ FROM clinicalgenomics/mip:2.0
 
 LABEL base_image="clinicalgenomics/mip:2.0"
 LABEL version="1"
-LABEL software="bwa-mem2"
-LABEL software.version="2.0"
-LABEL extra.binaries="bwa-mem2"
+LABEL software="bwa"
+LABEL software.version="0.7.17"
+LABEL extra.binaries="bwa"
 LABEL maintainer="Clinical-Genomics/MIP"
 
-RUN conda install bwa-mem2=2.0=he513fc3_0
+RUN conda install bwa=0.7.17=ha92aebf_3
 
 ## Clean up after conda
 RUN /opt/conda/bin/conda clean -tipsy

--- a/definitions/install_parameters.yaml
+++ b/definitions/install_parameters.yaml
@@ -106,6 +106,7 @@ rd_dna:
     - bedtools
     - bwa
     - bwakit
+    - bwa-mem2
     - cadd
     - chanjo
     - chromograph

--- a/definitions/rd_dna_initiation_map.yaml
+++ b/definitions/rd_dna_initiation_map.yaml
@@ -9,6 +9,7 @@ CHAIN_ALL:
     - fastqc_ar
   - CHAIN_MAIN:
     - bwa_mem
+    - bwa_mem2
     - samtools_merge
     - markduplicates
     - gatk_baserecalibration

--- a/definitions/rd_dna_panel_initiation_map.yaml
+++ b/definitions/rd_dna_panel_initiation_map.yaml
@@ -7,6 +7,7 @@ CHAIN_ALL:
     - fastqc_ar
   - CHAIN_MAIN:
     - bwa_mem
+    - bwa_mem2
     - samtools_merge
     - markduplicates
     - gatk_baserecalibration

--- a/definitions/rd_dna_panel_parameters.yaml
+++ b/definitions/rd_dna_panel_parameters.yaml
@@ -8,6 +8,7 @@ custom_default_parameters:
     - analysis_type
     - conda_path
     - bwa_build_reference
+    - bwa_mem2_build_reference
     - exome_target_bed
     - infile_dirs
     - pedigree_fam_file
@@ -77,6 +78,7 @@ gatk_path:
 human_genome_reference:
   associated_recipe:
     - bwa_mem
+    - bwa_mem2
     - gatk_baserecalibration
     - gatk_haplotypecaller
     - gatk_genotypegvcfs
@@ -96,6 +98,7 @@ human_genome_reference:
 human_genome_reference_file_endings:
   associated_recipe:
     - bwa_mem
+    - bwa_mem2
     - gatk_baserecalibration
     - gatk_haplotypecaller
     - gatk_genotypegvcfs
@@ -119,6 +122,7 @@ recipe_core_number:
   default:
     analysisrunstatus: 1
     bwa_mem: 12
+    bwa_mem2: 12
     cadd_ar: 1
     endvariantannotationblock: 1
     fastqc_ar: 0
@@ -189,6 +193,7 @@ recipe_time:
   default:
     analysisrunstatus: 1
     bwa_mem: 2
+    bwa_mem2: 2
     cadd_ar: 2
     endvariantannotationblock: 1
     fastqc_ar: 10
@@ -237,6 +242,7 @@ infile_dirs:
 picardtools_path:
   associated_recipe:
     - bwa_mem
+    - bwa_mem2
     - picardtools_collecthsmetrics
     - picardtools_collectmultiplemetrics
   data_type: SCALAR
@@ -276,7 +282,7 @@ bwa_mem:
   associated_recipe:
     - mip
   data_type: SCALAR
-  default: 1
+  default: 0
   file_tag: _sorted
   outfile_suffix: ".bam"
   program_executables:
@@ -292,15 +298,38 @@ bwa_build_reference:
   exists_check: file
   reference: reference_dir
   type: path
+bwa_mem2:
+  analysis_mode: sample
+  associated_recipe:
+    - mip
+  data_type: SCALAR
+  default: 1
+  file_tag: _sorted
+  outfile_suffix: ".bam"
+  program_executables:
+    - bwa-mem2
+    - samtools
+  recipe_type: aligners
+  type: recipe
+bwa_mem2_build_reference:
+  associated_recipe:
+    - bwa_mem2
+  build_file: 1
+  data_type: SCALAR
+  exists_check: file
+  reference: reference_dir
+  type: path
 bwa_mem_bamstats:
   associated_recipe:
     - bwa_mem
+    - bwa_mem2
   data_type: SCALAR
   default: 1
   type: recipe_argument
 bwa_mem_cram:
   associated_recipe:
     - bwa_mem
+    - bwa_mem2
   data_type: SCALAR
   default: 0
   type: recipe_argument
@@ -313,6 +342,7 @@ bwa_mem_hla:
 bwa_soft_clip_sup_align:
   associated_recipe:
     - bwa_mem
+    - bwa_mem2
   data_type: SCALAR
   default: 0
   type: recipe_argument

--- a/definitions/rd_dna_parameters.yaml
+++ b/definitions/rd_dna_parameters.yaml
@@ -8,6 +8,7 @@ custom_default_parameters:
     - analysis_type
     - conda_path
     - bwa_build_reference
+    - bwa_mem2_build_reference
     - exome_target_bed
     - infile_dirs
     - pedigree_fam_file
@@ -81,6 +82,7 @@ human_genome_reference:
   associated_recipe:
     - bcftools_mpileup
     - bwa_mem
+    - bwa_mem2
     - cnvnator_ar
     - delly_call
     - expansionhunter
@@ -106,6 +108,7 @@ human_genome_reference_file_endings:
   associated_recipe:
     - bcftools_mpileup
     - bwa_mem
+    - bwa_mem2
     - cnvnator_ar
     - delly_call
     - expansionhunter
@@ -135,6 +138,7 @@ recipe_core_number:
     analysisrunstatus: 1
     bcftools_mpileup: 16
     bwa_mem: 36
+    bwa_mem2: 36
     chanjo_sexcheck: 1
     chromograph_ar: 1
     cnvnator_ar: 13
@@ -240,6 +244,7 @@ recipe_time:
   default:
     analysisrunstatus: 1
     bwa_mem: 30
+    bwa_mem2: 30
     bcftools_mpileup: 40
     cadd_ar: 10
     chanjo_sexcheck: 2
@@ -315,6 +320,7 @@ infile_dirs:
 picardtools_path:
   associated_recipe:
     - bwa_mem
+    - bwa_mem2
     - delly_reformat
     - markduplicates
     - picardtools_collecthsmetrics
@@ -375,7 +381,7 @@ bwa_mem:
   associated_recipe:
     - mip
   data_type: SCALAR
-  default: 1
+  default: 0
   file_tag: _sorted
   outfile_suffix: ".bam"
   program_executables:
@@ -391,15 +397,38 @@ bwa_build_reference:
   exists_check: file
   reference: reference_dir
   type: path
+bwa_mem2:
+  analysis_mode: sample
+  associated_recipe:
+    - mip
+  data_type: SCALAR
+  default: 1
+  file_tag: _sorted
+  outfile_suffix: ".bam"
+  program_executables:
+    - bwa-mem2
+    - samtools
+  recipe_type: aligners
+  type: recipe
+bwa_mem2_build_reference:
+  associated_recipe:
+    - bwa_mem2
+  build_file: 1
+  data_type: SCALAR
+  exists_check: file
+  reference: reference_dir
+  type: path
 bwa_mem_bamstats:
   associated_recipe:
     - bwa_mem
+    - bwa_mem2
   data_type: SCALAR
   default: 1
   type: recipe_argument
 bwa_mem_cram:
   associated_recipe:
     - bwa_mem
+    - bwa_mem2
   data_type: SCALAR
   default: 0
   type: recipe_argument
@@ -412,6 +441,7 @@ bwa_mem_hla:
 bwa_soft_clip_sup_align:
   associated_recipe:
     - bwa_mem
+    - bwa_mem2
   data_type: SCALAR
   default: 0
   type: recipe_argument

--- a/definitions/rd_dna_parameters.yaml
+++ b/definitions/rd_dna_parameters.yaml
@@ -245,7 +245,7 @@ recipe_time:
   default:
     analysisrunstatus: 1
     bwa_mem: 30
-    bwa_mem2: 30
+    bwa_mem2: 10
     bcftools_mpileup: 40
     cadd_ar: 10
     chanjo_sexcheck: 2

--- a/lib/MIP/Cli/Mip/Analyse/Rd_dna.pm
+++ b/lib/MIP/Cli/Mip/Analyse/Rd_dna.pm
@@ -17,7 +17,7 @@ use Moose::Util::TypeConstraints;
 ## MIPs lib
 use MIP::Main::Analyse qw{ mip_analyse };
 
-our $VERSION = 1.58;
+our $VERSION = 1.59;
 
 extends(qw{ MIP::Cli::Mip::Analyse });
 
@@ -321,7 +321,7 @@ q{gatk_baserecalibration_known_sites, gatk_haplotypecaller_snp_known_set, gatk_v
             cmd_tags      => [q{Analysis recipe switch}],
             documentation => q{Align reads using Bwa Mem},
             is            => q{rw},
-            isa           => enum( [ 1, 2 ] ),
+            isa           => enum( [ 0, 1, 2 ] ),
         )
     );
 
@@ -330,7 +330,7 @@ q{gatk_baserecalibration_known_sites, gatk_haplotypecaller_snp_known_set, gatk_v
             cmd_tags      => [q{Analysis recipe switch}],
             documentation => q{Align reads using Bwa mem 2},
             is            => q{rw},
-            isa           => enum( [ 1, 2 ] ),
+            isa           => enum( [ 0, 1, 2 ] ),
         )
     );
 

--- a/lib/MIP/Cli/Mip/Analyse/Rd_dna.pm
+++ b/lib/MIP/Cli/Mip/Analyse/Rd_dna.pm
@@ -17,7 +17,7 @@ use Moose::Util::TypeConstraints;
 ## MIPs lib
 use MIP::Main::Analyse qw{ mip_analyse };
 
-our $VERSION = 1.57;
+our $VERSION = 1.58;
 
 extends(qw{ MIP::Cli::Mip::Analyse });
 
@@ -95,6 +95,9 @@ sub run {
 
         # BWA human genome reference file endings
         bwa_build_reference => [qw{ .bwt .ann .amb .pac .sa }],
+
+        bwa_mem2_build_reference =>
+          [qw{ .0123 .ann .amb .bwt.2bit.64 .bwt.8bit.32 .pac }],
 
         exome_target_bed => [qw{ .interval_list .pad100.interval_list }],
 
@@ -317,6 +320,15 @@ q{gatk_baserecalibration_known_sites, gatk_haplotypecaller_snp_known_set, gatk_v
         q{bwa_mem} => (
             cmd_tags      => [q{Analysis recipe switch}],
             documentation => q{Align reads using Bwa Mem},
+            is            => q{rw},
+            isa           => enum( [ 1, 2 ] ),
+        )
+    );
+
+    option(
+        q{bwa_mem2} => (
+            cmd_tags      => [q{Analysis recipe switch}],
+            documentation => q{Align reads using Bwa mem 2},
             is            => q{rw},
             isa           => enum( [ 1, 2 ] ),
         )

--- a/lib/MIP/Cli/Mip/Analyse/Rd_dna_panel.pm
+++ b/lib/MIP/Cli/Mip/Analyse/Rd_dna_panel.pm
@@ -17,7 +17,7 @@ use Moose::Util::TypeConstraints;
 ## MIPs lib
 use MIP::Main::Analyse qw{ mip_analyse };
 
-our $VERSION = 1.09;
+our $VERSION = 1.10;
 
 extends(qw{ MIP::Cli::Mip::Analyse });
 
@@ -97,6 +97,9 @@ sub run {
 
         # BWA human genome reference file endings
         bwa_build_reference => [qw{ .bwt .ann .amb .pac .sa }],
+
+        bwa_mem2_build_reference =>
+          [qw{ .0123 .ann .amb .bwt.2bit.64 .bwt.8bit.32 .pac }],
 
         exome_target_bed => [qw{ .interval_list .pad100.interval_list }],
 
@@ -299,6 +302,15 @@ q{gatk_baserecalibration_known_sites, gatk_haplotypecaller_snp_known_set, gatk_v
         q{bwa_mem} => (
             cmd_tags      => [q{Analysis recipe switch}],
             documentation => q{Align reads using Bwa Mem},
+            is            => q{rw},
+            isa           => enum( [ 1, 2 ] ),
+        )
+    );
+
+    option(
+        q{bwa_mem2} => (
+            cmd_tags      => [q{Analysis recipe switch}],
+            documentation => q{Align reads using Bwa mem 2},
             is            => q{rw},
             isa           => enum( [ 1, 2 ] ),
         )

--- a/lib/MIP/Cli/Mip/Analyse/Rd_dna_panel.pm
+++ b/lib/MIP/Cli/Mip/Analyse/Rd_dna_panel.pm
@@ -312,7 +312,7 @@ q{gatk_baserecalibration_known_sites, gatk_haplotypecaller_snp_known_set, gatk_v
             cmd_tags      => [q{Analysis recipe switch}],
             documentation => q{Align reads using Bwa mem 2},
             is            => q{rw},
-            isa           => enum( [ 1, 2 ] ),
+            isa           => enum( [ 0, 1, 2 ] ),
         )
     );
 

--- a/lib/MIP/Cli/Mip/Install.pm
+++ b/lib/MIP/Cli/Mip/Install.pm
@@ -23,7 +23,7 @@ use MIP::Definition qw{ get_parameter_from_definition_files };
 use MIP::Get::Parameter qw{ get_install_parameter_attribute };
 use MIP::Main::Install qw{ mip_install };
 
-our $VERSION = 1.20;
+our $VERSION = 1.21;
 
 extends(qw{ MIP::Cli::Mip });
 
@@ -229,7 +229,7 @@ sub _build_usage {
             isa           => ArrayRef [
                 enum(
                     [
-                        qw{ arriba bedtools blobfish bootstrapann bwa bwakit cadd chanjo
+                        qw{ arriba bedtools blobfish bootstrapann bwa bwakit bwa-mem2 cadd chanjo
                           chromograph cnvnator delly expansionhunter fastqc gatk gatk4 genmod
                           gffcompare htslib manta mip_scripts multiqc peddy picard plink preseq python
                           rhocall rseqc rtg-tools salmon sambamba smncopynumbercaller star star-fusion
@@ -251,7 +251,7 @@ sub _build_usage {
             isa           => ArrayRef [
                 enum(
                     [
-                        qw{ arriba bedtools blobfish bootstrapann bwa bwakit cadd chanjo
+                        qw{ arriba bedtools blobfish bootstrapann bwa bwakit bwa-mem2 cadd chanjo
                           chromograph cnvnator delly expansionhunter fastqc gatk gatk4 genmod
                           gffcompare htslib manta mip_scripts multiqc peddy picard plink preseq python
                           rhocall rseqc rtg-tools salmon sambamba smncopynumbercaller star star-fusion

--- a/lib/MIP/Environment/Executable.pm
+++ b/lib/MIP/Environment/Executable.pm
@@ -23,7 +23,7 @@ BEGIN {
     use base qw{ Exporter };
 
     # Set the version for version checking
-    our $VERSION = 1.09;
+    our $VERSION = 1.10;
 
     # Functions and variables which can be optionally exported
     our @EXPORT_OK = qw{
@@ -256,6 +256,11 @@ q?'my ($version) = /Version:\s+(\S+)/xms; if($version) {print $version;last;}'?,
         },
         bwa => {
             version_cmd => q{2>&1 >/dev/null},
+            version_regexp =>
+q?'my ($version) = /Version:\s+(\S+)/xms; if($version) {print $version;last;}'?,
+        },
+        q{bwa-mem2} => {
+            version_cmd => q{ version 2>&1 >/dev/null},
             version_regexp =>
 q?'my ($version) = /Version:\s+(\S+)/xms; if($version) {print $version;last;}'?,
         },

--- a/lib/MIP/Parameter.pm
+++ b/lib/MIP/Parameter.pm
@@ -26,7 +26,7 @@ BEGIN {
     use base qw{ Exporter };
 
     # Set the version for version checking
-    our $VERSION = 1.16;
+    our $VERSION = 1.17;
 
     # Functions and variables which can be optionally exported
     our @EXPORT_OK = qw{
@@ -890,6 +890,13 @@ sub set_custom_default_to_active_parameter {
             },
         },
         bwa_build_reference => {
+            method   => \&set_default_human_genome,
+            arg_href => {
+                active_parameter_href => $active_parameter_href,
+                parameter_name        => $parameter_name,
+            },
+        },
+        bwa_mem2_build_reference => {
             method   => \&set_default_human_genome,
             arg_href => {
                 active_parameter_href => $active_parameter_href,

--- a/lib/MIP/Parse/Gender.pm
+++ b/lib/MIP/Parse/Gender.pm
@@ -36,7 +36,7 @@ BEGIN {
     use base qw{ Exporter };
 
     # Set the version for version checking
-    our $VERSION = 1.09;
+    our $VERSION = 1.10;
 
     # Functions and variables which can be optionally exported
     our @EXPORT_OK = qw{ build_stream_file_cmd
@@ -277,7 +277,7 @@ sub parse_fastq_for_gender {
     use MIP::File_info qw{ get_sample_file_attribute };
     use MIP::Program::Gnu::Coreutils qw{ gnu_cut };
     use MIP::Program::Gnu::Software::Gnu_grep qw{ gnu_grep };
-    use MIP::Program::Bwa qw{ bwa_mem };
+    use MIP::Program::Bwa qw{ bwa_mem2_mem };
 
     my $other_gender_count = get_active_parameter_attribute(
         {
@@ -327,7 +327,7 @@ sub parse_fastq_for_gender {
         my @bwa_infiles = build_stream_file_cmd( { fastq_files_ref => \@fastq_files, } );
 
         ## Build bwa mem command
-        my @commands = bwa_mem(
+        my @commands = bwa_mem2_mem(
             {
                 idxbase                 => $referencefile_path,
                 infile_path             => $bwa_infiles[0],

--- a/lib/MIP/Program/Bwa.pm
+++ b/lib/MIP/Program/Bwa.pm
@@ -257,7 +257,7 @@ sub bwa_mem {
 
 sub bwa_mem2_mem {
 
-## Function : Perl wrapper for writing bwa mem 2 mem recipe to $filehandle. Based on bwa 0.7.17.
+## Function : Perl wrapper for writing bwa mem 2 mem recipe to $filehandle. Based on bwa mem 2 2.0.
 ## Returns  : @commands
 ## Arguments: $filehandle              => Sbatch filehandle to write to
 ##          : $idxbase                 => Idxbase (human genome references and bwa mem idx files)
@@ -393,7 +393,7 @@ sub bwa_mem2_mem {
 
 sub bwa_mem2_index {
 
-## Function : Perl wrapper for writing bwa mem 2 index recipe to $filehandle. Based on bwa 0.7.17.
+## Function : Perl wrapper for writing bwa mem 2 index recipe to $filehandle. Based on bwa mem 2 2.0.
 ## Returns  : @commands
 ## Arguments: $filehandle             => Filehandle to write to
 ##          : $prefix                 => Prefix of the index [same as fasta name]

--- a/lib/MIP/Program/Bwa.pm
+++ b/lib/MIP/Program/Bwa.pm
@@ -27,8 +27,96 @@ BEGIN {
     our $VERSION = 1.06;
 
     # Functions and variables which can be optionally exported
-    our @EXPORT_OK = qw{ bwa_mem run_bwamem bwa_index };
+    our @EXPORT_OK = qw{ bwa_index bwa_mem bwa_mem2_mem bwa_mem2_index run_bwamem };
 
+}
+
+sub bwa_index {
+
+## Function : Perl wrapper for writing bwa mem recipe to $filehandle. Based on bwa 0.7.15-r1140.
+## Returns  : @commands
+## Arguments: $construction_algorithm => BWT construction algorithm: bwtsw, is or rb2 [auto]
+##          : $filehandle             => Filehandle to write to
+##          : $prefix                 => Prefix of the index [same as fasta name]
+##          : $reference_genome       => Reference genome [.fasta]
+##          : $stderrfile_path        => Stderrfile path
+##          : $stderrfile_path_append => Append stderr info to file path
+##          : $stdoutfile_path        => Stdoutfile path
+
+    my ($arg_href) = @_;
+
+    ## Flatten argument(s)
+    my $construction_algorithm;
+    my $filehandle;
+    my $prefix;
+    my $reference_genome;
+    my $stderrfile_path;
+    my $stderrfile_path_append;
+    my $stdoutfile_path;
+
+    ## Default(s)
+
+    my $tmpl = {
+        construction_algorithm => {
+            allow       => [qw{ bwtsw rb2 }],
+            store       => \$construction_algorithm,
+            strict_type => 1,
+        },
+        filehandle => {
+            store => \$filehandle,
+        },
+        prefix => { defined => 1, required => 1, store => \$prefix, strict_type => 1, },
+        reference_genome => {
+            defined     => 1,
+            required    => 1,
+            store       => \$reference_genome,
+            strict_type => 1,
+        },
+        stderrfile_path => {
+            store       => \$stderrfile_path,
+            strict_type => 1,
+        },
+        stderrfile_path_append => {
+            store       => \$stderrfile_path_append,
+            strict_type => 1,
+        },
+        stdoutfile_path => {
+            store       => \$stdoutfile_path,
+            strict_type => 1,
+        },
+    };
+
+    check( $tmpl, $arg_href, 1 ) or croak q{Could not parse arguments!};
+
+    my @commands = qw{ bwa index };
+
+    push @commands, q{-p} . $SPACE . $prefix;
+
+    if ($construction_algorithm) {
+
+        push @commands, q{-a} . $SPACE . $construction_algorithm;
+    }
+
+    push @commands, $reference_genome;
+
+    push @commands,
+      unix_standard_streams(
+        {
+            stderrfile_path        => $stderrfile_path,
+            stderrfile_path_append => $stderrfile_path_append,
+            stdoutfile_path        => $stdoutfile_path,
+        }
+      );
+
+    unix_write_to_file(
+        {
+            commands_ref => \@commands,
+            filehandle   => $filehandle,
+            separator    => $SPACE,
+        }
+    );
+
+    return @commands;
 }
 
 sub bwa_mem {
@@ -167,6 +255,217 @@ sub bwa_mem {
     return @commands;
 }
 
+sub bwa_mem2_mem {
+
+## Function : Perl wrapper for writing bwa mem 2 mem recipe to $filehandle. Based on bwa 0.7.17.
+## Returns  : @commands
+## Arguments: $filehandle              => Sbatch filehandle to write to
+##          : $idxbase                 => Idxbase (human genome references and bwa mem idx files)
+##          : $infile_path             => Infile path (read 1 or interleaved i.e. read 1 and 2)
+##          : $interleaved_fastq_file  => Smart pairing
+##          : $mark_split_as_secondary => Mark shorter split hits as secondary
+##          : $read_group_header       => Read group header line, such as '@RG\tID:foo\tSM:bar'
+##          : $second_infile_path      => Second infile path (read 2)
+##          : $soft_clip_sup_align     => Use soft clipping for supplementary alignments
+##          : $stderrfile_path         => Stderrfile path
+##          : $stderrfile_path_append  => Stderrfile path append
+##          : $stdoutfile_path         => Stdoutfile path
+##          : $thread_number           => Number of threads
+
+    my ($arg_href) = @_;
+
+    ## Flatten argument(s)
+    my $filehandle;
+    my $idxbase;
+    my $infile_path;
+    my $read_group_header;
+    my $second_infile_path;
+    my $soft_clip_sup_align;
+    my $stderrfile_path;
+    my $stderrfile_path_append;
+    my $stdoutfile_path;
+    my $thread_number;
+
+    ## Default(s)
+    my $interleaved_fastq_file;
+    my $mark_split_as_secondary;
+
+    my $tmpl = {
+        filehandle => { store => \$filehandle, },
+        idxbase    => {
+            defined     => 1,
+            required    => 1,
+            store       => \$idxbase,
+            strict_type => 1,
+        },
+        infile_path => {
+            defined     => 1,
+            required    => 1,
+            store       => \$infile_path,
+            strict_type => 1,
+        },
+        interleaved_fastq_file => {
+            allow       => [ undef, 0, 1 ],
+            default     => 0,
+            store       => \$interleaved_fastq_file,
+            strict_type => 1,
+        },
+        mark_split_as_secondary => {
+            allow       => [ 0, 1 ],
+            default     => 0,
+            store       => \$mark_split_as_secondary,
+            strict_type => 1,
+        },
+        read_group_header   => { store => \$read_group_header,  strict_type => 1, },
+        second_infile_path  => { store => \$second_infile_path, strict_type => 1, },
+        soft_clip_sup_align => {
+            allow       => [ undef, 0, 1 ],
+            default     => 0,
+            store       => \$soft_clip_sup_align,
+            strict_type => 1,
+        },
+        stderrfile_path => { store => \$stderrfile_path, strict_type => 1, },
+        stderrfile_path_append =>
+          { store => \$stderrfile_path_append, strict_type => 1, },
+        stdoutfile_path => { store => \$stdoutfile_path, strict_type => 1, },
+        thread_number   => {
+            allow       => qr/ ^\d+$ /xms,
+            store       => \$thread_number,
+            strict_type => 1,
+        },
+    };
+
+    check( $tmpl, $arg_href, 1 ) or croak q{Could not parse arguments!};
+
+    my @commands = qw{ bwa-mem2 mem };
+
+    if ($thread_number) {
+
+        push @commands, q{-t} . $SPACE . $thread_number;
+    }
+    if ($interleaved_fastq_file) {
+
+        push @commands, q{-p};
+    }
+    if ($mark_split_as_secondary) {
+
+        push @commands, q{-M};
+    }
+    if ($soft_clip_sup_align) {
+
+        push @commands, q{-Y};
+    }
+    if ($read_group_header) {
+
+        push @commands, q{-R} . $SPACE . $read_group_header;
+    }
+
+    ## Human reference genome and bwa mem files
+    push @commands, $idxbase;
+
+    push @commands, $infile_path;
+
+    ## Read 2
+    if ($second_infile_path) {
+
+        push @commands, $second_infile_path;
+    }
+
+    push @commands,
+      unix_standard_streams(
+        {
+            stderrfile_path        => $stderrfile_path,
+            stderrfile_path_append => $stderrfile_path_append,
+            stdoutfile_path        => $stdoutfile_path,
+        }
+      );
+
+    unix_write_to_file(
+        {
+            commands_ref => \@commands,
+            filehandle   => $filehandle,
+            separator    => $SPACE,
+        }
+    );
+
+    return @commands;
+}
+
+sub bwa_mem2_index {
+
+## Function : Perl wrapper for writing bwa mem 2 index recipe to $filehandle. Based on bwa 0.7.17.
+## Returns  : @commands
+## Arguments: $filehandle             => Filehandle to write to
+##          : $prefix                 => Prefix of the index [same as fasta name]
+##          : $reference_genome       => Reference genome [.fasta]
+##          : $stderrfile_path        => Stderrfile path
+##          : $stderrfile_path_append => Append stderr info to file path
+##          : $stdoutfile_path        => Stdoutfile path
+
+    my ($arg_href) = @_;
+
+    ## Flatten argument(s)
+    my $filehandle;
+    my $prefix;
+    my $reference_genome;
+    my $stderrfile_path;
+    my $stderrfile_path_append;
+    my $stdoutfile_path;
+
+    ## Default(s)
+
+    my $tmpl = {
+        filehandle => {
+            store => \$filehandle,
+        },
+        prefix => { defined => 1, required => 1, store => \$prefix, strict_type => 1, },
+        reference_genome => {
+            defined     => 1,
+            required    => 1,
+            store       => \$reference_genome,
+            strict_type => 1,
+        },
+        stderrfile_path => {
+            store       => \$stderrfile_path,
+            strict_type => 1,
+        },
+        stderrfile_path_append => {
+            store       => \$stderrfile_path_append,
+            strict_type => 1,
+        },
+        stdoutfile_path => {
+            store       => \$stdoutfile_path,
+            strict_type => 1,
+        },
+    };
+
+    check( $tmpl, $arg_href, 1 ) or croak q{Could not parse arguments!};
+
+    my @commands = qw{ bwa-mem2 index };
+
+    push @commands, q{-p} . $SPACE . $prefix;
+
+    push @commands, $reference_genome;
+
+    push @commands,
+      unix_standard_streams(
+        {
+            stderrfile_path        => $stderrfile_path,
+            stderrfile_path_append => $stderrfile_path_append,
+            stdoutfile_path        => $stdoutfile_path,
+        }
+      );
+
+    unix_write_to_file(
+        {
+            commands_ref => \@commands,
+            filehandle   => $filehandle,
+            separator    => $SPACE,
+        }
+    );
+    return @commands;
+}
+
 sub run_bwamem {
 
 ## Function : Perl wrapper for writing run_bwamem recipe to $filehandle. Based on bwakit 0.7.12.
@@ -285,91 +584,4 @@ sub run_bwamem {
     return @commands;
 }
 
-sub bwa_index {
-
-## Function : Perl wrapper for writing bwa mem recipe to $filehandle. Based on bwa 0.7.15-r1140.
-## Returns  : @commands
-## Arguments: $construction_algorithm => BWT construction algorithm: bwtsw, is or rb2 [auto]
-##          : $filehandle             => Filehandle to write to
-##          : $prefix                 => Prefix of the index [same as fasta name]
-##          : $reference_genome       => Reference genome [.fasta]
-##          : $stderrfile_path        => Stderrfile path
-##          : $stderrfile_path_append => Append stderr info to file path
-##          : $stdoutfile_path        => Stdoutfile path
-
-    my ($arg_href) = @_;
-
-    ## Flatten argument(s)
-    my $construction_algorithm;
-    my $filehandle;
-    my $prefix;
-    my $reference_genome;
-    my $stderrfile_path;
-    my $stderrfile_path_append;
-    my $stdoutfile_path;
-
-    ## Default(s)
-
-    my $tmpl = {
-        construction_algorithm => {
-            allow       => [qw{ bwtsw rb2 }],
-            store       => \$construction_algorithm,
-            strict_type => 1,
-        },
-        filehandle => {
-            store => \$filehandle,
-        },
-        prefix => { defined => 1, required => 1, store => \$prefix, strict_type => 1, },
-        reference_genome => {
-            defined     => 1,
-            required    => 1,
-            store       => \$reference_genome,
-            strict_type => 1,
-        },
-        stderrfile_path => {
-            store       => \$stderrfile_path,
-            strict_type => 1,
-        },
-        stderrfile_path_append => {
-            store       => \$stderrfile_path_append,
-            strict_type => 1,
-        },
-        stdoutfile_path => {
-            store       => \$stdoutfile_path,
-            strict_type => 1,
-        },
-    };
-
-    check( $tmpl, $arg_href, 1 ) or croak q{Could not parse arguments!};
-
-    my @commands = qw{ bwa index };
-
-    push @commands, q{-p} . $SPACE . $prefix;
-
-    if ($construction_algorithm) {
-
-        push @commands, q{-a} . $SPACE . $construction_algorithm;
-    }
-
-    push @commands, $reference_genome;
-
-    push @commands,
-      unix_standard_streams(
-        {
-            stderrfile_path        => $stderrfile_path,
-            stderrfile_path_append => $stderrfile_path_append,
-            stdoutfile_path        => $stdoutfile_path,
-        }
-      );
-
-    unix_write_to_file(
-        {
-            commands_ref => \@commands,
-            filehandle   => $filehandle,
-            separator    => $SPACE,
-        }
-    );
-
-    return @commands;
-}
 1;

--- a/lib/MIP/Program/Gatk.pm
+++ b/lib/MIP/Program/Gatk.pm
@@ -26,7 +26,7 @@ BEGIN {
     use base qw{ Exporter };
 
     # Set the version for version checking
-    our $VERSION = 1.18;
+    our $VERSION = 1.19;
 
     # Functions and variables which can be optionally exported
     our @EXPORT_OK = qw{
@@ -2316,6 +2316,7 @@ sub gatk_haplotypecaller {
 ##          : $standard_min_confidence_threshold_for_calling => The minimum phred-scaled confidence threshold at which variants should be called
 ##          : $stderrfile_path                               => Stderrfile path
 ##          : $temp_directory                                => Redirect tmp files to java temp
+##          : $use_new_qual_calculator                       => Use the new AF model instead of the so-called exact model
 ##          : $verbosity                                     => Set the minimum level of logging
 ##          : $xargs_mode                                    => Set if the program will be executed via xargs
 
@@ -2345,6 +2346,7 @@ sub gatk_haplotypecaller {
     my $emit_ref_confidence;
     my $java_use_large_pages;
     my $linked_de_bruijn_graph;
+    my $use_new_qual_calculator;
     my $verbosity;
     my $xargs_mode;
 
@@ -2454,6 +2456,12 @@ sub gatk_haplotypecaller {
             store       => \$temp_directory,
             strict_type => 1,
         },
+        use_new_qual_calculator => {
+            allow       => [ undef, 0, 1 ],
+            default     => 1,
+            store       => \$use_new_qual_calculator,
+            strict_type => 1,
+        },
         verbosity => {
             allow       => [qw{ INFO ERROR FATAL }],
             default     => q{INFO},
@@ -2523,6 +2531,11 @@ sub gatk_haplotypecaller {
     if ($num_ref_samples_if_no_call) {
         push @commands,
           q{--num-reference-samples-if-no-call} . $SPACE . $num_ref_samples_if_no_call;
+    }
+
+    if ($use_new_qual_calculator) {
+
+        push @commands, q{--use-new-qual-calculator};
     }
 
     if ($linked_de_bruijn_graph) {

--- a/lib/MIP/Recipes/Analysis/Bwa_mem.pm
+++ b/lib/MIP/Recipes/Analysis/Bwa_mem.pm
@@ -30,7 +30,7 @@ BEGIN {
     our $VERSION = 1.24;
 
     # Functions and variables which can be optionally exported
-    our @EXPORT_OK = qw{ analysis_bwa_mem analysis_run_bwa_mem };
+    our @EXPORT_OK = qw{ analysis_bwa_mem analysis_bwa_mem2 analysis_run_bwa_mem };
 
 }
 
@@ -302,6 +302,434 @@ sub analysis_bwa_mem {
 
         # Prior to ALTs in reference genome
         bwa_mem(
+            {
+                filehandle              => $filehandle,
+                idxbase                 => $referencefile_path,
+                infile_path             => $fastq_file_path,
+                interleaved_fastq_file  => $is_interleaved_fastq,
+                mark_split_as_secondary => 1,
+                read_group_header       => $rg_header_line,
+                soft_clip_sup_align => $active_parameter_href->{bwa_soft_clip_sup_align},
+                second_infile_path  => $second_fastq_file_path,
+                thread_number       => $recipe_resource{core_number},
+            }
+        );
+
+        # Pipe SAM to BAM conversion of aligned reads
+        print {$filehandle} $PIPE . $SPACE;
+
+        samtools_view(
+            {
+                auto_detect_input_format => 1,
+                filehandle               => $filehandle,
+                infile_path              => q{-},
+                thread_number            => $recipe_resource{core_number},
+                uncompressed_bam_output  => $uncompressed_bam_output,
+                with_header              => 1,
+            }
+        );
+        print {$filehandle} $PIPE . $SPACE;
+
+        ## Set samtools sort input; Pipe from samtools view
+        my $samtools_sort_infile =
+          catfile( dirname( devnull() ), q{stdin} );
+
+        ## Increment paired end tracker
+        $paired_end_tracker++;
+
+        ## Sort the output from bwa mem
+        samtools_sort(
+            {
+                filehandle    => $filehandle,
+                infile_path   => $samtools_sort_infile,
+                outfile_path  => $outfile_path,
+                output_format => $output_format,
+                temp_file_path_prefix =>
+                  catfile( $temp_directory, q{samtools_sort_temp} ),
+                thread_number => $recipe_resource{core_number},
+                write_index   => 1,
+            }
+        );
+        say {$filehandle} $NEWLINE;
+
+        if ( $active_parameter_href->{bwa_mem_bamstats} ) {
+
+            samtools_stats(
+                {
+                    auto_detect_input_format => 1,
+                    filehandle               => $filehandle,
+                    infile_path              => $outfile_path,
+                    remove_overlap           => 1,
+                }
+            );
+            print {$filehandle} $PIPE . $SPACE;
+
+            ## Collect raw total sequences and reads mapped from samtools stats and calculate the percentage. Write it to stdout
+            _add_percentage_mapped_reads_from_samtools(
+                {
+                    filehandle   => $filehandle,
+                    outfile_path => $outfile_path_prefix . $DOT . q{stats},
+                }
+            );
+            say {$filehandle} $NEWLINE;
+        }
+
+        if (    $active_parameter_href->{bwa_mem_cram}
+            and $outfile_suffix ne q{.cram} )
+        {
+
+            say {$filehandle} q{## Create CRAM file from SAM|BAM};
+            samtools_view(
+                {
+                    filehandle         => $filehandle,
+                    infile_path        => $outfile_path,
+                    outfile_path       => $outfile_path_prefix . $DOT . q{cram},
+                    output_format      => q{cram},
+                    referencefile_path => $referencefile_path,
+                    with_header        => 1,
+                }
+            );
+            say {$filehandle} $NEWLINE;
+        }
+
+        close $filehandle;
+
+        if ( $recipe_mode == 1 ) {
+
+            if (    $active_parameter_href->{bwa_mem_cram}
+                and $outfile_suffix ne q{.cram} )
+            {
+
+                # Required for analysisRunStatus check downstream
+                my $qc_cram_path = $outfile_path_prefix . $DOT . q{cram};
+                set_recipe_metafile_in_sample_info(
+                    {
+                        infile           => $outfile_name_prefix,
+                        metafile_tag     => q{cram},
+                        path             => $qc_cram_path,
+                        recipe_name      => $recipe_name,
+                        sample_id        => $sample_id,
+                        sample_info_href => $sample_info_href,
+                    }
+                );
+
+            }
+            if ( $active_parameter_href->{bwa_mem_bamstats} ) {
+
+                ## Collect QC metadata info for later use
+                my $qc_stats_outfile = $outfile_path_prefix . $DOT . q{stats};
+                set_recipe_outfile_in_sample_info(
+                    {
+                        infile           => $outfile_name_prefix,
+                        path             => $qc_stats_outfile,
+                        recipe_name      => q{bamstats},
+                        sample_id        => $sample_id,
+                        sample_info_href => $sample_info_href,
+                    }
+                );
+            }
+
+            set_recipe_outfile_in_sample_info(
+                {
+                    infile           => $outfile_name_prefix,
+                    path             => $outfile_path,
+                    recipe_name      => $recipe_name,
+                    sample_id        => $sample_id,
+                    sample_info_href => $sample_info_href,
+                }
+            );
+
+            submit_recipe(
+                {
+                    base_command      => $profile_base_command,
+                    case_id           => $case_id,
+                    dependency_method => q{sample_to_sample_parallel},
+                    job_id_chain      => $job_id_chain,
+                    job_id_href       => $job_id_href,
+                    job_reservation_name =>
+                      $active_parameter_href->{job_reservation_name},
+                    log => $log,
+                    max_parallel_processes_count_href =>
+                      $file_info_href->{max_parallel_processes_count},
+                    recipe_file_path     => $recipe_file_path,
+                    recipe_files_tracker => $infile_index,
+                    sample_id            => $sample_id,
+                    submission_profile   => $active_parameter_href->{submission_profile},
+                }
+            );
+        }
+    }
+    return 1;
+}
+
+sub analysis_bwa_mem2 {
+
+## Function : Performs alignment of single and paired-end as well as interleaved fastq(.gz) files using the bwa mem 2 binary
+## Returns  :
+## Arguments: $active_parameter_href   => Active parameters for this analysis hash {REF}
+##          : $case_id                 => Family id
+##          : $file_info_href          => File info hash {REF}
+##          : $job_id_href             => Job id hash {REF}
+##          : $parameter_href          => Parameter hash {REF}
+##          : $profile_base_command    => Submission profile base command
+##          : $recipe_name             => Program name
+##          : $sample_id               => Sample id
+##          : $sample_info_href        => Info on samples and case hash {REF}
+##          : $temp_directory          => Temporary directory
+
+    my ($arg_href) = @_;
+
+    ## Flatten argument(s)
+    my $active_parameter_href;
+    my $file_info_href;
+    my $job_id_href;
+    my $parameter_href;
+    my $recipe_name;
+    my $sample_id;
+    my $sample_info_href;
+
+    ## Default(s)
+    my $case_id;
+    my $profile_base_command;
+    my $temp_directory;
+
+    my $tmpl = {
+        active_parameter_href => {
+            default     => {},
+            defined     => 1,
+            required    => 1,
+            store       => \$active_parameter_href,
+            strict_type => 1,
+        },
+        case_id => {
+            default     => $arg_href->{active_parameter_href}{case_id},
+            store       => \$case_id,
+            strict_type => 1,
+        },
+        file_info_href => {
+            default     => {},
+            defined     => 1,
+            required    => 1,
+            store       => \$file_info_href,
+            strict_type => 1,
+        },
+        job_id_href => {
+            default     => {},
+            defined     => 1,
+            required    => 1,
+            store       => \$job_id_href,
+            strict_type => 1,
+        },
+        parameter_href => {
+            default     => {},
+            defined     => 1,
+            required    => 1,
+            store       => \$parameter_href,
+            strict_type => 1,
+        },
+        profile_base_command => {
+            default     => q{sbatch},
+            store       => \$profile_base_command,
+            strict_type => 1,
+        },
+        recipe_name => {
+            defined     => 1,
+            required    => 1,
+            store       => \$recipe_name,
+            strict_type => 1,
+        },
+        sample_info_href => {
+            default     => {},
+            defined     => 1,
+            required    => 1,
+            store       => \$sample_info_href,
+            strict_type => 1,
+        },
+        sample_id => {
+            defined     => 1,
+            required    => 1,
+            store       => \$sample_id,
+            strict_type => 1,
+        },
+        temp_directory => {
+            default     => $arg_href->{active_parameter_href}{temp_directory},
+            store       => \$temp_directory,
+            strict_type => 1,
+        },
+    };
+
+    check( $tmpl, $arg_href, 1 ) or croak q{Could not parse arguments!};
+
+    use MIP::File_info qw{get_sample_file_attribute};
+    use MIP::Get::File qw{get_io_files};
+    use MIP::Get::Parameter qw{get_recipe_attributes get_recipe_resources};
+    use MIP::Parse::File qw{parse_io_outfiles};
+    use MIP::Processmanagement::Processes qw{submit_recipe};
+    use MIP::Program::Bwa qw{bwa_mem2_mem};
+    use MIP::Program::Samtools qw{samtools_stats samtools_sort samtools_view};
+    use MIP::Sample_info qw{
+      get_rg_header_line
+      set_recipe_metafile_in_sample_info
+      set_recipe_outfile_in_sample_info};
+    use MIP::Script::Setup_script qw{setup_script};
+
+    ### PREPROCESSING:
+
+    ## Retrieve logger object
+    my $log = Log::Log4perl->get_logger($LOG_NAME);
+
+    ## Set MIP recipe name
+    my $recipe_mode = $active_parameter_href->{$recipe_name};
+
+    ## Unpack parameters
+    ## Get the io infiles per chain and id
+    my %io = get_io_files(
+        {
+            id             => $sample_id,
+            file_info_href => $file_info_href,
+            parameter_href => $parameter_href,
+            recipe_name    => $recipe_name,
+            stream         => q{in},
+        }
+    );
+    my @infile_paths = @{ $io{in}{file_paths} };
+
+    my $job_id_chain = get_recipe_attributes(
+        {
+            parameter_href => $parameter_href,
+            recipe_name    => $recipe_name,
+            attribute      => q{chain},
+        }
+    );
+    my $referencefile_path = $active_parameter_href->{human_genome_reference};
+    my %recipe_resource    = get_recipe_resources(
+        {
+            active_parameter_href => $active_parameter_href,
+            recipe_name           => $recipe_name,
+        }
+    );
+
+    my %file_info_sample = get_sample_file_attribute(
+        {
+            file_info_href => $file_info_href,
+            sample_id      => $sample_id,
+        }
+    );
+
+    %io = (
+        %io,
+        parse_io_outfiles(
+            {
+                chain_id               => $job_id_chain,
+                id                     => $sample_id,
+                file_info_href         => $file_info_href,
+                file_name_prefixes_ref => $file_info_sample{no_direction_infile_prefixes},
+                outdata_dir            => $active_parameter_href->{outdata_dir},
+                parameter_href         => $parameter_href,
+                recipe_name            => $recipe_name,
+            }
+        )
+    );
+
+    my $outfile_suffix        = $io{out}{file_suffix};
+    my @outfile_name_prefixes = @{ $io{out}{file_name_prefixes} };
+    my @outfile_paths         = @{ $io{out}{file_paths} };
+    my @outfile_path_prefixes = @{ $io{out}{file_path_prefixes} };
+
+    ## Filehandles
+    # Create anonymous filehandle
+    my $filehandle = IO::Handle->new();
+
+    my $output_format;
+    my $uncompressed_bam_output;
+    if ( $outfile_suffix eq q{.bam} ) {
+
+        # Used downstream in samtools view
+        $uncompressed_bam_output = 1;
+        $output_format           = q{bam};
+    }
+
+    # Too avoid adjusting infile_index in submitting to jobs
+    my $paired_end_tracker = 0;
+
+    ## Perform per single-end or read pair
+  INFILE_PREFIX:
+    while ( my ( $infile_index, $infile_prefix ) =
+        each @{ $file_info_sample{no_direction_infile_prefixes} } )
+    {
+
+        ## Assign file features
+        my $outfile_name_prefix = $outfile_name_prefixes[$infile_index];
+        my $outfile_path        = $outfile_paths[$infile_index];
+        my $outfile_path_prefix = $outfile_path_prefixes[$infile_index];
+
+        # Collect interleaved status for fastq file
+        my $sequence_run_type = get_sample_file_attribute(
+            {
+                attribute      => q{sequence_run_type},
+                file_info_href => $file_info_href,
+                file_name      => $infile_prefix,
+                sample_id      => $sample_id,
+            }
+        );
+        my $is_interleaved_fastq = $sequence_run_type eq q{interleaved} ? 1 : 0;
+
+        ## Creates recipe directories (info & data & script), recipe script filenames and writes sbatch header
+        my ( $recipe_file_path, $recipe_info_path ) = setup_script(
+            {
+                active_parameter_href           => $active_parameter_href,
+                core_number                     => $recipe_resource{core_number},
+                directory_id                    => $sample_id,
+                filehandle                      => $filehandle,
+                job_id_href                     => $job_id_href,
+                memory_allocation               => $recipe_resource{memory},
+                log                             => $log,
+                recipe_directory                => $recipe_name,
+                recipe_name                     => $recipe_name,
+                process_time                    => $recipe_resource{time},
+                sleep                           => 1,
+                source_environment_commands_ref => $recipe_resource{load_env_ref},
+                temp_directory                  => $temp_directory,
+            }
+        );
+
+        ### SHELL:
+
+        ### BWA MEM
+        say {$filehandle} q{## Aligning reads with }
+          . $recipe_name
+          . q{ and sorting via Samtools};
+
+        ### Get parameters
+
+        ## Infile(s)
+        my $fastq_file_path = $infile_paths[$paired_end_tracker];
+        my $second_fastq_file_path;
+
+        # If second read direction is present
+        if ( $sequence_run_type eq q{paired-end} ) {
+
+            # Increment to collect correct read 2
+            $paired_end_tracker     = $paired_end_tracker + 1;
+            $second_fastq_file_path = $infile_paths[$paired_end_tracker];
+        }
+
+        ## Construct RG header line
+        my $rg_header_line = get_rg_header_line(
+            {
+                infile_prefix    => $infile_prefix,
+                platform         => $active_parameter_href->{platform},
+                sample_id        => $sample_id,
+                sample_info_href => $sample_info_href,
+                separator        => q{\t},
+            }
+        );
+        ## Add missing "@RG"
+        $rg_header_line =
+          $DOUBLE_QUOTE . q{@RG} . q{\t} . $rg_header_line . $DOUBLE_QUOTE;
+
+        # Prior to ALTs in reference genome
+        bwa_mem2_mem(
             {
                 filehandle              => $filehandle,
                 idxbase                 => $referencefile_path,

--- a/lib/MIP/Recipes/Analysis/Bwa_mem.pm
+++ b/lib/MIP/Recipes/Analysis/Bwa_mem.pm
@@ -19,7 +19,7 @@ use Readonly;
 
 ## MIPs lib/
 use MIP::Constants
-  qw{ $ASTERISK $DOT $DOUBLE_QUOTE $LOG_NAME $NEWLINE $PIPE $SPACE $UNDERSCORE };
+  qw{ $AMPERSAND $ASTERISK $DOT $DOUBLE_QUOTE $LOG_NAME $NEWLINE $PIPE $SPACE $UNDERSCORE };
 
 BEGIN {
 
@@ -27,7 +27,7 @@ BEGIN {
     use base qw{ Exporter };
 
     # Set the version for version checking
-    our $VERSION = 1.24;
+    our $VERSION = 1.25;
 
     # Functions and variables which can be optionally exported
     our @EXPORT_OK = qw{ analysis_bwa_mem analysis_bwa_mem2 analysis_run_bwa_mem };
@@ -138,7 +138,8 @@ sub analysis_bwa_mem {
     use MIP::Parse::File qw{parse_io_outfiles};
     use MIP::Processmanagement::Processes qw{submit_recipe};
     use MIP::Program::Bwa qw{bwa_mem};
-    use MIP::Program::Samtools qw{samtools_stats samtools_sort samtools_view};
+    use MIP::Program::Samtools
+      qw{ samtools_index samtools_stats samtools_sort samtools_view};
     use MIP::Sample_info qw{
       get_rg_header_line
       set_recipe_metafile_in_sample_info
@@ -347,10 +348,17 @@ sub analysis_bwa_mem {
                 temp_file_path_prefix =>
                   catfile( $temp_directory, q{samtools_sort_temp} ),
                 thread_number => $recipe_resource{core_number},
-                write_index   => 1,
             }
         );
         say {$filehandle} $NEWLINE;
+
+        samtools_index(
+            {
+                filehandle  => $filehandle,
+                infile_path => $outfile_path,
+            }
+        );
+        say {$filehandle} $AMPERSAND . $NEWLINE;
 
         if ( $active_parameter_href->{bwa_mem_bamstats} ) {
 
@@ -371,8 +379,9 @@ sub analysis_bwa_mem {
                     outfile_path => $outfile_path_prefix . $DOT . q{stats},
                 }
             );
-            say {$filehandle} $NEWLINE;
+            say {$filehandle} $AMPERSAND . $NEWLINE;
         }
+        say {$filehandle} q{wait} . $NEWLINE;
 
         if (    $active_parameter_href->{bwa_mem_cram}
             and $outfile_suffix ne q{.cram} )
@@ -560,18 +569,19 @@ sub analysis_bwa_mem2 {
 
     check( $tmpl, $arg_href, 1 ) or croak q{Could not parse arguments!};
 
-    use MIP::File_info qw{get_sample_file_attribute};
-    use MIP::Get::File qw{get_io_files};
-    use MIP::Get::Parameter qw{get_recipe_attributes get_recipe_resources};
-    use MIP::Parse::File qw{parse_io_outfiles};
-    use MIP::Processmanagement::Processes qw{submit_recipe};
-    use MIP::Program::Bwa qw{bwa_mem2_mem};
-    use MIP::Program::Samtools qw{samtools_stats samtools_sort samtools_view};
+    use MIP::File_info qw{ get_sample_file_attribute };
+    use MIP::Get::File qw{ get_io_files };
+    use MIP::Get::Parameter qw{ get_recipe_attributes get_recipe_resources };
+    use MIP::Parse::File qw{ parse_io_outfiles };
+    use MIP::Processmanagement::Processes qw{ submit_recipe };
+    use MIP::Program::Bwa qw{ bwa_mem2_mem };
+    use MIP::Program::Samtools
+      qw{ samtools_index samtools_stats samtools_sort samtools_view };
     use MIP::Sample_info qw{
       get_rg_header_line
       set_recipe_metafile_in_sample_info
-      set_recipe_outfile_in_sample_info};
-    use MIP::Script::Setup_script qw{setup_script};
+      set_recipe_outfile_in_sample_info };
+    use MIP::Script::Setup_script qw{ setup_script };
 
     ### PREPROCESSING:
 
@@ -775,10 +785,17 @@ sub analysis_bwa_mem2 {
                 temp_file_path_prefix =>
                   catfile( $temp_directory, q{samtools_sort_temp} ),
                 thread_number => $recipe_resource{core_number},
-                write_index   => 1,
             }
         );
         say {$filehandle} $NEWLINE;
+
+        samtools_index(
+            {
+                filehandle  => $filehandle,
+                infile_path => $outfile_path,
+            }
+        );
+        say {$filehandle} $AMPERSAND . $NEWLINE;
 
         if ( $active_parameter_href->{bwa_mem_bamstats} ) {
 
@@ -799,8 +816,9 @@ sub analysis_bwa_mem2 {
                     outfile_path => $outfile_path_prefix . $DOT . q{stats},
                 }
             );
-            say {$filehandle} $NEWLINE;
+            say {$filehandle} $AMPERSAND . $NEWLINE;
         }
+        say {$filehandle} q{wait} . $NEWLINE;
 
         if (    $active_parameter_href->{bwa_mem_cram}
             and $outfile_suffix ne q{.cram} )
@@ -994,7 +1012,8 @@ sub analysis_run_bwa_mem {
     use MIP::Parse::File qw{ parse_io_outfiles };
     use MIP::Processmanagement::Processes qw{ submit_recipe };
     use MIP::Program::Bwa qw{ bwa_mem run_bwamem };
-    use MIP::Program::Samtools qw{ samtools_stats samtools_sort samtools_view };
+    use MIP::Program::Samtools
+      qw{ samtools_index samtools_stats samtools_sort samtools_view };
     use MIP::Sample_info qw{
       get_rg_header_line
       set_recipe_metafile_in_sample_info
@@ -1194,6 +1213,14 @@ sub analysis_run_bwa_mem {
         );
         say {$filehandle} $NEWLINE;
 
+        samtools_index(
+            {
+                filehandle  => $filehandle,
+                infile_path => $outfile_path,
+            }
+        );
+        say {$filehandle} $AMPERSAND . $NEWLINE;
+
         if ( $active_parameter_href->{bwa_mem_bamstats} ) {
 
             samtools_stats(
@@ -1213,8 +1240,9 @@ sub analysis_run_bwa_mem {
                     outfile_path => $outfile_path_prefix . $DOT . q{stats},
                 }
             );
-            say {$filehandle} $NEWLINE;
+            say {$filehandle} $AMPERSAND . $NEWLINE;
         }
+        say {$filehandle} q{wait} . $NEWLINE;
 
         if (    $active_parameter_href->{bwa_mem_cram}
             and $outfile_suffix ne q{.cram} )
@@ -1368,7 +1396,7 @@ sub _add_percentage_mapped_reads_from_samtools {
 
     # End oneliner
     print {$filehandle} q?' ?;
-    say   {$filehandle} q{>} . $SPACE . $outfile_path;
+    print {$filehandle} q{>} . $SPACE . $outfile_path . $SPACE;
 
     return;
 }

--- a/lib/MIP/Recipes/Analysis/Gatk_haplotypecaller.pm
+++ b/lib/MIP/Recipes/Analysis/Gatk_haplotypecaller.pm
@@ -27,7 +27,7 @@ BEGIN {
     use base qw{ Exporter };
 
     # Set the version for version checking
-    our $VERSION = 1.26;
+    our $VERSION = 1.25;
 
     # Functions and variables which can be optionally exported
     our @EXPORT_OK =

--- a/lib/MIP/Recipes/Analysis/Gatk_haplotypecaller.pm
+++ b/lib/MIP/Recipes/Analysis/Gatk_haplotypecaller.pm
@@ -27,7 +27,7 @@ BEGIN {
     use base qw{ Exporter };
 
     # Set the version for version checking
-    our $VERSION = 1.25;
+    our $VERSION = 1.26;
 
     # Functions and variables which can be optionally exported
     our @EXPORT_OK =

--- a/lib/MIP/Recipes/Build/Bwa_prerequisites.pm
+++ b/lib/MIP/Recipes/Build/Bwa_prerequisites.pm
@@ -391,6 +391,7 @@ sub build_bwa_mem2_prerequisites {
 
     ## Constants
     Readonly my $MAX_RANDOM_NUMBER => 100_00;
+    Readonly my $MEMORY_ALLOCATION => 100;
     Readonly my $PROCESSING_TIME   => 3;
 
     ## Unpack parameters
@@ -418,6 +419,7 @@ sub build_bwa_mem2_prerequisites {
             filehandle                      => $filehandle,
             job_id_href                     => $job_id_href,
             log                             => $log,
+            memory_allocation               => $MEMORY_ALLOCATION,
             process_time                    => $PROCESSING_TIME,
             recipe_directory                => $recipe_name,
             recipe_name                     => $recipe_name,

--- a/lib/MIP/Recipes/Build/Bwa_prerequisites.pm
+++ b/lib/MIP/Recipes/Build/Bwa_prerequisites.pm
@@ -25,10 +25,10 @@ BEGIN {
     use base qw{ Exporter };
 
     # Set the version for version checking
-    our $VERSION = 1.06;
+    our $VERSION = 1.07;
 
     # Functions and variables which can be optionally exported
-    our @EXPORT_OK = qw{ build_bwa_prerequisites };
+    our @EXPORT_OK = qw{ build_bwa_prerequisites build_bwa_mem2_prerequisites };
 
 }
 
@@ -245,6 +245,241 @@ sub build_bwa_prerequisites {
 
         ## Ensure that this subrutine is only executed once
         $parameter_href->{bwa_build_reference}{build_file} = 0;
+    }
+
+    close $filehandle or $log->logcroak(q{Could not close filehandle});
+
+    if ( $recipe_mode == 1 ) {
+
+        submit_recipe(
+            {
+                base_command       => $profile_base_command,
+                dependency_method  => q{island_to_samples},
+                case_id            => $case_id,
+                job_id_href        => $job_id_href,
+                log                => $log,
+                job_id_chain       => $job_id_chain,
+                recipe_file_path   => $recipe_file_path,
+                sample_ids_ref     => \@{ $active_parameter_href->{sample_ids} },
+                submission_profile => $active_parameter_href->{submission_profile},
+            }
+        );
+    }
+    return 1;
+}
+
+sub build_bwa_mem2_prerequisites {
+
+## Function : Creates the Bwa mem 2 prerequisites
+## Returns  :
+## Arguments: $active_parameter_href        => Active parameters for this analysis hash {REF}
+##          : $case_id                      => Family id
+##          : $file_info_href               => File info hash {REF}
+##          : $human_genome_reference       => Human genome reference
+##          : $job_id_href                  => Job id hash {REF}
+##          : $log                          => Log object
+##          : $parameter_build_suffixes_ref => The bwa reference associated file endings {REF}
+##          : $parameter_href               => Parameter hash {REF}
+##          : $profile_base_command         => Submission profile base command
+##          : $recipe_name                  => Program name
+##          : $sample_info_href             => Info on samples and case hash {REF}
+##          : $temp_directory               => Temporary directory
+
+    my ($arg_href) = @_;
+
+    ## Flatten argument(s)
+    my $active_parameter_href;
+    my $file_info_href;
+    my $job_id_href;
+    my $log;
+    my $parameter_build_suffixes_ref;
+    my $parameter_href;
+    my $recipe_name;
+    my $sample_info_href;
+
+    ## Default(s)
+    my $case_id;
+    my $human_genome_reference;
+    my $profile_base_command;
+    my $temp_directory;
+
+    my $tmpl = {
+        active_parameter_href => {
+            default     => {},
+            defined     => 1,
+            required    => 1,
+            store       => \$active_parameter_href,
+            strict_type => 1,
+        },
+        case_id => {
+            default     => $arg_href->{active_parameter_href}{case_id},
+            store       => \$case_id,
+            strict_type => 1,
+        },
+        file_info_href => {
+            default     => {},
+            defined     => 1,
+            required    => 1,
+            store       => \$file_info_href,
+            strict_type => 1,
+        },
+        human_genome_reference => {
+            default     => $arg_href->{active_parameter_href}{human_genome_reference},
+            store       => \$human_genome_reference,
+            strict_type => 1,
+        },
+        job_id_href => {
+            default     => {},
+            defined     => 1,
+            required    => 1,
+            store       => \$job_id_href,
+            strict_type => 1,
+        },
+        log => {
+            defined  => 1,
+            required => 1,
+            store    => \$log,
+        },
+        parameter_build_suffixes_ref => {
+            default     => [],
+            defined     => 1,
+            required    => 1,
+            store       => \$parameter_build_suffixes_ref,
+            strict_type => 1,
+        },
+        parameter_href => {
+            default     => {},
+            defined     => 1,
+            required    => 1,
+            store       => \$parameter_href,
+            strict_type => 1,
+        },
+        profile_base_command => {
+            default     => q{sbatch},
+            store       => \$profile_base_command,
+            strict_type => 1,
+        },
+        recipe_name => {
+            defined     => 1,
+            required    => 1,
+            store       => \$recipe_name,
+            strict_type => 1,
+        },
+        sample_info_href => {
+            default     => {},
+            defined     => 1,
+            required    => 1,
+            store       => \$sample_info_href,
+            strict_type => 1,
+        },
+        temp_directory => {
+            default     => $arg_href->{active_parameter_href}{temp_directory},
+            store       => \$temp_directory,
+            strict_type => 1,
+        },
+    };
+
+    check( $tmpl, $arg_href, 1 ) or croak q{Could not parse arguments!};
+
+    use MIP::Get::Parameter qw{ get_recipe_resources };
+    use MIP::Language::Shell qw{ check_exist_and_move_file };
+    use MIP::Processmanagement::Processes qw{ submit_recipe };
+    use MIP::Program::Bwa qw{ bwa_mem2_index };
+    use MIP::Recipes::Build::Human_genome_prerequisites
+      qw{ build_human_genome_prerequisites };
+    use MIP::Script::Setup_script qw{ setup_script };
+
+    ## Constants
+    Readonly my $MAX_RANDOM_NUMBER => 100_00;
+    Readonly my $PROCESSING_TIME   => 3;
+
+    ## Unpack parameters
+    my $job_id_chain    = $parameter_href->{$recipe_name}{chain};
+    my $recipe_mode     = $active_parameter_href->{$recipe_name};
+    my %recipe_resource = get_recipe_resources(
+        {
+            active_parameter_href => $active_parameter_href,
+            recipe_name           => q{bwa_mem2},
+        }
+    );
+
+    ## filehandleS
+    # Create anonymous filehandle
+    my $filehandle = IO::Handle->new();
+
+    ## Generate a random integer between 0-10,000.
+    my $random_integer = int rand $MAX_RANDOM_NUMBER;
+
+    ## Creates recipe directories (info & data & script), recipe script filenames and writes sbatch header
+    my ($recipe_file_path) = setup_script(
+        {
+            active_parameter_href           => $active_parameter_href,
+            directory_id                    => $case_id,
+            filehandle                      => $filehandle,
+            job_id_href                     => $job_id_href,
+            log                             => $log,
+            process_time                    => $PROCESSING_TIME,
+            recipe_directory                => $recipe_name,
+            recipe_name                     => $recipe_name,
+            source_environment_commands_ref => $recipe_resource{load_env_ref},
+        }
+    );
+
+    build_human_genome_prerequisites(
+        {
+            active_parameter_href => $active_parameter_href,
+            filehandle            => $filehandle,
+            file_info_href        => $file_info_href,
+            job_id_href           => $job_id_href,
+            log                   => $log,
+            parameter_build_suffixes_ref =>
+              \@{ $file_info_href->{human_genome_reference_file_endings} },
+            parameter_href   => $parameter_href,
+            recipe_name      => $recipe_name,
+            random_integer   => $random_integer,
+            sample_info_href => $sample_info_href,
+        }
+    );
+
+    if ( $parameter_href->{bwa_mem2_build_reference}{build_file} == 1 ) {
+
+        $log->warn( q{Will try to create required }
+              . $human_genome_reference
+              . q{ index files before executing }
+              . $recipe_name );
+
+        say {$filehandle} q{## Building BWA index};
+
+        ## Get parameters
+        my $prefix = $human_genome_reference . $UNDERSCORE . $random_integer;
+        bwa_mem2_index(
+            {
+                filehandle       => $filehandle,
+                prefix           => $prefix,
+                reference_genome => $human_genome_reference,
+            }
+        );
+        say {$filehandle} $NEWLINE;
+
+      PREREQ_FILE:
+        foreach my $file ( @{$parameter_build_suffixes_ref} ) {
+
+            my $intended_file_path = $human_genome_reference . $file;
+            my $temporary_file_path =
+              $human_genome_reference . $UNDERSCORE . $random_integer . $file;
+
+            ## Checks if a file exists and moves the file in place if file is lacking or has a size of 0 bytes.
+            check_exist_and_move_file(
+                {
+                    filehandle          => $filehandle,
+                    intended_file_path  => $intended_file_path,
+                    temporary_file_path => $temporary_file_path,
+                }
+            );
+        }
+
+        ## Ensure that this subrutine is only executed once
+        $parameter_href->{bwa_mem2_build_reference}{build_file} = 0;
     }
 
     close $filehandle or $log->logcroak(q{Could not close filehandle});

--- a/lib/MIP/Recipes/Build/Rd_dna.pm
+++ b/lib/MIP/Recipes/Build/Rd_dna.pm
@@ -23,7 +23,7 @@ BEGIN {
     use base qw{ Exporter };
 
     # Set the version for version checking
-    our $VERSION = 1.03;
+    our $VERSION = 1.04;
 
     # Functions and variables which can be optionally exported
     our @EXPORT_OK = qw{ build_rd_dna_meta_files };
@@ -95,7 +95,8 @@ sub build_rd_dna_meta_files {
 
     check( $tmpl, $arg_href, 1 ) or croak q{Could not parse arguments!};
 
-    use MIP::Recipes::Build::Bwa_prerequisites qw{ build_bwa_prerequisites };
+    use MIP::Recipes::Build::Bwa_prerequisites
+      qw{ build_bwa_prerequisites build_bwa_mem2_prerequisites };
     use MIP::Recipes::Build::Capture_file_prerequisites
       qw{ build_capture_file_prerequisites };
     use MIP::Recipes::Build::Human_genome_prerequisites
@@ -104,6 +105,7 @@ sub build_rd_dna_meta_files {
 
     my %build_recipe = (
         bwa_build_reference                 => \&build_bwa_prerequisites,
+        bwa_mem2_build_reference            => \&build_bwa_mem2_prerequisites,
         exome_target_bed                    => \&build_capture_file_prerequisites,
         human_genome_reference_file_endings => \&build_human_genome_prerequisites,
         rtg_vcfeval_reference_genome        => \&build_rtg_prerequisites,

--- a/lib/MIP/Recipes/Pipeline/Analyse_rd_dna.pm
+++ b/lib/MIP/Recipes/Pipeline/Analyse_rd_dna.pm
@@ -25,7 +25,7 @@ BEGIN {
     use base qw{ Exporter };
 
     # Set the version for version checking
-    our $VERSION = 1.35;
+    our $VERSION = 1.36;
 
     # Functions and variables which can be optionally exported
     our @EXPORT_OK = qw{ parse_rd_dna pipeline_analyse_rd_dna };
@@ -547,6 +547,7 @@ sub pipeline_analyse_rd_dna {
         analysisrunstatus => \&analysis_analysisrunstatus,
         bcftools_mpileup  => \&analysis_bcftools_mpileup,
         bwa_mem           => undef,                          # Depends on genome build
+        bwa_mem2          => undef,
         cadd_ar           => \&analysis_cadd,
         chanjo_sexcheck   => \&analysis_chanjo_sex_check,
         chromograph_ar    => undef,                          # Depends on pedigree

--- a/lib/MIP/Recipes/Pipeline/Analyse_rd_dna_panel.pm
+++ b/lib/MIP/Recipes/Pipeline/Analyse_rd_dna_panel.pm
@@ -25,7 +25,7 @@ BEGIN {
     use base qw{ Exporter };
 
     # Set the version for version checking
-    our $VERSION = 1.19;
+    our $VERSION = 1.20;
 
     # Functions and variables which can be optionally exported
     our @EXPORT_OK = qw{ parse_rd_dna_panel pipeline_analyse_rd_dna_panel };
@@ -449,6 +449,7 @@ sub pipeline_analyse_rd_dna_panel {
     my %analysis_recipe = (
         analysisrunstatus            => \&analysis_analysisrunstatus,
         bwa_mem                      => undef,
+        bwa_mem2                     => undef,
         cadd_ar                      => \&analysis_cadd_panel,
         endvariantannotationblock    => \&analysis_endvariantannotationblock_panel,
         fastqc_ar                    => \&analysis_fastqc,

--- a/lib/MIP/Set/Analysis.pm
+++ b/lib/MIP/Set/Analysis.pm
@@ -23,7 +23,7 @@ BEGIN {
     use base qw{ Exporter };
 
     # Set the version for version checking
-    our $VERSION = 1.14;
+    our $VERSION = 1.15;
 
     # Functions and variables which can be optionally exported
     our @EXPORT_OK = qw{
@@ -75,7 +75,8 @@ sub set_recipe_bwa_mem {
 
     check( $tmpl, $arg_href, 1 ) or croak q{Could not parse arguments!};
 
-    use MIP::Recipes::Analysis::Bwa_mem qw{ analysis_bwa_mem analysis_run_bwa_mem };
+    use MIP::Recipes::Analysis::Bwa_mem
+      qw{ analysis_bwa_mem analysis_bwa_mem2 analysis_run_bwa_mem };
 
     Readonly my $GENOME_BUILD_VERSION_GRCH_PRIOR_ALTS => 37;
     Readonly my $GENOME_BUILD_VERSION_HG_PRIOR_ALTS   => 19;
@@ -92,7 +93,8 @@ sub set_recipe_bwa_mem {
 
         # Human genome version <= grch37
         # Use bwa mem recipe
-        $analysis_recipe_href->{bwa_mem} = \&analysis_bwa_mem;
+        $analysis_recipe_href->{bwa_mem}  = \&analysis_bwa_mem;
+        $analysis_recipe_href->{bwa_mem2} = \&analysis_bwa_mem2;
         return;
     }
 
@@ -108,7 +110,8 @@ sub set_recipe_bwa_mem {
 
     ## Human genome version <= hg19
     # Use bwa mem recipe
-    $analysis_recipe_href->{bwa_mem} = \&analysis_bwa_mem;
+    $analysis_recipe_href->{bwa_mem}  = \&analysis_bwa_mem;
+    $analysis_recipe_href->{bwa_mem2} = \&analysis_bwa_mem2;
 
     return;
 }

--- a/t/analysis_bwa_mem.t
+++ b/t/analysis_bwa_mem.t
@@ -89,6 +89,7 @@ my %file_info = test_mip_hashes(
         recipe_name   => $recipe_name,
     }
 );
+$file_info{ADM1059A1}{ADM1059A1_161011_HHJJCCCXY_NAATGCGC_lane7}{sequence_run_type} = q{paired-end};
 
 my %job_id;
 my %parameter = test_mip_hashes(

--- a/t/analysis_bwa_mem2.t
+++ b/t/analysis_bwa_mem2.t
@@ -1,0 +1,145 @@
+#!/usr/bin/env perl
+
+use 5.026;
+use Carp;
+use charnames qw{ :full :short };
+use English qw{ -no_match_vars };
+use File::Basename qw{ dirname };
+use File::Spec::Functions qw{ catdir catfile };
+use FindBin qw{ $Bin };
+use open qw{ :encoding(UTF-8) :std };
+use Params::Check qw{ allow check last_error };
+use Test::More;
+use utf8;
+use warnings qw{ FATAL utf8 };
+
+## CPANM
+use autodie qw { :all };
+use Modern::Perl qw{ 2018 };
+use Readonly;
+use Test::Trap;
+
+## MIPs lib/
+use lib catdir( dirname($Bin), q{lib} );
+use MIP::Constants qw{ $COLON $COMMA $SPACE };
+use MIP::Test::Fixtures qw{ test_log test_mip_hashes test_standard_cli };
+
+my $VERBOSE = 1;
+our $VERSION = 1.00;
+
+$VERBOSE = test_standard_cli(
+    {
+        verbose => $VERBOSE,
+        version => $VERSION,
+    }
+);
+
+## Constants
+Readonly my $GENOME_BUILD_VERSION_19 => 19;
+
+BEGIN {
+
+    use MIP::Test::Fixtures qw{ test_import };
+
+### Check all internal dependency modules and imports
+## Modules with import
+    my %perl_module = (
+        q{MIP::Recipes::Analysis::Bwa_mem} => [qw{ analysis_bwa_mem2 }],
+        q{MIP::Test::Fixtures} => [qw{ test_log test_mip_hashes test_standard_cli }],
+    );
+
+    test_import( { perl_module_href => \%perl_module, } );
+}
+
+use MIP::Recipes::Analysis::Bwa_mem qw{ analysis_bwa_mem2 };
+
+diag(   q{Test analysis_bwa_mem2 from Bwa_mem.pm v}
+      . $MIP::Recipes::Analysis::Bwa_mem::VERSION
+      . $COMMA
+      . $SPACE . q{Perl}
+      . $SPACE
+      . $PERL_VERSION
+      . $SPACE
+      . $EXECUTABLE_NAME );
+
+my $log = test_log( { log_name => q{MIP}, no_screen => 1, } );
+
+## Given parameters
+my $recipe_name    = q{bwa_mem2};
+my $slurm_mock_cmd = catfile( $Bin, qw{ data modules slurm-mock.pl } );
+
+my %active_parameter = test_mip_hashes(
+    {
+        mip_hash_name => q{active_parameter},
+        recipe_name   => $recipe_name,
+    }
+);
+$active_parameter{$recipe_name}                     = 1;
+$active_parameter{recipe_core_number}{$recipe_name} = 1;
+$active_parameter{recipe_time}{$recipe_name}        = 1;
+my $sample_id = $active_parameter{sample_ids}[0];
+$active_parameter{platform}               = q{ILLUMINA};
+$active_parameter{bwa_mem_cram}           = 1;
+$active_parameter{bwa_mem_bamstats}       = 1;
+$active_parameter{human_genome_reference} = q{grch37_homo_sapiens_-d5-.fasta};
+
+my %file_info = test_mip_hashes(
+    {
+        mip_hash_name => q{file_info},
+        recipe_name   => $recipe_name,
+    }
+);
+
+my %job_id;
+my %parameter = test_mip_hashes(
+    {
+        mip_hash_name => q{recipe_parameter},
+        recipe_name   => $recipe_name,
+    }
+);
+@{ $parameter{cache}{order_recipes_ref} } = ($recipe_name);
+$parameter{$recipe_name}{outfile_suffix} = q{.bam};
+
+my %sample_info = (
+    sample => {
+        $sample_id => {
+            file => {
+                ADM1059A1_161011_HHJJCCCXY_NAATGCGC_lane7 => {
+                    sequence_run_type   => q{single-end},
+                    read_direction_file => {
+                        ADM1059A1_161011_HHJJCCCXY_NAATGCGC_lane7_1 => {
+                            flowcell       => q{HHJJCCCXY},
+                            lane           => q{7},
+                            sample_barcode => q{NAATGCGC},
+                        },
+                    },
+                },
+            },
+        },
+    },
+);
+
+## Will test the bwamem with hg19
+$file_info{human_genome_reference_source}  = q{hg};
+$file_info{human_genome_reference_version} = $GENOME_BUILD_VERSION_19;
+my $is_ok = analysis_bwa_mem2(
+    {
+        active_parameter_href => \%active_parameter,
+        file_info_href        => \%file_info,
+        job_id_href           => \%job_id,
+        parameter_href        => \%parameter,
+        profile_base_command  => $slurm_mock_cmd,
+        recipe_name           => $recipe_name,
+        sample_id             => $sample_id,
+        sample_info_href      => \%sample_info,
+    }
+);
+
+## Then return TRUE
+ok( $is_ok,
+        q{ Executed analysis recipe }
+      . $recipe_name
+      . q{ with genome build }
+      . $GENOME_BUILD_VERSION_19 );
+
+done_testing();

--- a/t/build_bwa_mem2_prerequisites.t
+++ b/t/build_bwa_mem2_prerequisites.t
@@ -1,0 +1,105 @@
+#!/usr/bin/env perl
+
+use 5.026;
+use Carp;
+use charnames qw{ :full :short };
+use English qw{ -no_match_vars };
+use File::Basename qw{ dirname };
+use File::Spec::Functions qw{ catdir catfile };
+use FindBin qw{ $Bin };
+use open qw{ :encoding(UTF-8) :std };
+use Params::Check qw{ allow check last_error };
+use Test::More;
+use utf8;
+use warnings qw{ FATAL utf8 };
+
+## CPANM
+use autodie qw { :all };
+use Modern::Perl qw{ 2018 };
+use Readonly;
+
+## MIPs lib/
+use lib catdir( dirname($Bin), q{lib} );
+use MIP::Constants qw{ $COLON $COMMA $SPACE };
+use MIP::Test::Fixtures qw{ test_log test_mip_hashes test_standard_cli };
+
+my $VERBOSE = 1;
+our $VERSION = 1.00;
+
+$VERBOSE = test_standard_cli(
+    {
+        verbose => $VERBOSE,
+        version => $VERSION,
+    }
+);
+
+BEGIN {
+
+    use MIP::Test::Fixtures qw{ test_import };
+
+### Check all internal dependency modules and imports
+## Modules with import
+    my %perl_module = (
+        q{MIP::Recipes::Build::Bwa_prerequisites} => [qw{ build_bwa_mem2_prerequisites }],
+        q{MIP::Test::Fixtures} => [qw{ test_log test_mip_hashes test_standard_cli }],
+    );
+
+    test_import( { perl_module_href => \%perl_module, } );
+}
+
+use MIP::Recipes::Build::Bwa_prerequisites qw{ build_bwa_mem2_prerequisites };
+
+diag(   q{Test build_bwa_mem2_prerequisites from Bwa_prerequisites.pm v}
+      . $MIP::Recipes::Build::Bwa_prerequisites::VERSION
+      . $COMMA
+      . $SPACE . q{Perl}
+      . $SPACE
+      . $PERL_VERSION
+      . $SPACE
+      . $EXECUTABLE_NAME );
+
+my $log = test_log( { log_name => q{MIP}, no_screen => 1, } );
+
+## Given build parameters
+my $parameter_build_name = q{bwa_build_reference};
+my $recipe_name          = q{bwa_mem};
+my $slurm_mock_cmd       = catfile( $Bin, qw{ data modules slurm-mock.pl } );
+
+my %active_parameter = test_mip_hashes(
+    {
+        mip_hash_name => q{active_parameter},
+        recipe_name   => $recipe_name,
+    }
+);
+## Submission via slurm_mock
+$active_parameter{$recipe_name} = 1;
+
+my %file_info = test_mip_hashes(
+    {
+        mip_hash_name => q{file_info},
+        recipe_name   => $recipe_name,
+    }
+);
+my %job_id;
+my %parameter = test_mip_hashes( { mip_hash_name => q{recipe_parameter}, } );
+
+my %sample_info;
+
+my $is_ok = build_bwa_mem2_prerequisites(
+    {
+        active_parameter_href        => \%active_parameter,
+        file_info_href               => \%file_info,
+        job_id_href                  => \%job_id,
+        log                          => $log,
+        parameter_build_suffixes_ref => \@{ $file_info{$parameter_build_name} },
+        parameter_href               => \%parameter,
+        profile_base_command         => $slurm_mock_cmd,
+        recipe_name                  => $recipe_name,
+        sample_info_href             => \%sample_info,
+    }
+);
+
+## Then return TRUE
+ok( $is_ok, q{ Executed build bwa_mem prerequisites} );
+
+done_testing();

--- a/t/bwa_mem2_index.t
+++ b/t/bwa_mem2_index.t
@@ -1,0 +1,127 @@
+#!/usr/bin/env perl
+
+use 5.026;
+use Carp;
+use charnames qw{ :full :short };
+use English qw{ -no_match_vars };
+use File::Basename qw{ dirname };
+use File::Spec::Functions qw{ catdir };
+use FindBin qw{ $Bin };
+use open qw{ :encoding(UTF-8) :std };
+use Params::Check qw{ allow check last_error };
+use Test::More;
+use utf8;
+use warnings qw{ FATAL utf8 };
+
+## CPANM
+use autodie qw{ :all };
+use Modern::Perl qw{ 2018 };
+use Readonly;
+
+## MIPs lib/
+use lib catdir( dirname($Bin), q{lib} );
+use MIP::Constants qw{ $COMMA $SPACE };
+use MIP::Test::Commands qw{ test_function };
+use MIP::Test::Fixtures qw{ test_standard_cli };
+
+my $VERBOSE = 1;
+our $VERSION = 1.00;
+
+$VERBOSE = test_standard_cli(
+    {
+        verbose => $VERBOSE,
+        version => $VERSION,
+    }
+);
+
+BEGIN {
+
+    use MIP::Test::Fixtures qw{ test_import };
+
+### Check all internal dependency modules and imports
+## Modules with import
+    my %perl_module = (
+        q{MIP::Program::Bwa}   => [qw{ bwa_mem2_index }],
+        q{MIP::Test::Fixtures} => [qw{ test_standard_cli }],
+    );
+
+    test_import( { perl_module_href => \%perl_module, } );
+}
+
+use MIP::Program::Bwa qw{ bwa_mem2_index };
+
+diag(   q{Test bwa_mem2_index from Bwa.pm v}
+      . $MIP::Program::Bwa::VERSION
+      . $COMMA
+      . $SPACE . q{Perl}
+      . $SPACE
+      . $PERL_VERSION
+      . $SPACE
+      . $EXECUTABLE_NAME );
+
+## Base arguments
+my @function_base_commands = qw{ bwa-mem2 index };
+
+my %base_argument = (
+    filehandle => {
+        input           => undef,
+        expected_output => \@function_base_commands,
+    },
+    stderrfile_path => {
+        input           => q{stderrfile.test},
+        expected_output => q{2> stderrfile.test},
+    },
+    stderrfile_path_append => {
+        input           => q{stderrfile.test},
+        expected_output => q{2>> stderrfile.test},
+    },
+    stdoutfile_path => {
+        input           => q{stdoutfile.test},
+        expected_output => q{1> stdoutfile.test},
+    },
+);
+
+## Can be duplicated with %base_argument and/or %specific_argument
+## to enable testing of each individual argument
+my %required_argument = (
+    prefix => {
+        input           => q{test_file_prefix},
+        expected_output => q{test_file_prefix},
+    },
+    reference_genome => {
+        input           => q{test_file.fasta},
+        expected_output => q{test_file.fasta},
+    },
+);
+
+my %specific_argument = (
+    prefix => {
+        input           => q{test_file},
+        expected_output => q{-p test_file},
+    },
+    reference_genome => {
+        input           => q{test_file.fasta},
+        expected_output => q{test_file.fasta},
+    },
+);
+
+## Coderef - enables generalized use of generate call
+my $module_function_cref = \&bwa_mem2_index;
+
+## Test both base and function specific arguments
+my @arguments = ( \%base_argument, \%specific_argument );
+
+ARGUMENT_HASH_REF:
+foreach my $argument_href (@arguments) {
+    my @commands = test_function(
+        {
+            argument_href              => $argument_href,
+            do_test_base_command       => 1,
+            function_base_commands_ref => \@function_base_commands,
+            module_function_cref       => $module_function_cref,
+            required_argument_href     => \%required_argument,
+        }
+    );
+}
+
+done_testing();

--- a/t/bwa_mem2_mem.t
+++ b/t/bwa_mem2_mem.t
@@ -1,0 +1,169 @@
+#!/usr/bin/env perl
+
+use 5.026;
+use Carp;
+use charnames qw{ :full :short };
+use English qw{ -no_match_vars };
+use File::Basename qw{ dirname };
+use File::Spec::Functions qw{ catdir };
+use FindBin qw{ $Bin };
+use open qw{ :encoding(UTF-8) :std };
+use Params::Check qw{ allow check last_error };
+use Test::More;
+use utf8;
+use warnings qw{ FATAL utf8 };
+
+## CPANM
+use autodie qw{ :all };
+use Modern::Perl qw{ 2018 };
+use Readonly;
+
+## MIPs lib/
+use lib catdir( dirname($Bin), q{lib} );
+use MIP::Constants qw{ $COMMA $DOUBLE_QUOTE $SPACE $TAB };
+use MIP::Test::Commands qw{ test_function };
+use MIP::Test::Fixtures qw{ test_standard_cli };
+
+my $VERBOSE = 1;
+our $VERSION = 1.00;
+
+$VERBOSE = test_standard_cli(
+    {
+        verbose => $VERBOSE,
+        version => $VERSION,
+    }
+);
+
+BEGIN {
+
+    use MIP::Test::Fixtures qw{ test_import };
+
+### Check all internal dependency modules and imports
+## Modules with import
+    my %perl_module = (
+        q{MIP::Program::Bwa}   => [qw{ bwa_mem2_mem }],
+        q{MIP::Test::Fixtures} => [qw{ test_standard_cli }],
+    );
+
+    test_import( { perl_module_href => \%perl_module, } );
+}
+
+use MIP::Program::Bwa qw{ bwa_mem2_mem };
+
+diag(   q{Test bwa_mem2_mem from Bwa.pm v}
+      . $MIP::Program::Bwa::VERSION
+      . $COMMA
+      . $SPACE . q{Perl}
+      . $SPACE
+      . $PERL_VERSION
+      . $SPACE
+      . $EXECUTABLE_NAME );
+
+## Base arguments
+my @function_base_commands = qw{ bwa-mem2 mem };
+
+## Read group header line
+my @read_group_headers = (
+    $DOUBLE_QUOTE . q{@RG},
+    q{ID:} . q{1_140128_H8AHNADXX_1-1-2A_GATCAG_1} . $TAB,
+    q{SM:} . q{1-1-2A},
+    q{PL:} . q{ILLUMINA} . $DOUBLE_QUOTE,
+);
+
+my %base_argument = (
+    filehandle => {
+        input           => undef,
+        expected_output => \@function_base_commands,
+    },
+    stderrfile_path => {
+        input           => q{stderrfile.test},
+        expected_output => q{2> stderrfile.test},
+    },
+    stderrfile_path_append => {
+        input           => q{stderrfile.test},
+        expected_output => q{2>> stderrfile.test},
+    },
+    stdoutfile_path => {
+        input           => q{test_outfile.bam},
+        expected_output => q{1> test_outfile.bam},
+    },
+);
+
+## Can be duplicated with %base and/or %specific to enable testing of each individual argument
+my %required_argument = (
+    filehandle => {
+        input           => undef,
+        expected_output => \@function_base_commands,
+    },
+    idxbase => {
+        input           => q{grch37_homo_sapiens_-d5-.fasta},
+        expected_output => q{grch37_homo_sapiens_-d5-.fasta},
+    },
+    infile_path => {
+        input           => q{test_infile.fastq},
+        expected_output => q{test_infile.fastq},
+    },
+);
+
+my %specific_argument = (
+    infile_path => {
+        input           => q{test_infile_1.fastq},
+        expected_output => q{test_infile_1.fastq},
+    },
+    interleaved_fastq_file => {
+        input           => 1,
+        expected_output => q{-p},
+    },
+    mark_split_as_secondary => {
+        input           => 1,
+        expected_output => q{-M},
+    },
+    read_group_header => {
+        input           => ( join $SPACE,                  @read_group_headers ),
+        expected_output => ( q{-R} . $SPACE . join $SPACE, @read_group_headers ),
+    },
+    second_infile_path => {
+        input           => q{test_infile_2.fastq},
+        expected_output => q{test_infile_2.fastq},
+    },
+    soft_clip_sup_align => {
+        input           => 1,
+        expected_output => q{-Y},
+    },
+    stderrfile_path => {
+        input           => q{stderrfile.test},
+        expected_output => q{2> stderrfile.test},
+    },
+    stderrfile_path_append => {
+        input           => q{stderrfile.test},
+        expected_output => q{2>> stderrfile.test},
+    },
+    stdoutfile_path => {
+        input           => q{test_outfile.bam},
+        expected_output => q{1> test_outfile.bam},
+    },
+    thread_number => {
+        input           => 2,
+        expected_output => q{-t 2},
+    },
+);
+
+## Coderef - enables generalized use of generate call
+my $module_function_cref = \&bwa_mem2_mem;
+
+## Test both base and function specific arguments
+my @arguments = ( \%required_argument, \%specific_argument );
+
+foreach my $argument_href (@arguments) {
+    my @commands = test_function(
+        {
+            argument_href              => $argument_href,
+            do_test_base_command       => 1,
+            function_base_commands_ref => \@function_base_commands,
+            module_function_cref       => $module_function_cref,
+            required_argument_href     => \%required_argument,
+        }
+    );
+}
+
+done_testing();

--- a/t/data/test_data/recipe_parameter.yaml
+++ b/t/data/test_data/recipe_parameter.yaml
@@ -3,6 +3,10 @@ bwa_build_reference:
   build_file: 1
 bwa_mem:
   chain: TEST
+bwa_mem2_build_reference:
+  build_file: 1
+bwa_mem2:
+  chain: TEST
 exome_target_bed:
   build_file: 1
 human_genome_reference_file_endings:

--- a/t/gatk_haplotypecaller.t
+++ b/t/gatk_haplotypecaller.t
@@ -25,7 +25,7 @@ use MIP::Test::Commands qw{ test_function };
 use MIP::Test::Fixtures qw{ test_standard_cli };
 
 my $VERBOSE = 1;
-our $VERSION = 1.05;
+our $VERSION = 1.06;
 
 $VERBOSE = test_standard_cli(
     {
@@ -143,6 +143,10 @@ my %specific_argument = (
         input           => $STANDARD_MIN_CONFIDENCE_THRESHOLD_FOR_CALLING,
         expected_output => q{--standard-min-confidence-threshold-for-calling }
           . $STANDARD_MIN_CONFIDENCE_THRESHOLD_FOR_CALLING,
+    },
+    use_new_qual_calculator => {
+        input           => 1,
+        expected_output => q{--use-new-qual-calculator},
     },
 );
 

--- a/t/set_recipe_bwa_mem.t
+++ b/t/set_recipe_bwa_mem.t
@@ -24,7 +24,7 @@ use MIP::Constants qw{ $COMMA $SPACE };
 use MIP::Test::Fixtures qw{ test_standard_cli };
 
 my $VERBOSE = 1;
-our $VERSION = 1.00;
+our $VERSION = 1.01;
 
 $VERBOSE = test_standard_cli(
     {
@@ -41,7 +41,7 @@ BEGIN {
 ## Modules with import
     my %perl_module = (
         q{MIP::Recipes::Analysis::Bwa_mem} =>
-          [qw{ analysis_bwa_mem analysis_run_bwa_mem }],
+          [qw{ analysis_bwa_mem analysis_bwa_mem2 analysis_run_bwa_mem }],
         q{MIP::Set::Analysis}  => [qw{ set_recipe_bwa_mem }],
         q{MIP::Test::Fixtures} => [qw{ test_standard_cli }],
     );
@@ -50,7 +50,8 @@ BEGIN {
 }
 
 use MIP::Set::Analysis qw{ set_recipe_bwa_mem };
-use MIP::Recipes::Analysis::Bwa_mem qw{ analysis_bwa_mem analysis_run_bwa_mem };
+use MIP::Recipes::Analysis::Bwa_mem
+  qw{ analysis_bwa_mem analysis_bwa_mem2 analysis_run_bwa_mem };
 
 diag(   q{Test set_recipe_bwa_mem from Analysis.pm v}
       . $MIP::Set::Analysis::VERSION
@@ -77,7 +78,11 @@ set_recipe_bwa_mem(
         human_genome_reference_version => $GENOME_BUILD_VERSION_19,
     }
 );
-my %expected_analysis_recipe = ( bwa_mem => \&analysis_bwa_mem, );
+my %expected_analysis_recipe = (
+    bwa_mem  => \&analysis_bwa_mem,
+    bwa_mem2 => \&analysis_bwa_mem2,
+);
+
 ## Then set bwa mem recipe
 is_deeply( \%analysis_recipe, \%expected_analysis_recipe,
     q{Set bwa mem recipe for } . $reference_source . $GENOME_BUILD_VERSION_19 );
@@ -105,7 +110,8 @@ set_recipe_bwa_mem(
         human_genome_reference_version => $GENOME_BUILD_VERSION_37,
     }
 );
-$expected_analysis_recipe{bwa_mem} = \&analysis_bwa_mem;
+$expected_analysis_recipe{bwa_mem}  = \&analysis_bwa_mem;
+$expected_analysis_recipe{bwa_mem2} = \&analysis_bwa_mem2;
 
 ## Then set bwa mem recipe
 is_deeply( \%analysis_recipe, \%expected_analysis_recipe,

--- a/templates/mip_install_config.yaml
+++ b/templates/mip_install_config.yaml
@@ -83,7 +83,7 @@ container:
   gatk4:
     executable:
       gatk:
-    uri: docker.io/broadinstitute/gatk:4.1.4.0
+    uri: docker.io/broadinstitute/gatk:4.1.3.0
   genmod:
     executable:
       genmod:

--- a/templates/mip_install_config.yaml
+++ b/templates/mip_install_config.yaml
@@ -39,6 +39,10 @@ container:
       typeHLA-selctg.js:
       seqtk:
     uri: docker.io/clinicalgenomics/bwakit:0.7.15
+  bwa-mem2:
+    executable:
+      bwa-mem2:
+    uri: docker.io/clinicalgenomics/bwa-mem2:2.0
   bedtools:
     executable:
       bedtools:

--- a/templates/program_test_cmds.yaml
+++ b/templates/program_test_cmds.yaml
@@ -18,6 +18,8 @@ bwa:
   path: 'bwa'
 bwakit:
   path: 'run-bwamem'
+bwa-mem2:
+  path: 'bwa-mem2'
 cadd:
   execution: 'CADD.sh -h'
 chanjo:


### PR DESCRIPTION
### This PR adds | fixes:

- Bwa_mem2 and keeps bwa_mem for backwards compatibility
- New bwa mem index command and automated build of fasta index required for bwa_mem2
- Default is now to use Bwa_mem2 and not bwa_mem
- Roll-back GATK to 4.1.3.0 to enable more controllled upgrade in later PR

### How to test:

- Automatic and continuous test suite

### Expected outcome:
- [x] Installation, unit and integration test suite pass
- [x] Roughly 30-40% faster alignment time
- [x] No significant changes in sensitivity or precision due to the new alignment method

### Review:
- [ ] Code review
- [x] Tests pass

This [version](https://semver.org/) is a:
- [ ] **MAJOR** - when you make incompatible API changes. If applicable record manual test results in PR header
- [x] **MINOR** - when you add functionality in a backwards compatible manner. If applicable record manual test results in PR header
- [ ] **PATCH** - when you make backwards compatible bug fixes or documentation/instructions
