### PR TITLE
Add GLnexus

### DIFF
--- a/definitions/install_parameters.yaml
+++ b/definitions/install_parameters.yaml
@@ -119,6 +119,7 @@ rd_dna:
     - gatk
     - gatk4
     - genmod
+    - glnexus
     - htslib
     - manta
     - mip_scripts

--- a/lib/MIP/Cli/Mip/Install.pm
+++ b/lib/MIP/Cli/Mip/Install.pm
@@ -23,7 +23,7 @@ use MIP::Definition qw{ get_parameter_from_definition_files };
 use MIP::Get::Parameter qw{ get_install_parameter_attribute };
 use MIP::Main::Install qw{ mip_install };
 
-our $VERSION = 1.23;
+our $VERSION = 1.24;
 
 extends(qw{ MIP::Cli::Mip });
 
@@ -230,11 +230,11 @@ sub _build_usage {
                 enum(
                     [
                         qw{ arriba bedtools blobfish bootstrapann bwa bwakit bwa-mem2 cadd chanjo
-                          chromograph cnvnator cyrius deepvariant delly expansionhunter fastqc gatk gatk4 genmod
-                          gffcompare htslib manta mip_scripts multiqc peddy picard plink preseq python
-                          rhocall rseqc rtg-tools salmon sambamba smncopynumbercaller star star-fusion
-                          stranger stringtie svdb telomerecat tiddit trim-galore ucsc upd utilities
-                          varg variant_integrity vcf2cytosure vcfanno vep vts }
+                          chromograph cnvnator cyrius deepvariant delly expansionhunter fastqc gatk gatk4
+                          genmod gffcompare glnexus htslib manta mip_scripts multiqc peddy picard plink
+                          preseq python rhocall rseqc rtg-tools salmon sambamba smncopynumbercaller star
+                          star-fusion stranger stringtie svdb telomerecat tiddit trim-galore ucsc upd
+                          utilities varg variant_integrity vcf2cytosure vcfanno vep vts }
                     ]
                 ),
             ],
@@ -252,11 +252,11 @@ sub _build_usage {
                 enum(
                     [
                         qw{ arriba bedtools blobfish bootstrapann bwa bwakit bwa-mem2 cadd chanjo
-                          chromograph cnvnator cyrius deepvariant delly expansionhunter fastqc gatk gatk4 genmod
-                          gffcompare htslib manta mip_scripts multiqc peddy picard plink preseq python
-                          rhocall rseqc rtg-tools salmon sambamba smncopynumbercaller star star-fusion
-                          stranger stringtie svdb telomerecat tiddit trim-galore ucsc upd utilities
-                          varg variant_integrity vcf2cytosure vcfanno vep vts }
+                          chromograph cnvnator cyrius deepvariant delly expansionhunter fastqc gatk gatk4
+                          genmod gffcompare glnexus htslib manta mip_scripts multiqc peddy picard plink
+                          preseq python rhocall rseqc rtg-tools salmon sambamba smncopynumbercaller star
+                          star-fusion stranger stringtie svdb telomerecat tiddit trim-galore ucsc upd
+                          utilities varg variant_integrity vcf2cytosure vcfanno vep vts }
                     ]
                 ),
             ],

--- a/templates/mip_install_config.yaml
+++ b/templates/mip_install_config.yaml
@@ -103,6 +103,10 @@ container:
     executable:
       gffcompare:
     uri: docker.io/clinicalgenomics/gffcompare:0.11.2
+  glnexus:
+    executable:
+      glnexus_cli:
+    uri: quay.io/mlin/glnexus:v1.2.7
   htslib:
     executable:
       bcftools:

--- a/templates/program_test_cmds.yaml
+++ b/templates/program_test_cmds.yaml
@@ -48,6 +48,8 @@ genmod:
   execution: 'genmod'
 gffcompare:
   execution: 'gffcompare --version'
+glnexus:
+  execution: 'glnexus_cli --help'
 htslib:
   execution: 'bgzip --version'
 manta:


### PR DESCRIPTION
deepvariant recommends using GLnexus for merging vcfs. I tried to
use GATK to merge vcf files, but it did not like deepvariant format
so, I am sticking with GLnexus.

### This PR adds | fixes:

- GLNexus

### How to test:

- Automatic and continuous test suite

### Expected outcome:
- [ ] Installation, unit and integration test suite pass

### Review:
- [ ] Code review
- [ ] Tests pass

This [version](https://semver.org/) is a:
- [ ] **MAJOR** - when you make incompatible API changes. If applicable record manual test results in PR header
- [x] **MINOR** - when you add functionality in a backwards compatible manner. If applicable record manual test results in PR header
- [ ] **PATCH** - when you make backwards compatible bug fixes or documentation/instructions
