### PR TITLE
Feature/telomerecat

### DIFF
--- a/definitions/install_parameters.yaml
+++ b/definitions/install_parameters.yaml
@@ -132,6 +132,7 @@ rd_dna:
     - smncopynumbercaller
     - stranger
     - svdb
+    - telomerecat
     - tiddit
     - ucsc
     - upd

--- a/definitions/rd_dna_initiation_map.yaml
+++ b/definitions/rd_dna_initiation_map.yaml
@@ -26,6 +26,8 @@ CHAIN_ALL:
       - smncopynumbercaller
     - CHAIN_CYRIUS:
       - star_caller
+    - CHAIN_TEL:
+      - telomerecat_ar
     - CHAIN_PTMME:
       - picardtools_collectmultiplemetrics
     - CHAIN_PTCHSM:

--- a/definitions/rd_dna_parameters.yaml
+++ b/definitions/rd_dna_parameters.yaml
@@ -182,6 +182,7 @@ recipe_core_number:
     sv_reformat: 1
     sv_varianteffectpredictor: 0
     sv_vcfparser: 13
+    telomerecat_ar: 12
     tiddit_coverage: 1
     upd_ar: 1
     varg_ar: 1
@@ -293,6 +294,7 @@ recipe_time:
     sv_reformat: 1
     sv_varianteffectpredictor: 10
     sv_vcfparser: 2
+    telomerecat_ar: 1
     tiddit: 20
     tiddit_coverage: 5
     upd_ar: 1
@@ -635,6 +637,23 @@ star_caller:
   program_executables:
     - star_caller.py
   type: recipe
+telomerecat_ar:
+  analysis_mode: case
+  associated_recipe:
+    - mip
+  data_type: SCALAR
+  default: 1
+  file_tag: _tel
+  outfile_suffix: ".csv"
+  program_executables:
+    - telomerecat
+  type: recipe
+telomerecat_use_sample_id_as_display_name:
+  associated_recipe:
+    - telomerecat_ar
+  data_type: SCALAR
+  default: 0
+  type: mip
 tiddit_coverage:
   analysis_mode: sample
   associated_recipe:

--- a/lib/MIP/Cli/Mip/Analyse/Rd_dna.pm
+++ b/lib/MIP/Cli/Mip/Analyse/Rd_dna.pm
@@ -17,7 +17,7 @@ use Moose::Util::TypeConstraints;
 ## MIPs lib
 use MIP::Main::Analyse qw{ mip_analyse };
 
-our $VERSION = 1.59;
+our $VERSION = 1.60;
 
 extends(qw{ MIP::Cli::Mip::Analyse });
 
@@ -571,6 +571,24 @@ q{Default: grch37_dbsnp_-138-.vcf, grch37_1000g_indels_-phase1-.vcf, grch37_mill
             documentation => q{CYP2D6 allele analysis},
             is            => q{rw},
             isa           => enum( [ 0, 1, 2 ] ),
+        )
+    );
+
+    option(
+        q{telomerecat} => (
+            cmd_tags      => [q{Analysis recipe switch}],
+            documentation => q{Telomere analysis},
+            is            => q{rw},
+            isa           => enum( [ 0, 1, 2 ] ),
+        )
+    );
+
+    option(
+        q{telomerecat_use_sample_id_as_display_name} => (
+            cmd_tags      => [q{Default: 0}],
+            documentation => q{Use sample id as display name for telomerecat outfile},
+            is            => q{rw},
+            isa           => Bool,
         )
     );
 

--- a/lib/MIP/Cli/Mip/Install.pm
+++ b/lib/MIP/Cli/Mip/Install.pm
@@ -23,7 +23,7 @@ use MIP::Definition qw{ get_parameter_from_definition_files };
 use MIP::Get::Parameter qw{ get_install_parameter_attribute };
 use MIP::Main::Install qw{ mip_install };
 
-our $VERSION = 1.21;
+our $VERSION = 1.22;
 
 extends(qw{ MIP::Cli::Mip });
 
@@ -233,8 +233,8 @@ sub _build_usage {
                           chromograph cnvnator cyrius delly expansionhunter fastqc gatk gatk4 genmod
                           gffcompare htslib manta mip_scripts multiqc peddy picard plink preseq python
                           rhocall rseqc rtg-tools salmon sambamba smncopynumbercaller star star-fusion
-                          stranger stringtie svdb tiddit trim-galore ucsc upd utilities varg
-                          variant_integrity vcf2cytosure vcfanno vep vts }
+                          stranger stringtie svdb telomerecat tiddit trim-galore ucsc upd utilities
+                          varg variant_integrity vcf2cytosure vcfanno vep vts }
                     ]
                 ),
             ],
