### PR TITLE
feat(sample_info_files): remove duplicates

### DIFF
--- a/lib/MIP/Sample_info.pm
+++ b/lib/MIP/Sample_info.pm
@@ -26,7 +26,7 @@ BEGIN {
     use base qw{Exporter};
 
     # Set the version for version checking
-    our $VERSION = 1.37;
+    our $VERSION = 1.38;
 
     # Functions and variables which can be optionally exported
     our @EXPORT_OK = qw{
@@ -599,6 +599,10 @@ sub set_file_path_to_store {
         step       => $recipe_name,
         tag        => $tag,
     );
+
+    ## Remove old entries with the same path
+    @{ $sample_info_href->{files} } =
+      grep { $_->{path} ne $path } @{ $sample_info_href->{files} };
 
     ## Set file path according to file type and tag
     push @{ $sample_info_href->{files} }, {%file_info};


### PR DESCRIPTION
### This PR adds | fixes:

- The 'files' key in the sample_info hash accumulates the same store files between runs of he same sample. This PR introduces a check for that and deletes any old hash_ref with the same path key. 

### How to test:

- Automatic and continuous test suite

### Expected outcome:
- [ ] Installation, unit and integration test suite pass

### Review:
- [ ] Code review
- [ ] Tests pass

This [version](https://semver.org/) is a:
- [ ] **MAJOR** - when you make incompatible API changes. If applicable record manual test results in PR header
- [ ] **MINOR** - when you add functionality in a backwards compatible manner. If applicable record manual test results in PR header
- [x] **PATCH** - when you make backwards compatible bug fixes or documentation/instructions
