### PR TITLE
feat(bwa_mem): swithed back to using bwa_mem as default

### DIFF
--- a/definitions/rd_dna_panel_parameters.yaml
+++ b/definitions/rd_dna_panel_parameters.yaml
@@ -282,7 +282,7 @@ bwa_mem:
   associated_recipe:
     - mip
   data_type: SCALAR
-  default: 0
+  default: 1
   file_tag: _sorted
   outfile_suffix: ".bam"
   program_executables:
@@ -303,7 +303,7 @@ bwa_mem2:
   associated_recipe:
     - mip
   data_type: SCALAR
-  default: 1
+  default: 0
   file_tag: _sorted
   outfile_suffix: ".bam"
   program_executables:

--- a/definitions/rd_dna_parameters.yaml
+++ b/definitions/rd_dna_parameters.yaml
@@ -385,7 +385,7 @@ bwa_mem:
   associated_recipe:
     - mip
   data_type: SCALAR
-  default: 0
+  default: 1
   file_tag: _sorted
   outfile_suffix: ".bam"
   program_executables:
@@ -406,7 +406,7 @@ bwa_mem2:
   associated_recipe:
     - mip
   data_type: SCALAR
-  default: 1
+  default: 0
   file_tag: _sorted
   outfile_suffix: ".bam"
   program_executables:


### PR DESCRIPTION
### This PR adds | fixes:

- Switch back to using bwa_mem as default since bwa_mem2 casued edge case errors on validation at least 2 validation cases

### How to test:

- Automatic and continuous test suite

### Expected outcome:
- [ ] Installation, unit and integration test suite pass

### Review:
- [ ] Code review
- [ ] Tests pass

This [version](https://semver.org/) is a:
- [ ] **MAJOR** - when you make incompatible API changes. If applicable record manual test results in PR header
- [ ] **MINOR** - when you add functionality in a backwards compatible manner. If applicable record manual test results in PR header
- [x] **PATCH** - when you make backwards compatible bug fixes or documentation/instructions
