### PR TITLE
feat(rhocall_viz): updates sequence dictionary

### DIFF
--- a/definitions/rd_dna_parameters.yaml
+++ b/definitions/rd_dna_parameters.yaml
@@ -221,7 +221,7 @@ recipe_memory:
     picardtools_collectmultiplemetrics: 8
     plink: 10
     rhocall_ar: 2
-    rhocall_viz: 2
+    rhocall_viz: 5
     sambamba_depth: 10
     samtools_subsample_mt: 2
     split_fastq_file: 2

--- a/lib/MIP/Program/Picardtools.pm
+++ b/lib/MIP/Program/Picardtools.pm
@@ -27,7 +27,7 @@ BEGIN {
     use base qw{ Exporter };
 
     # Set the version for version checking
-    our $VERSION = 1.08;
+    our $VERSION = 1.09;
 
     # Functions and variables which can be optionally exported
     our @EXPORT_OK = qw{
@@ -43,6 +43,7 @@ BEGIN {
       picardtools_markduplicates
       picardtools_mergesamfiles
       picardtools_sortvcf
+      picardtools_updatevcfsequencedictionary
       sort_vcf
     };
 }
@@ -1736,6 +1737,121 @@ sub picardtools_collectrnaseqmetrics {
     }
 
     push @commands, q{-STRAND_SPECIFICITY} . $SPACE . $strand_specificity;
+
+    push @commands,
+      unix_standard_streams(
+        {
+            stderrfile_path        => $stderrfile_path,
+            stderrfile_path_append => $stderrfile_path_append,
+        }
+      );
+
+    unix_write_to_file(
+        {
+            commands_ref => \@commands,
+            filehandle   => $filehandle,
+            separator    => $SPACE,
+        }
+    );
+    return @commands;
+}
+
+sub picardtools_updatevcfsequencedictionary {
+
+## Function : Perl wrapper for writing picardtools UpdateVcfSequenceDictionary recipe to $filehandle. Based on picardtools 2.22.4.
+## Returns  : @commands
+## Arguments: $filehandle              => Sbatch filehandle to write to
+##          : $infile_path             => Infile paths
+##          : $java_jar                => Java jar
+##          : $java_use_large_pages    => Use java large pages
+##          : $memory_allocation       => Memory allocation for java
+##          : $outfile_path            => Outfile path
+##          : $sequence_dictionary     => Sequence dictionry
+##          : $stderrfile_path         => Stderrfile path
+##          : $stderrfile_path_append  => Stderrfile path append
+##          : $temp_directory          => Redirect tmp files to java temp
+
+    my ($arg_href) = @_;
+
+    ## Flatten argument(s)
+    my $filehandle;
+    my $infile_path;
+    my $java_jar;
+    my $java_use_large_pages;
+    my $memory_allocation;
+    my $outfile_path;
+    my $sequence_dictionary;
+    my $stderrfile_path;
+    my $stderrfile_path_append;
+    my $temp_directory;
+
+    my $tmpl = {
+        filehandle  => { store => \$filehandle },
+        infile_path => {
+            defined     => 1,
+            required    => 1,
+            store       => \$infile_path,
+            strict_type => 1,
+        },
+        java_jar             => { strict_type => 1, store => \$java_jar, },
+        java_use_large_pages => {
+            allow       => [ 0, 1 ],
+            default     => 0,
+            store       => \$java_use_large_pages,
+            strict_type => 1,
+        },
+        memory_allocation => { store => \$memory_allocation, strict_type => 1, },
+        outfile_path      => {
+            defined     => 1,
+            required    => 1,
+            store       => \$outfile_path,
+            strict_type => 1,
+        },
+        sequence_dictionary => {
+            defined     => 1,
+            required    => 1,
+            store       => \$sequence_dictionary,
+            strict_type => 1,
+        },
+        stderrfile_path => { store => \$stderrfile_path, strict_type => 1, },
+        stderrfile_path_append =>
+          { store => \$stderrfile_path_append, strict_type => 1, },
+        temp_directory => { store => \$temp_directory, strict_type => 1, },
+    };
+
+    check( $tmpl, $arg_href, 1 ) or croak q{Could not parse arguments!};
+
+    # Stores commands depending on input parameters
+    my @commands;
+
+    ## Return java core commands
+    if ($java_jar) {
+
+        @commands = java_core(
+            {
+                java_jar                  => $java_jar,
+                java_use_large_pages      => $java_use_large_pages,
+                memory_allocation         => $memory_allocation,
+                picard_use_barclay_parser => 1,
+                temp_directory            => $temp_directory,
+            }
+        );
+    }
+
+    push @commands, q{UpdateVcfSequenceDictionary};
+
+    ## Picardtools base args
+    @commands = picardtools_base(
+        {
+            commands_ref => \@commands,
+        }
+    );
+
+    push @commands, q{-INPUT} . $SPACE . $infile_path;
+
+    push @commands, q{-OUTPUT} . $SPACE . $outfile_path;
+
+    push @commands, q{-SEQUENCE_DICTIONARY} . $SPACE . $sequence_dictionary;
 
     push @commands,
       unix_standard_streams(

--- a/t/picardtools_updatevcfsequencedictionary.t
+++ b/t/picardtools_updatevcfsequencedictionary.t
@@ -1,0 +1,135 @@
+#!/usr/bin/env perl
+
+use 5.026;
+use Carp;
+use charnames qw{ :full :short };
+use English qw{ -no_match_vars };
+use File::Basename qw{ dirname };
+use File::Spec::Functions qw{ catdir catfile };
+use FindBin qw{ $Bin };
+use open qw{ :encoding(UTF-8) :std };
+use Params::Check qw{ allow check last_error };
+use Test::More;
+use utf8;
+use warnings qw{ FATAL utf8 };
+
+## CPANM
+use autodie qw{ :all };
+use Modern::Perl qw{ 2018 };
+
+## MIPs lib/
+use lib catdir( dirname($Bin), q{lib} );
+use MIP::Constants qw{ $COMMA $SPACE };
+use MIP::Test::Commands qw{ test_function };
+use MIP::Test::Fixtures qw{ test_standard_cli };
+
+my $VERBOSE = 1;
+our $VERSION = 1.00;
+
+$VERBOSE = test_standard_cli(
+    {
+        verbose => $VERBOSE,
+        version => $VERSION,
+    }
+);
+
+BEGIN {
+
+    use MIP::Test::Fixtures qw{ test_import };
+
+### Check all internal dependency modules and imports
+## Modules with import
+    my %perl_module = (
+        q{MIP::Program::Picardtools} => [qw{ picardtools_updatevcfsequencedictionary }],
+        q{MIP::Test::Fixtures}       => [qw{ test_standard_cli }],
+    );
+
+    test_import( { perl_module_href => \%perl_module, } );
+}
+
+use MIP::Program::Picardtools qw{ picardtools_updatevcfsequencedictionary };
+use MIP::Test::Commands qw{ test_function };
+
+diag(   q{Test picardtools_updatevcfsequencedictionary from Picardtools.pm v}
+      . $MIP::Program::Picardtools::VERSION
+      . $COMMA
+      . $SPACE . q{Perl}
+      . $SPACE
+      . $PERL_VERSION
+      . $SPACE
+      . $EXECUTABLE_NAME );
+
+## Base arguments
+my @function_base_commands = qw{ picard UpdateVcfSequenceDictionary };
+
+my %base_argument = (
+    filehandle => {
+        input           => undef,
+        expected_output => \@function_base_commands,
+    },
+    stderrfile_path => {
+        input           => q{stderrfile.test},
+        expected_output => q{2> stderrfile.test},
+    },
+    stderrfile_path_append => {
+        input           => q{stderrfile.test},
+        expected_output => q{2>> stderrfile.test},
+    },
+);
+
+## Can be duplicated with %base_argument and/or %specific_argument
+## to enable testing of each individual argument
+my %required_argument = (
+    infile_path => {
+        input           => catfile(qw{ dir infile }),
+        expected_output => q{-INPUT} . $SPACE . catfile(qw{ dir infile }),
+    },
+    outfile_path => {
+        input           => catfile(qw{ dir outfile }),
+        expected_output => q{-OUTPUT} . $SPACE . catfile(qw{ dir outfile }),
+    },
+    sequence_dictionary => {
+        input           => catfile(qw{ references grch37_homo_sapiens_-d5-.dict }),
+        expected_output => q{-SEQUENCE_DICTIONARY}
+          . $SPACE
+          . catfile(qw{ references grch37_homo_sapiens_-d5-.dict }),
+    },
+);
+
+my %specific_argument = (
+    infile_path => {
+        input           => catfile(qw{ dir infile }),
+        expected_output => q{-INPUT} . $SPACE . catfile(qw{ dir infile }),
+    },
+    outfile_path => {
+        input           => catfile(qw{ dir outfile }),
+        expected_output => q{-OUTPUT} . $SPACE . catfile(qw{ dir outfile }),
+    },
+    sequence_dictionary => {
+        input           => catfile(qw{ references grch37_homo_sapiens_-d5-.dict }),
+        expected_output => q{-SEQUENCE_DICTIONARY}
+          . $SPACE
+          . catfile(qw{ references grch37_homo_sapiens_-d5-.dict }),
+    },
+);
+
+## Coderef - enables generalized use of generate call
+my $module_function_cref = \&picardtools_updatevcfsequencedictionary;
+
+## Test both base and function specific arguments
+my @arguments = ( \%base_argument, \%specific_argument );
+
+ARGUMENT_HASH_REF:
+foreach my $argument_href (@arguments) {
+    my @commands = test_function(
+        {
+            argument_href              => $argument_href,
+            do_test_base_command       => 1,
+            function_base_commands_ref => \@function_base_commands,
+            module_function_cref       => $module_function_cref,
+            required_argument_href     => \%required_argument,
+        }
+    );
+}
+
+done_testing();


### PR DESCRIPTION
### This PR adds | fixes:

- Updates the vcf sequence dictionary in the vcf prior to running rhocall viz

### How to test:

- Automatic and continuous test suite

### Expected outcome:
- [ ] Installation, unit and integration test suite pass

### Review:
- [ ] Code review
- [ ] Tests pass

This [version](https://semver.org/) is a:
- [ ] **MAJOR** - when you make incompatible API changes. If applicable record manual test results in PR header
- [ ] **MINOR** - when you add functionality in a backwards compatible manner. If applicable record manual test results in PR header
- [x] **PATCH** - when you make backwards compatible bug fixes or documentation/instructions
