### PR TITLE
feat(trim-galore): parallelisation

### DIFF
--- a/lib/MIP/Cluster.pm
+++ b/lib/MIP/Cluster.pm
@@ -25,7 +25,7 @@ BEGIN {
     require Exporter;
 
     # Set the version for version checking
-    our $VERSION = 1.06;
+    our $VERSION = 1.07;
 
     # Functions and variables which can be optionally exported
     our @EXPORT_OK = qw{
@@ -187,7 +187,7 @@ sub update_memory_allocation {
     my $recipe_memory_allocation = $process_memory_allocation * $parallel_processes;
 
     ## Check that memory is available
-    check_recipe_memory_allocation(
+    $recipe_memory_allocation = check_recipe_memory_allocation(
         {
             node_ram_memory          => $node_ram_memory,
             recipe_memory_allocation => $recipe_memory_allocation,

--- a/lib/MIP/Recipes/Analysis/Trim_galore.pm
+++ b/lib/MIP/Recipes/Analysis/Trim_galore.pm
@@ -123,7 +123,7 @@ sub analysis_trim_galore {
 
     check( $tmpl, $arg_href, 1 ) or croak q{Could not parse arguments!};
 
-    use MIP::Cluster qw{ get_core_number update_memory_allocation };
+    use MIP::Cluster qw{ update_memory_allocation };
     use MIP::File_info qw{ get_sample_file_attribute };
     use MIP::Get::File qw{ get_io_files };
     use MIP::Get::Parameter qw{ get_recipe_attributes get_recipe_resources };
@@ -492,7 +492,8 @@ sub _get_cores_for_trimgalore {
     Readonly my $THREE => 3;
 
     ## Currently (Trim galore v0.6.5) the way to calculate the core argument to trim galore:
-    ## Always 1 for trim galore and 2 for cutadapt the rest are splitted between read, write and cutadapt.
+    ## Always three cores for overhead (1 for trim galore and 2 for cutadapt)
+    ## the rest are splitted between the three processe (read, write and cutadapt).
     my $core_argument =
       floor( ( $max_cores_per_node / $parallel_processes - $THREE ) / $THREE );
     my $recipe_core_number = ( $core_argument * $THREE + $THREE ) * $parallel_processes;

--- a/lib/MIP/Recipes/Analysis/Trim_galore.pm
+++ b/lib/MIP/Recipes/Analysis/Trim_galore.pm
@@ -8,7 +8,7 @@ use English qw{ -no_match_vars };
 use File::Spec::Functions qw{ catdir catfile };
 use open qw{ :encoding(UTF-8) :std };
 use Params::Check qw{ allow check last_error };
-use strict;
+use POSIX qw{ floor };
 use utf8;
 use warnings;
 use warnings qw{ FATAL utf8 };
@@ -26,7 +26,7 @@ BEGIN {
     use base qw{ Exporter };
 
     # Set the version for version checking
-    our $VERSION = 1.08;
+    our $VERSION = 1.09;
 
     # Functions and variables which can be optionally exported
     our @EXPORT_OK = qw{ analysis_trim_galore };
@@ -160,13 +160,7 @@ sub analysis_trim_galore {
             attribute      => q{chain},
         }
     );
-    my $recipe_mode     = $active_parameter_href->{$recipe_name};
-    my %recipe_resource = get_recipe_resources(
-        {
-            active_parameter_href => $active_parameter_href,
-            recipe_name           => $recipe_name,
-        }
-    );
+    my $recipe_mode = $active_parameter_href->{$recipe_name};
 
     ## Construct outfiles
     my $outsample_directory =
@@ -211,21 +205,25 @@ sub analysis_trim_galore {
         }
     );
 
-    ## Get core number depending on user supplied input exists or not and max number of cores
-    my $core_number = get_core_number(
+    my %recipe_resource = get_recipe_resources(
         {
-            max_cores_per_node => $active_parameter_href->{max_cores_per_node},
-            modifier_core_number =>
-              scalar @{ $file_info_sample{no_direction_infile_prefixes} },
-            recipe_core_number => $recipe_resource{core_number},
+            active_parameter_href => $active_parameter_href,
+            recipe_name           => $recipe_name,
         }
     );
 
-    # Get recipe memory allocation
+    my $parallel_processes = scalar @{ $file_info_sample{no_direction_infile_prefixes} };
+    my ( $process_core_number, $recipe_core_number ) = _get_cores_for_trimgalore(
+        {
+            max_cores_per_node => $active_parameter_href->{max_cores_per_node},
+            parallel_processes => $parallel_processes,
+        }
+    );
+
     my $memory_allocation = update_memory_allocation(
         {
             node_ram_memory           => $active_parameter_href->{node_ram_memory},
-            parallel_processes        => $core_number,
+            parallel_processes        => $recipe_core_number,
             process_memory_allocation => $recipe_resource{memory},
         }
     );
@@ -234,7 +232,7 @@ sub analysis_trim_galore {
     my ( $recipe_file_path, $recipe_info_path ) = setup_script(
         {
             active_parameter_href           => $active_parameter_href,
-            core_number                     => $core_number,
+            core_number                     => $recipe_core_number,
             directory_id                    => $sample_id,
             filehandle                      => $filehandle,
             job_id_href                     => $job_id_href,
@@ -293,7 +291,7 @@ sub analysis_trim_galore {
         ## Trim galore
         trim_galore(
             {
-                cores            => $recipe_resource{core_number},
+                cores            => $process_core_number,
                 filehandle       => $filehandle,
                 infile_paths_ref => \@fastq_files,
                 outdir_path      => $outsample_directory,
@@ -460,4 +458,50 @@ sub _construct_trim_galore_outfile_paths {
     }
     return @outfile_paths;
 }
+
+sub _get_cores_for_trimgalore {
+
+## Function : Calculate nr of cores to be supplied to each Trim galore process and the recipe
+## Returns  : $core_argument, $recipe_core_number
+## Arguments: $max_cores_per_node => Cores available
+##          : $parallel_processes => Run fastqc after trimming
+
+    my ($arg_href) = @_;
+
+    ## Flatten argument(s)
+    my $max_cores_per_node;
+    my $parallel_processes;
+
+    my $tmpl = {
+        max_cores_per_node => {
+            allow       => [qr/\A \d+ \z/xms],
+            required    => 1,
+            store       => \$max_cores_per_node,
+            strict_type => 1,
+        },
+        parallel_processes => {
+            allow       => [qr/\A \d+ \z/xms],
+            required    => 1,
+            store       => \$parallel_processes,
+            strict_type => 1,
+        },
+    };
+
+    check( $tmpl, $arg_href, 1 ) or croak q{Could not parse arguments!};
+
+    Readonly my $THREE => 3;
+
+    ## Currently (Trim galore v0.6.5) the way to calculate the core argument to trim galore:
+    ## Always 1 for trim galore and 2 for cutadapt the rest are splitted between read, write and cutadapt.
+    my $core_argument =
+      floor( ( $max_cores_per_node / $parallel_processes - $THREE ) / $THREE );
+    my $recipe_core_number = ( $core_argument * $THREE + $THREE ) * $parallel_processes;
+
+    ## Only supply core argument if more than 1
+    $core_argument      = $core_argument > 1 ? $core_argument      : 0;
+    $recipe_core_number = $core_argument     ? $recipe_core_number : $parallel_processes;
+
+    return ( $core_argument, $recipe_core_number );
+}
+
 1;


### PR DESCRIPTION
### This PR adds | fixes:

- speeds up trim-galore by using the parallelisation option
The way the --cores option is calculated is somewhat convoluted:
![image](https://user-images.githubusercontent.com/3168925/91158373-d504dc00-e6c6-11ea-93cf-38f26ac9cbc7.png)
https://github.com/FelixKrueger/TrimGalore/blob/master/Docs/Trim_Galore_User_Guide.md#full-list-of-options-for-trim-galore

### How to test:

- Automatic and continuous test suite

### Expected outcome:
- [x] Installation, unit and integration test suite pass

### Review:
- [ ] Code review
- [ ] Tests pass

This [version](https://semver.org/) is a:
- [ ] **MAJOR** - when you make incompatible API changes. If applicable record manual test results in PR header
- [ ] **MINOR** - when you add functionality in a backwards compatible manner. If applicable record manual test results in PR header
- [x] **PATCH** - when you make backwards compatible bug fixes or documentation/instructions
