### PR TITLE
fix(trim_galore): adds fontconfig to Dockerfile

### DIFF
--- a/containers/trim_galore/Dockerfile
+++ b/containers/trim_galore/Dockerfile
@@ -5,13 +5,13 @@ FROM clinicalgenomics/mip:2.0
 ################## METADATA ######################
 
 LABEL base_image="clinicalgenomics/mip:2.0"
-LABEL version="1"
+LABEL version="2"
 LABEL software="trim_galore"
 LABEL software.version="0.6.4"
 LABEL extra.binaries=""
 LABEL maintainer="Clinical-Genomics/MIP"
 
-RUN conda install trim-galore=0.6.4=1
+RUN conda install trim-galore=0.6.4=1 fontconfig
 
 ## Clean up after conda
 RUN /opt/conda/bin/conda clean -ya


### PR DESCRIPTION
### This PR adds | fixes:

- needed to resolve a java error in the trim galore container (at least for version 0.6.4)

### How to test:

- Automatic and continuous test suite

### Expected outcome:
- [ ] Installation, unit and integration test suite pass

### Review:
- [ ] Code review
- [ ] Tests pass

This [version](https://semver.org/) is a:
- [ ] **MAJOR** - when you make incompatible API changes. If applicable record manual test results in PR header
- [ ] **MINOR** - when you add functionality in a backwards compatible manner. If applicable record manual test results in PR header
- [x] **PATCH** - when you make backwards compatible bug fixes or documentation/instructions