@@ -255,8 +255,8 @@ sub _build_usage {
                           chromograph cnvnator cyrius delly expansionhunter fastqc gatk gatk4 genmod
                           gffcompare htslib manta mip_scripts multiqc peddy picard plink preseq python
                           rhocall rseqc rtg-tools salmon sambamba smncopynumbercaller star star-fusion
-                          stranger stringtie svdb tiddit trim-galore ucsc upd utilities varg
-                          variant_integrity vcf2cytosure vcfanno vep vts }
+                          stranger stringtie svdb telomerecat tiddit trim-galore ucsc upd utilities
+                          varg variant_integrity vcf2cytosure vcfanno vep vts }
                     ]
                 ),
             ],

--- a/lib/MIP/Environment/Container.pm
+++ b/lib/MIP/Environment/Container.pm
@@ -23,7 +23,7 @@ BEGIN {
     use base qw{ Exporter };
 
     # Set the version for version checking
-    our $VERSION = 1.01;
+    our $VERSION = 1.02;
 
     # Functions and variables which can be optionally exported
     our @EXPORT_OK =
@@ -215,7 +215,7 @@ sub parse_container_uri {
 
     return if $container_manager eq q{docker};
 
-    if ( ${$uri_ref} =~ /\A docker[.]io /xms ) {
+    if ( ${$uri_ref} =~ /\A quay|docker[.]io /xms ) {
 
         ${$uri_ref} = q{docker://} . ${$uri_ref};
     }

--- a/lib/MIP/Environment/Executable.pm
+++ b/lib/MIP/Environment/Executable.pm
@@ -23,7 +23,7 @@ BEGIN {
     use base qw{ Exporter };
 
     # Set the version for version checking
-    our $VERSION = 1.10;
+    our $VERSION = 1.11;
 
     # Functions and variables which can be optionally exported
     our @EXPORT_OK = qw{
@@ -427,6 +427,10 @@ q?'my ($version) = /version:\s+(\S+)/xms; if($version) {print $version;last;}'?,
             version_cmd => q{--version},
             version_regexp =>
 q?'my ($version) = /\(htslib\)\s+(\S+)/xms; if($version) {print $version;last;}'?,
+        },
+        telomerecat => {
+            version_regexp =>
+q?'BEGIN {my $match = 0}; if ($match) {my ($version) = /(\d+.\d+.\d+)/; print $version; last;} $match=1 if (/\A Version: /xms);'?,
         },
         q{TIDDIT.py} => {
             version_cmd => q{--version},

--- a/lib/MIP/Language/Perl.pm
+++ b/lib/MIP/Language/Perl.pm
@@ -25,7 +25,7 @@ BEGIN {
     use base qw{ Exporter };
 
     # Set the version for version checking
-    our $VERSION = 1.12;
+    our $VERSION = 1.13;
 
     our @EXPORT_OK = qw{ perl_base perl_nae_oneliners };
 }
@@ -38,7 +38,9 @@ sub perl_base {
 ## Returns  :
 ## Arguments: $autosplit    => Turns on autosplit mode when used with a -n or -p
 ##          : $command_line => Enter one line of program
+##          : $inplace      => In place edit
 ##          : $n            => Iterate over filename arguments
+##          : $p            => Print line
 
     my ($arg_href) = @_;
 
@@ -47,7 +49,9 @@ sub perl_base {
     ## Default(s)
     my $autosplit;
     my $command_line;
+    my $inplace;
     my $n;
+    my $print;
 
     my $tmpl = {
         autosplit => {
@@ -62,10 +66,22 @@ sub perl_base {
             store       => \$command_line,
             strict_type => 1,
         },
+        inplace => {
+            allow       => [ undef, 0, 1 ],
+            default     => 0,
+            store       => \$inplace,
+            strict_type => 1,
+        },
         n => {
             allow       => [ undef, 0, 1 ],
             default     => 0,
             store       => \$n,
+            strict_type => 1,
+        },
+        print => {
+            allow       => [ undef, 0, 1 ],
+            default     => 0,
+            store       => \$print,
             strict_type => 1,
         },
     };
@@ -82,6 +98,14 @@ sub perl_base {
     if ($autosplit) {
 
         push @commands, q{-a};
+    }
+    if ($inplace) {
+
+        push @commands, q{-i};
+    }
+    if ($print) {
+
+        push @commands, q{-p};
     }
     if ($command_line) {
 

--- a/lib/MIP/Program/Telomerecat.pm
+++ b/lib/MIP/Program/Telomerecat.pm
@@ -1,0 +1,138 @@
+package MIP::Program::Telomerecat;
+
+use 5.026;
+use Carp;
+use charnames qw{ :full :short };
+use English qw{ -no_match_vars };
+use open qw{ :encoding(UTF-8) :std };
+use Params::Check qw{ allow check last_error };
+use strict;
+use utf8;
+use warnings;
+use warnings qw{ FATAL utf8 };
+
+## CPANM
+use autodie qw{ :all };
+
+## MIPs lib/
+use MIP::Constants qw{ $SPACE };
+use MIP::Unix::Standard_streams qw{ unix_standard_streams };
+use MIP::Unix::Write_to_file qw{ unix_write_to_file };
+
+BEGIN {
+    require Exporter;
+    use base qw{ Exporter };
+
+    # Set the version for version checking
+    our $VERSION = 1.00;
+
+    # Functions and variables which can be optionally exported
+    our @EXPORT_OK = qw{ telomerecat_bam2length };
+}
+
+sub telomerecat_bam2length {
+
+## Function : Perl wrapper for telomerecat bam2length. Based on version 3.4.0
+## Returns  : @commands
+## Arguments: $filehandle             => Filehandle to write to
+##          : $infile_paths_ref       => Bam files
+##          : $outfile_path           => Outfile path
+##          : $processes              => Number of processes
+##          : $stderrfile_path        => Stderrfile path
+##          : $stderrfile_path_append => Append stderr info to file path
+##          : $stdinfile_path         => Stdinfile path
+##          : $stdoutfile_path        => Stdoutfile path
+##          : $temp_directory         => Temporary directory
+
+    my ($arg_href) = @_;
+
+    ## Flatten argument(s)
+    my $filehandle;
+    my $infile_paths_ref;
+    my $outfile_path;
+    my $stderrfile_path;
+    my $stderrfile_path_append;
+    my $stdinfile_path;
+    my $stdoutfile_path;
+    my $temp_directory;
+
+    ## Default(s)
+    my $processes;
+
+    my $tmpl = {
+        filehandle => {
+            store => \$filehandle,
+        },
+        infile_paths_ref => {
+            default     => [],
+            required    => 1,
+            store       => \$infile_paths_ref,
+            strict_type => 1,
+        },
+        outfile_path => {
+            required    => 1,
+            store       => \$outfile_path,
+            strict_type => 1,
+        },
+        processes => {
+            allow       => [ undef, qr/\A \d+ \z/xms ],
+            default     => 1,
+            store       => \$processes,
+            strict_type => 1,
+        },
+        stderrfile_path => {
+            store       => \$stderrfile_path,
+            strict_type => 1,
+        },
+        stderrfile_path_append => {
+            store       => \$stderrfile_path_append,
+            strict_type => 1,
+        },
+        stdinfile_path  => { store => \$stdinfile_path, strict_type => 1, },
+        stdoutfile_path => {
+            store       => \$stdoutfile_path,
+            strict_type => 1,
+        },
+        temp_directory => { store => \$temp_directory, strict_type => 1, },
+    };
+
+    check( $tmpl, $arg_href, 1 ) or croak q{Could not parse arguments!};
+
+    my @commands = qw{ telomerecat bam2length };
+
+    push @commands, q{--output} . $SPACE . $outfile_path;
+
+    if ($processes) {
+
+        push @commands, q{-p} . $SPACE . $processes;
+    }
+
+    if ($temp_directory) {
+
+        push @commands, q{--temp_dir} . $SPACE . $temp_directory;
+    }
+
+    push @commands, join $SPACE, @{$infile_paths_ref};
+
+    push @commands,
+      unix_standard_streams(
+        {
+            stderrfile_path        => $stderrfile_path,
+            stderrfile_path_append => $stderrfile_path_append,
+            stdinfile_path         => $stdinfile_path,
+            stdoutfile_path        => $stdoutfile_path,
+        }
+      );
+
+    unix_write_to_file(
+        {
+            commands_ref => \@commands,
+            filehandle   => $filehandle,
+            separator    => $SPACE,
+
+        }
+    );
+    return @commands;
+}
+
+1;

--- a/lib/MIP/Recipes/Analysis/Telomerecat.pm
+++ b/lib/MIP/Recipes/Analysis/Telomerecat.pm
@@ -34,14 +34,14 @@ sub analysis_telomerecat {
 
 ## Function : Analyse telomere lengths using Telomerecat
 ## Returns  :
-## Arguments: $active_parameter_href   => Active parameters for this analysis hash {REF}
-##          : $case_id                 => Family id
-##          : $file_info_href          => File_info hash {REF}
-##          : $job_id_href             => Job id hash {REF}
-##          : $parameter_href          => Parameter hash {REF}
-##          : $profile_base_command    => Submission profile base command
-##          : $recipe_name             => Recipe name
-##          : $sample_info_href        => Info on samples and case hash {REF}
+## Arguments: $active_parameter_href => Active parameters for this analysis hash {REF}
+##          : $case_id               => Family id
+##          : $file_info_href        => File_info hash {REF}
+##          : $job_id_href           => Job id hash {REF}
+##          : $parameter_href        => Parameter hash {REF}
+##          : $profile_base_command  => Submission profile base command
+##          : $recipe_name           => Recipe name
+##          : $sample_info_href      => Info on samples and case hash {REF}
 
     my ($arg_href) = @_;
 
@@ -307,6 +307,7 @@ sub _rename_sample {
             strict_type => 1,
         },
         filehandle => {
+            required => 1,
             store => \$filehandle,
         },
         sample_display_href => {
@@ -338,9 +339,9 @@ sub _rename_sample {
 
             my @perl_cmds = perl_base(
                 {
-                    print        => 1,
-                    inplace      => 1,
                     command_line => 1,
+                    inplace      => 1,
+                    print        => 1,
                 }
             );
 

--- a/lib/MIP/Recipes/Pipeline/Analyse_rd_dna.pm
+++ b/lib/MIP/Recipes/Pipeline/Analyse_rd_dna.pm
@@ -25,7 +25,7 @@ BEGIN {
     use base qw{ Exporter };
 
     # Set the version for version checking
-    our $VERSION = 1.36;
+    our $VERSION = 1.37;
 
     # Functions and variables which can be optionally exported
     our @EXPORT_OK = qw{ parse_rd_dna pipeline_analyse_rd_dna };
@@ -134,7 +134,7 @@ sub parse_rd_dna {
       qw{ cnvnator_ar delly_reformat tiddit };
     Readonly my @ONLY_WGS_RECIPIES =>
       qw{ cnvnator_ar delly_call delly_reformat expansionhunter
-      samtools_subsample_mt smncopynumbercaller star_caller tiddit };
+      samtools_subsample_mt smncopynumbercaller star_caller telomerecat_ar tiddit };
     Readonly my @REMOVE_CONFIG_KEYS => qw{ associated_recipe };
 
     my $consensus_analysis_type = get_cache(
@@ -494,6 +494,7 @@ sub pipeline_analyse_rd_dna {
     use MIP::Recipes::Analysis::Sv_combinevariantcallsets
       qw{ analysis_sv_combinevariantcallsets };
     use MIP::Recipes::Analysis::Split_fastq_file qw{ analysis_split_fastq_file };
+    use MIP::Recipes::Analysis::Telomerecat qw{ analysis_telomerecat };
     use MIP::Recipes::Analysis::Tiddit qw{ analysis_tiddit };
     use MIP::Recipes::Analysis::Tiddit_coverage qw{ analysis_tiddit_coverage };
     use MIP::Recipes::Analysis::Varg qw{ analysis_varg };
@@ -597,6 +598,7 @@ sub pipeline_analyse_rd_dna {
         sv_reformat               => \&analysis_reformat_sv,
         sv_varianteffectpredictor => undef,                   # Depends on analysis type
         sv_vcfparser              => undef,                   # Depends on analysis type
+        telomerecat_ar            => \&analysis_telomerecat,
         tiddit                    => \&analysis_tiddit,
         tiddit_coverage        => \&analysis_tiddit_coverage,
         varg_ar                => \&analysis_varg,

--- a/lib/MIP/Set/Analysis.pm
+++ b/lib/MIP/Set/Analysis.pm
@@ -23,7 +23,7 @@ BEGIN {
     use base qw{ Exporter };
 
     # Set the version for version checking
-    our $VERSION = 1.15;
+    our $VERSION = 1.16;
 
     # Functions and variables which can be optionally exported
     our @EXPORT_OK = qw{
@@ -279,6 +279,7 @@ sub set_recipe_on_analysis_type {
       qw{ analysis_gatk_variantrecalibration_wes analysis_gatk_variantrecalibration_wgs };
     use MIP::Recipes::Analysis::Mip_vcfparser
       qw{ analysis_mip_vcfparser_sv_wes analysis_mip_vcfparser_sv_wgs };
+    use MIP::Recipes::Analysis::Telomerecat qw{ analysis_telomerecat };
     use MIP::Recipes::Analysis::Vep qw{ analysis_vep_sv_wes analysis_vep_sv_wgs };
 
     my %analysis_type_recipe = (

--- a/t/analysis_telomerecat.t
+++ b/t/analysis_telomerecat.t
@@ -16,7 +16,6 @@ use warnings qw{ FATAL utf8 };
 ## CPANM
 use autodie qw { :all };
 use Modern::Perl qw{ 2018 };
-use Readonly;
 use Test::Trap;
 
 ## MIPs lib/

--- a/t/analysis_telomerecat.t
+++ b/t/analysis_telomerecat.t
@@ -1,0 +1,125 @@
+#!/usr/bin/env perl
+
+use 5.026;
+use Carp;
+use charnames qw{ :full :short };
+use English qw{ -no_match_vars };
+use File::Basename qw{ dirname };
+use File::Spec::Functions qw{ catdir catfile };
+use FindBin qw{ $Bin };
+use open qw{ :encoding(UTF-8) :std };
+use Params::Check qw{ allow check last_error };
+use Test::More;
+use utf8;
+use warnings qw{ FATAL utf8 };
+
+## CPANM
+use autodie qw { :all };
+use Modern::Perl qw{ 2018 };
+use Readonly;
+use Test::Trap;
+
+## MIPs lib/
+use lib catdir( dirname($Bin), q{lib} );
+use MIP::Constants qw{ $COLON $COMMA $SPACE };
+use MIP::Test::Fixtures qw{ test_log test_mip_hashes test_standard_cli };
+
+my $VERBOSE = 1;
+our $VERSION = 1.00;
+
+$VERBOSE = test_standard_cli(
+    {
+        verbose => $VERBOSE,
+        version => $VERSION,
+    }
+);
+
+BEGIN {
+
+    use MIP::Test::Fixtures qw{ test_import };
+
+### Check all internal dependency modules and imports
+## Modules with import
+    my %perl_module = (
+        q{MIP::Recipes::Analysis::Telomerecat} => [qw{ analysis_telomerecat }],
+        q{MIP::Test::Fixtures} => [qw{ test_log test_mip_hashes test_standard_cli }],
+    );
+
+    test_import( { perl_module_href => \%perl_module, } );
+}
+
+use MIP::Recipes::Analysis::Telomerecat qw{ analysis_telomerecat };
+
+diag(   q{Test analysis_telomerecat from Telomerecat.pm v}
+      . $MIP::Recipes::Analysis::Telomerecat::VERSION
+      . $COMMA
+      . $SPACE . q{Perl}
+      . $SPACE
+      . $PERL_VERSION
+      . $SPACE
+      . $EXECUTABLE_NAME );
+
+my $log = test_log( { log_name => q{MIP}, no_screen => 1, } );
+
+## Given recipe parameters when sample infiles to merge
+my $recipe_name    = q{telomerecat};
+my $slurm_mock_cmd = catfile( $Bin, qw{ data modules slurm-mock.pl } );
+
+my %active_parameter = test_mip_hashes(
+    {
+        mip_hash_name => q{active_parameter},
+        recipe_name   => $recipe_name,
+    }
+);
+$active_parameter{$recipe_name}                     = 1;
+$active_parameter{recipe_core_number}{$recipe_name} = 1;
+$active_parameter{recipe_time}{$recipe_name}        = 1;
+
+my %file_info = test_mip_hashes(
+    {
+        mip_hash_name => q{file_info},
+        recipe_name   => $recipe_name,
+    }
+);
+
+my %job_id;
+my %parameter = test_mip_hashes(
+    {
+        mip_hash_name => q{recipe_parameter},
+        recipe_name   => $recipe_name,
+    }
+);
+@{ $parameter{cache}{order_recipes_ref} } = ($recipe_name);
+my %sample_info = (
+    sample => {
+        ADM1059A1 => {
+            sample_display_name => q{boris},
+            sex                 => q{male},
+        },
+        ADM1059A2 => {
+            sample_display_name => q{stefan},
+            sex                 => q{unknown},
+        },
+        ADM1059A3 => {
+            sample_display_name => q{venus},
+            sex                 => q{female},
+        },
+    }
+);
+my $is_ok = analysis_telomerecat(
+    {
+        active_parameter_href => \%active_parameter,
+        case_id               => $active_parameter{case_id},
+        file_info_href        => \%file_info,
+        job_id_href           => \%job_id,
+        parameter_href        => \%parameter,
+        profile_base_command  => $slurm_mock_cmd,
+        recipe_name           => $recipe_name,
+        sample_info_href      => \%sample_info,
+    }
+);
+
+## Then return TRUE
+ok( $is_ok, q{ Executed analysis recipe } . $recipe_name );
+
+done_testing();

--- a/t/data/643594-miptest/643594-miptest_pedigree.yaml
+++ b/t/data/643594-miptest/643594-miptest_pedigree.yaml
@@ -11,7 +11,7 @@ samples:
     mother: ADM1059A3
     phenotype: affected
     sample_id: ADM1059A2
-    sample_name: NA12882
+    sample_display_name: NA12882
     sex: male
     time_point: 0
   - analysis_type: wes
@@ -21,7 +21,7 @@ samples:
     mother: '0'
     phenotype: unaffected
     sample_id: ADM1059A1
-    sample_name: NA12877
+    sample_display_name: NA12877
     sex: male
     time_point: 0
   - analysis_type: wes
@@ -31,6 +31,6 @@ samples:
     mother: '0'
     phenotype: unaffected
     sample_id: ADM1059A3
-    sample_name: NA12878
+    sample_display_name: NA12878
     sex: female
     time_point: 0

--- a/t/parse_container_uri.t
+++ b/t/parse_container_uri.t
@@ -87,6 +87,7 @@ is( $uri, $expected_uri, q{Parse uri for docker} );
 
 ## Given a quay uri
 $uri = q{quay.io/clinicalgenomics/chanjo:4.2.0};
+
 ## When container manager is singularity
 parse_container_uri(
     {

--- a/t/parse_container_uri.t
+++ b/t/parse_container_uri.t
@@ -23,7 +23,7 @@ use MIP::Constants qw{ $COMMA $SPACE };
 use MIP::Test::Fixtures qw{ test_standard_cli };
 
 my $VERBOSE = 1;
-our $VERSION = 1.00;
+our $VERSION = 1.01;
 
 $VERBOSE = test_standard_cli(
     {
@@ -81,7 +81,21 @@ parse_container_uri(
     }
 );
 
-## Then prepend docker://
+## Then leave uri unchanged
 $expected_uri = q{docker.io/clinicalgenomics/chanjo:4.2.0};
 is( $uri, $expected_uri, q{Parse uri for docker} );
+
+## Given a quay uri
+$uri = q{quay.io/clinicalgenomics/chanjo:4.2.0};
+## When container manager is singularity
+parse_container_uri(
+    {
+        container_manager => q{singularity},
+        uri_ref           => \$uri,
+    }
+);
+
+## Then leave uri unchanged
+$expected_uri = q{docker://quay.io/clinicalgenomics/chanjo:4.2.0};
+is( $uri, $expected_uri, q{Parse quay uri for singularity} );
 done_testing();

--- a/t/perl_base.t
+++ b/t/perl_base.t
@@ -25,7 +25,7 @@ use MIP::Test::Commands qw{ test_function };
 use MIP::Test::Fixtures qw{ test_standard_cli };
 
 my $VERBOSE = 1;
-our $VERSION = 1.00;
+our $VERSION = 1.01;
 
 $VERBOSE = test_standard_cli(
     {
@@ -66,17 +66,25 @@ my @function_base_commands = qw{ perl };
 ## to enable testing of each individual argument
 
 my %specific_argument = (
-    command_line => {
+    autosplit => {
         input           => 1,
-        expected_output => q{-e},
+        expected_output => q{-a},
     },
     n => {
         input           => 1,
         expected_output => q{-n},
     },
-    autosplit => {
+    command_line => {
         input           => 1,
-        expected_output => q{-a},
+        expected_output => q{-e},
+    },
+    inplace => {
+        input           => 1,
+        expected_output => q{-i},
+    },
+    print => {
+        input           => 1,
+        expected_output => q{-p},
     },
 );
 

--- a/t/telomerecat_bam2length.t
+++ b/t/telomerecat_bam2length.t
@@ -16,7 +16,6 @@ use warnings qw{ FATAL utf8 };
 ## CPANM
 use autodie qw{ :all };
 use Modern::Perl qw{ 2018 };
-use Readonly;
 
 ## MIPs lib/
 use lib catdir( dirname($Bin), q{lib} );

--- a/t/telomerecat_bam2length.t
+++ b/t/telomerecat_bam2length.t
@@ -121,7 +121,7 @@ my @arguments = ( \%base_argument, \%specific_argument );
 ARGUMENT_HASH_REF:
 foreach my $argument_href (@arguments) {
 
-    my @commands = test_function(
+    test_function(
         {
             argument_href              => $argument_href,
             do_test_base_command       => 1,

--- a/t/telomerecat_bam2length.t
+++ b/t/telomerecat_bam2length.t
@@ -1,0 +1,146 @@
+#!/usr/bin/env perl
+
+use 5.026;
+use Carp;
+use charnames qw{ :full :short };
+use English qw{ -no_match_vars };
+use File::Basename qw{ dirname };
+use File::Spec::Functions qw{ catdir };
+use FindBin qw{ $Bin };
+use open qw{ :encoding(UTF-8) :std };
+use Params::Check qw{ allow check last_error };
+use Test::More;
+use utf8;
+use warnings qw{ FATAL utf8 };
+
+## CPANM
+use autodie qw{ :all };
+use Modern::Perl qw{ 2018 };
+use Readonly;
+
+## MIPs lib/
+use lib catdir( dirname($Bin), q{lib} );
+use MIP::Constants qw{ $COMMA $SPACE };
+use MIP::Test::Commands qw{ test_function };
+use MIP::Test::Fixtures qw{ test_standard_cli };
+
+my $VERBOSE = 1;
+our $VERSION = 1.00;
+
+$VERBOSE = test_standard_cli(
+    {
+        verbose => $VERBOSE,
+        version => $VERSION,
+    }
+);
+
+BEGIN {
+
+    use MIP::Test::Fixtures qw{ test_import };
+
+### Check all internal dependency modules and imports
+## Modules with import
+    my %perl_module = (
+        q{MIP::Program::Telemerocat} => [qw{ telomerecat_bam2length }],
+        q{MIP::Test::Fixtures}       => [qw{ test_standard_cli }],
+    );
+
+    test_import( { perl_module_href => \%perl_module, } );
+}
+
+use MIP::Program::MODULE qw{ SUB_ROUTINE };
+
+diag(   q{Test SUB_ROUTINE from MODULE.pm v}
+      . $MIP::Program::MODULE::VERSION
+      . $COMMA
+      . $SPACE . q{Perl}
+      . $SPACE
+      . $PERL_VERSION
+      . $SPACE
+      . $EXECUTABLE_NAME );
+
+## Base arguments
+my @function_base_commands = qw{ BASE_COMMAND };
+
+my %base_argument = (
+    filehandle => {
+        input           => undef,
+        expected_output => \@function_base_commands,
+    },
+    stderrfile_path => {
+        input           => q{stderrfile.test},
+        expected_output => q{2> stderrfile.test},
+    },
+    stderrfile_path_append => {
+        input           => q{stderrfile.test},
+        expected_output => q{2>> stderrfile.test},
+    },
+    stdoutfile_path => {
+        input           => q{stdoutfile.test},
+        expected_output => q{1> stdoutfile.test},
+    },
+);
+
+## Can be duplicated with %base_argument and/or %specific_argument
+## to enable testing of each individual argument
+my %required_argument = (
+    ARRAY => {
+        inputs_ref      => [qw{ TEST_STRING_1 TEST_STRING_2 }],
+        expected_output => q{PROGRAM OUTPUT},
+    },
+    HASH => {
+        input_href => {
+            key_1 => q{value_1},
+            key_2 => q{value_2},
+        },
+
+        # Always sorted to an alphabetical order according to ASCII table
+        expected_output => q{--hash_arg key_1=value_1 --hash_arg key_2=value_2},
+    },
+    SCALAR => {
+        input           => q{TEST_STRING},
+        expected_output => q{PROGRAM_OUTPUT},
+    },
+);
+
+my %specific_argument = (
+    ARRAY => {
+        inputs_ref      => [qw{ TEST_STRING_1 TEST_STRING_2 }],
+        expected_output => q{PROGRAM OUTPUT},
+    },
+    HASH => {
+        input_href => {
+            key_1 => q{value_1},
+            key_2 => q{value_2},
+        },
+
+        # Always sorted to an alphabetical order according to ASCII table
+        expected_output => q{--hash_arg key_1=value_1 --hash_arg key_2=value_2},
+    },
+    SCALAR => {
+        input           => q{TEST_STRING},
+        expected_output => q{PROGRAM_OUTPUT},
+    },
+);
+
+## Coderef - enables generalized use of generate call
+my $module_function_cref = \&SUB_ROUTINE;
+
+## Test both base and function specific arguments
+my @arguments = ( \%base_argument, \%specific_argument );
+
+ARGUMENT_HASH_REF:
+foreach my $argument_href (@arguments) {
+
+    my @commands = test_function(
+        {
+            argument_href              => $argument_href,
+            do_test_base_command       => 1,
+            function_base_commands_ref => \@function_base_commands,
+            module_function_cref       => $module_function_cref,
+            required_argument_href     => \%required_argument,
+        }
+    );
+}
+
+done_testing();

--- a/t/telomerecat_bam2length.t
+++ b/t/telomerecat_bam2length.t
@@ -41,17 +41,17 @@ BEGIN {
 ### Check all internal dependency modules and imports
 ## Modules with import
     my %perl_module = (
-        q{MIP::Program::Telemerocat} => [qw{ telomerecat_bam2length }],
+        q{MIP::Program::Telomerecat} => [qw{ telomerecat_bam2length }],
         q{MIP::Test::Fixtures}       => [qw{ test_standard_cli }],
     );
 
     test_import( { perl_module_href => \%perl_module, } );
 }
 
-use MIP::Program::MODULE qw{ SUB_ROUTINE };
+use MIP::Program::Telomerecat qw{ telomerecat_bam2length };
 
-diag(   q{Test SUB_ROUTINE from MODULE.pm v}
-      . $MIP::Program::MODULE::VERSION
+diag(   q{Test telomerecat_bam2length from Telomerecat.pm v}
+      . $MIP::Program::Telomerecat::VERSION
       . $COMMA
       . $SPACE . q{Perl}
       . $SPACE
@@ -60,7 +60,7 @@ diag(   q{Test SUB_ROUTINE from MODULE.pm v}
       . $EXECUTABLE_NAME );
 
 ## Base arguments
-my @function_base_commands = qw{ BASE_COMMAND };
+my @function_base_commands = qw{ telomerecat bam2length };
 
 my %base_argument = (
     filehandle => {
@@ -84,47 +84,37 @@ my %base_argument = (
 ## Can be duplicated with %base_argument and/or %specific_argument
 ## to enable testing of each individual argument
 my %required_argument = (
-    ARRAY => {
-        inputs_ref      => [qw{ TEST_STRING_1 TEST_STRING_2 }],
-        expected_output => q{PROGRAM OUTPUT},
+    infile_paths_ref => {
+        inputs_ref      => [qw{ alignment1.bam alignment2.bam }],
+        expected_output => q{alignment1.bam alignment2.bam},
     },
-    HASH => {
-        input_href => {
-            key_1 => q{value_1},
-            key_2 => q{value_2},
-        },
-
-        # Always sorted to an alphabetical order according to ASCII table
-        expected_output => q{--hash_arg key_1=value_1 --hash_arg key_2=value_2},
-    },
-    SCALAR => {
-        input           => q{TEST_STRING},
-        expected_output => q{PROGRAM_OUTPUT},
+    outfile_path => {
+        input           => q{telomere_length.csv},
+        expected_output => q{--output telomere_lengths.csv},
     },
 );
 
 my %specific_argument = (
-    ARRAY => {
-        inputs_ref      => [qw{ TEST_STRING_1 TEST_STRING_2 }],
-        expected_output => q{PROGRAM OUTPUT},
+    infile_paths_ref => {
+        inputs_ref      => [qw{ alignment1.bam alignment2.bam }],
+        expected_output => q{alignment1.bam alignment2.bam},
     },
-    HASH => {
-        input_href => {
-            key_1 => q{value_1},
-            key_2 => q{value_2},
-        },
-
-        # Always sorted to an alphabetical order according to ASCII table
-        expected_output => q{--hash_arg key_1=value_1 --hash_arg key_2=value_2},
+    outfile_path => {
+        input           => q{telomere_lengths.csv},
+        expected_output => q{--output telomere_lengths.csv},
     },
-    SCALAR => {
-        input           => q{TEST_STRING},
-        expected_output => q{PROGRAM_OUTPUT},
+    processes => {
+        input           => 2,
+        expected_output => q{-p 2},
+    },
+    temp_directory => {
+        input           => catdir(qw{ temp path }),
+        expected_output => q{--temp_dir} . $SPACE . catdir(qw{ temp path }),
     },
 );
 
 ## Coderef - enables generalized use of generate call
-my $module_function_cref = \&SUB_ROUTINE;
+my $module_function_cref = \&telomerecat_bam2length;
 
 ## Test both base and function specific arguments
 my @arguments = ( \%base_argument, \%specific_argument );

--- a/templates/mip_install_config.yaml
+++ b/templates/mip_install_config.yaml
@@ -188,6 +188,10 @@ container:
     executable:
       svdb:
     uri: docker.io/jemten/svdb:2.2.0
+  telomerecat:
+    executable:
+      telomerecat:
+    uri: quay.io/wtsicgp/telomerecat:3.4.0
   tiddit:
     executable:
       TIDDIT.py:

--- a/templates/program_test_cmds.yaml
+++ b/templates/program_test_cmds.yaml
@@ -86,6 +86,8 @@ stringtie:
   execution: 'stringtie --version'
 svdb:
   execution: 'svdb'
+telomerecat:
+  execution: 'telomerecat'
 tiddit:
   execution: 'TIDDIT.py'
 trim-galore:


### PR DESCRIPTION
### This PR adds | fixes:

- Adds telomere length estimation
- Adds possibility to download docker images from other sources such as quay.io
- Extends perl_base sub with the -i and -p options

### How to test:

- Automatic and continuous test suite

### Expected outcome:
- [ ] Installation, unit and integration test suite pass

### Review:
- [ ] Code review
- [ ] Tests pass

This [version](https://semver.org/) is a:
- [ ] **MAJOR** - when you make incompatible API changes. If applicable record manual test results in PR header
- [x] **MINOR** - when you add functionality in a backwards compatible manner. If applicable record manual test results in PR header
- [ ] **PATCH** - when you make backwards compatible bug fixes or documentation/instructions
