### PR TITLE
feat(gnu_cp): Refactor and use some short flags instead of long

### DIFF
--- a/lib/MIP/Program/Gnu/Coreutils.pm
+++ b/lib/MIP/Program/Gnu/Coreutils.pm
@@ -29,7 +29,7 @@ BEGIN {
     require Exporter;
 
     # Set the version for version checking
-    our $VERSION = 1.15;
+    our $VERSION = 1.16;
 
     # Functions and variables which can be optionally exported
     our @EXPORT_OK = qw{ gnu_cat
@@ -297,7 +297,6 @@ sub gnu_cp {
     ## Stores commands depending on input parameters
     my @commands = qw{ cp };
 
-    ## Preserve the specified attributes
     if ( @{$preserve_attributes_ref} ) {
         push @commands, q{--preserve=} . join $COMMA, @{$preserve_attributes_ref};
     }
@@ -307,14 +306,13 @@ sub gnu_cp {
     }
 
     if ($recursive) {
-        push @commands, q{--recursive};
+        push @commands, q{-R};
     }
 
     if ($force) {
-        push @commands, q{--force};
+        push @commands, q{-f};
     }
 
-    ## Explain what is being done
     if ($verbose) {
         push @commands, q{--verbose};
     }

--- a/t/gnu_cp.t
+++ b/t/gnu_cp.t
@@ -1,140 +1,123 @@
 #!/usr/bin/env perl
 
-#### Copyright 2017 Henrik Stranneheim
-
-use Modern::Perl qw{ 2018 };
-use warnings qw(FATAL utf8);
-use autodie;
-use 5.026;    #Require at least perl 5.18
-use utf8;
-use open qw( :encoding(UTF-8) :std );
-use charnames qw( :full :short );
+use 5.026;
 use Carp;
-use English qw(-no_match_vars);
-use Params::Check qw(check allow last_error);
-
-use FindBin qw($Bin);    #Find directory of script
-use File::Basename qw(dirname basename);
-use File::Spec::Functions qw(catdir);
-use Getopt::Long;
+use charnames qw{ :full :short };
+use English qw{ -no_match_vars };
+use File::Basename qw{ dirname };
+use File::Spec::Functions qw{ catdir };
+use FindBin qw{ $Bin };
+use open qw{ :encoding(UTF-8) :std };
+use Params::Check qw{ allow check last_error };
 use Test::More;
+use utf8;
+use warnings qw{ FATAL utf8 };
+
+## CPANM
+use autodie qw{ :all };
+use Modern::Perl qw{ 2018 };
+use Readonly;
 
 ## MIPs lib/
-use lib catdir( dirname($Bin), 'lib' );
-use MIP::Script::Utils qw(help);
-
-our $USAGE = build_usage( {} );
+use lib catdir( dirname($Bin), q{lib} );
+use MIP::Constants qw{ $COMMA $SPACE };
+use MIP::Test::Commands qw{ test_function };
+use MIP::Test::Fixtures qw{ test_standard_cli };
 
 my $VERBOSE = 1;
-our $VERSION = '0.0.0';
+our $VERSION = 1.00;
 
-###User Options
-GetOptions(
-    'h|help' => sub {
-        done_testing();
-        print {*STDOUT} $USAGE, "\n";
-        exit;
-    },    #Display help text
-    'v|version' => sub {
-        done_testing();
-        print {*STDOUT} "\n" . basename($PROGRAM_NAME) . q{  } . $VERSION, "\n\n";
-        exit;
-    },    #Display version number
-    'vb|verbose' => $VERBOSE,
-  )
-  or (
-    done_testing(),
-    help(
-        {
-            USAGE     => $USAGE,
-            exit_code => 1,
-        }
-    )
-  );
+$VERBOSE = test_standard_cli(
+    {
+        verbose => $VERBOSE,
+        version => $VERSION,
+    }
+);
 
 BEGIN {
 
+    use MIP::Test::Fixtures qw{ test_import };
+
 ### Check all internal dependency modules and imports
-##Modules with import
-    my %perl_module;
+## Modules with import
+    my %perl_module = (
+        q{MIP::Program::Gnu::Coreutils} => [qw{ gnu_cp }],
+        q{MIP::Test::Fixtures}          => [qw{ test_standard_cli }],
+    );
 
-    $perl_module{'MIP::Script::Utils'} = [qw(help)];
-    while ( my ( $module, $module_import ) = each %perl_module ) {
-        use_ok( $module, @{$module_import} )
-          or BAIL_OUT 'Cannot load ' . $module;
-    }
-
-##Modules
-    my @modules = ('MIP::Program::Gnu::Coreutils');
-    for my $module (@modules) {
-        require_ok($module) or BAIL_OUT 'Cannot load ' . $module;
-    }
+    test_import( { perl_module_href => \%perl_module, } );
 }
 
-use MIP::Program::Gnu::Coreutils qw(gnu_cp);
-use MIP::Test::Commands qw(test_function);
+use MIP::Program::Gnu::Coreutils qw{ gnu_cp };
 
-diag("Test gnu_cp $MIP::Program::Gnu::Coreutils::VERSION, Perl $^V, $EXECUTABLE_NAME");
+diag(   q{Test gnu_cp from Gnu::Coreutils.pm v}
+      . $MIP::Program::Gnu::Coreutils::VERSION
+      . $COMMA
+      . $SPACE . q{Perl}
+      . $SPACE
+      . $PERL_VERSION
+      . $SPACE
+      . $EXECUTABLE_NAME );
 
 ## Base arguments
-my @function_base_commands = 'cp';
+my @function_base_commands = qw{ cp };
 
 my %base_argument = (
-    stderrfile_path => {
-        input           => 'stderrfile.test',
-        expected_output => '2> stderrfile.test',
-    },
-    stderrfile_path_append => {
-        input           => 'stderrfile.test',
-        expected_output => '2>> stderrfile.test',
-    },
     filehandle => {
         input           => undef,
         expected_output => \@function_base_commands,
+    },
+    stderrfile_path => {
+        input           => q{stderrfile.test},
+        expected_output => q{2> stderrfile.test},
+    },
+    stderrfile_path_append => {
+        input           => q{stderrfile.test},
+        expected_output => q{2>> stderrfile.test},
     },
 );
 
 ## Can be duplicated with %base and/or %specific to enable testing of each individual argument
 my %required_argument = (
     infile_path => {
-        input           => 'infile.test',
-        expected_output => 'infile.test',
+        input           => q{infile.test},
+        expected_output => q{infile.test},
     },
     outfile_path => {
-        input           => 'outfile.test',
-        expected_output => 'outfile.test'
+        input           => q{outfile.test},
+        expected_output => q{outfile.test}
     },
 );
 
 ## Specific arguments
 my %specific_argument = (
     infile_path => {
-        input           => 'infile.test',
-        expected_output => 'infile.test',
+        input           => q{infile.test},
+        expected_output => q{infile.test},
     },
     outfile_path => {
-        input           => 'outfile.test',
-        expected_output => 'outfile.test'
+        input           => q{outfile.test},
+        expected_output => q{outfile.test}
     },
     preserve_attributes_ref => {
-        inputs_ref      => [ 'attribute1.test', 'attribute2.test' ],
-        expected_output => '--preserve=attribute1.test,attribute2.test',
+        inputs_ref      => [qw{ attribute1.test attribute2.test }],
+        expected_output => q{--preserve=attribute1.test,attribute2.test},
     },
     recursive => {
         input           => 1,
-        expected_output => '--recursive',
+        expected_output => q{-R},
     },
     force => {
         input           => 1,
-        expected_output => '--force',
+        expected_output => q{-f},
     },
     preserve => {
         input           => 1,
-        expected_output => '-p',
+        expected_output => q{-p},
     },
     verbose => {
         input           => 1,
-        expected_output => '--verbose',
+        expected_output => q{--verbose},
     },
 );
 
@@ -145,50 +128,14 @@ my $module_function_cref = \&gnu_cp;
 my @arguments = ( \%base_argument, \%specific_argument );
 
 foreach my $argument_href (@arguments) {
-    my @commands = test_function(
+    test_function(
         {
             argument_href              => $argument_href,
-            required_argument_href     => \%required_argument,
-            module_function_cref       => $module_function_cref,
             function_base_commands_ref => \@function_base_commands,
+            module_function_cref       => $module_function_cref,
+            required_argument_href     => \%required_argument,
         }
     );
 }
 
 done_testing();
-
-######################
-####SubRoutines#######
-######################
-
-sub build_usage {
-
-##build_usage
-
-##Function : Build the USAGE instructions
-##Returns  : ""
-##Arguments: $program_name
-##         : $program_name => Name of the script
-
-    my ($arg_href) = @_;
-
-    ## Default(s)
-    my $program_name;
-
-    my $tmpl = {
-        program_name => {
-            default     => basename($PROGRAM_NAME),
-            strict_type => 1,
-            store       => \$program_name,
-        },
-    };
-
-    check( $tmpl, $arg_href, 1 ) or croak qw(Could not parse arguments!);
-
-    return <<"END_USAGE";
- $program_name [options]
-    -vb/--verbose Verbose
-    -h/--help Display this help message
-    -v/--version Display version
-END_USAGE
-}


### PR DESCRIPTION
### This PR adds | fixes:

- Refactor gnu_cp
- Use short flags for recursiv and force to become more platform independent

### How to test:

- Automatic and continuous test suite

### Expected outcome:
- [x] Installation, unit and integration test suite pass

### Review:
- [x] Code review
- [x] Tests pass

This [version](https://semver.org/) is a:
- [ ] **MAJOR** - when you make incompatible API changes. If applicable record manual test results in PR header
- [ ] **MINOR** - when you add functionality in a backwards compatible manner. If applicable record manual test results in PR header
- [x] **PATCH** - when you make backwards compatible bug fixes or documentation/instructions
