### PR TITLE
feat(qccollect): Added check for keys before calling sub

### DIFF
--- a/lib/MIP/Main/Qccollect.pm
+++ b/lib/MIP/Main/Qccollect.pm
@@ -33,7 +33,7 @@ BEGIN {
     require Exporter;
 
     # Set the version for version checking
-    our $VERSION = q{2.1.9};
+    our $VERSION = q{2.1.10};
 
     # Functions and variables which can be optionally exported
     our @EXPORT_OK = qw{ mip_qccollect };
@@ -336,6 +336,8 @@ sub case_qc {
         }
     }
 
+    if (exists $qc_data_href->{recipe}{pedigree_check} and exists $qc_data_href->{recipe}{relation_check}) {
+
     relation_check(
         {
             qc_data_href => $qc_data_href,
@@ -346,6 +348,7 @@ sub case_qc {
               \@{ $qc_data_href->{recipe}{pedigree_check}{sample_order} },
         }
     );
+    }
     return;
 }
 

--- a/lib/MIP/Main/Qccollect.pm
+++ b/lib/MIP/Main/Qccollect.pm
@@ -336,18 +336,20 @@ sub case_qc {
         }
     }
 
-    if (exists $qc_data_href->{recipe}{pedigree_check} and exists $qc_data_href->{recipe}{relation_check}) {
+    if (    exists $qc_data_href->{recipe}{pedigree_check}
+        and exists $qc_data_href->{recipe}{relation_check} )
+    {
 
-    relation_check(
-        {
-            qc_data_href => $qc_data_href,
-            relationship_values_ref =>
-              \@{ $qc_data_href->{recipe}{relation_check}{sample_relation_check} },
-            sample_info_href => $sample_info_href,
-            sample_orders_ref =>
-              \@{ $qc_data_href->{recipe}{pedigree_check}{sample_order} },
-        }
-    );
+        relation_check(
+            {
+                qc_data_href => $qc_data_href,
+                relationship_values_ref =>
+                  \@{ $qc_data_href->{recipe}{relation_check}{sample_relation_check} },
+                sample_info_href => $sample_info_href,
+                sample_orders_ref =>
+                  \@{ $qc_data_href->{recipe}{pedigree_check}{sample_order} },
+            }
+        );
     }
     return;
 }


### PR DESCRIPTION
### This PR adds | fixes:

- relation_check will error if plink has not been processed, which can happen for wgs single samples

### How to test:

- Automatic and continuous test suite

### Expected outcome:
- [ ] Installation, unit and integration test suite pass

### Review:
- [ ] Code review
- [ ] Tests pass

This [version](https://semver.org/) is a:
- [ ] **MAJOR** - when you make incompatible API changes. If applicable record manual test results in PR header
- [ ] **MINOR** - when you add functionality in a backwards compatible manner. If applicable record manual test results in PR header
- [x] **PATCH** - when you make backwards compatible bug fixes or documentation/instructions
