### PR TITLE
Feature/mip container

### DIFF
--- a/.github/workflows/conda_prod_install.yml
+++ b/.github/workflows/conda_prod_install.yml
@@ -10,7 +10,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
-      - uses: goanpeca/setup-miniconda@v1
+      - uses: conda-incubator/setup-miniconda@v2
         with:
           channels: bioconda, conda-forge
 

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -13,7 +13,7 @@ jobs:
       - uses: shogo82148/actions-setup-perl@v1
         with:
           perl-version: '5.26'
-      - uses: goanpeca/setup-miniconda@v1
+      - uses: conda-incubator/setup-miniconda@v2
         with:
           channels: bioconda, conda-forge
 

--- a/.github/workflows/docker_build_n_publish.yml
+++ b/.github/workflows/docker_build_n_publish.yml
@@ -1,0 +1,20 @@
+name: Publish to Docker Hub
+
+on:
+ release:
+  types:
+   - created
+jobs:
+  docker-image-CI:
+   name: Docker Image CI
+   runs-on: ubuntu-latest
+   steps:
+    - name: Check out git repository
+      uses: actions/checkout@v2
+    - name: Publish to Registry
+      uses: elgohr/Publish-Docker-Github-Action@master
+      with:
+        name: clinicalgenomics/mip
+        username: ${{ secrets.DOCKER_USERNAME }}
+        password: ${{ secrets.DOCKER_PASSWORD }}
+        tags: "latest,${{ github.event.release.tag_name }}"

--- a/.github/workflows/docker_build_n_publish.yml
+++ b/.github/workflows/docker_build_n_publish.yml
@@ -1,20 +1,22 @@
+---
+
 name: Publish to Docker Hub
 
-on:
- release:
-  types:
-   - created
+"on":
+  release:
+    types:
+      - created
 jobs:
   docker-image-CI:
-   name: Docker Image CI
-   runs-on: ubuntu-latest
-   steps:
-    - name: Check out git repository
-      uses: actions/checkout@v2
-    - name: Publish to Registry
-      uses: elgohr/Publish-Docker-Github-Action@master
-      with:
-        name: clinicalgenomics/mip
-        username: ${{ secrets.DOCKER_USERNAME }}
-        password: ${{ secrets.DOCKER_PASSWORD }}
-        tags: "latest,${{ github.event.release.tag_name }}"
+    name: Docker Image CI
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out git repository
+        uses: actions/checkout@v2
+      - name: Publish to Registry
+        uses: elgohr/Publish-Docker-Github-Action@master
+        with:
+          name: clinicalgenomics/mip
+          username: ${{ secrets.DOCKER_USERNAME }}
+          password: ${{ secrets.DOCKER_PASSWORD }}
+          tags: "latest,${{ github.event.release.tag_name }}"

--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -13,7 +13,7 @@ jobs:
       - uses: shogo82148/actions-setup-perl@v1
         with:
           perl-version: '5.26'
-      - uses: goanpeca/setup-miniconda@v1
+      - uses: conda-incubator/setup-miniconda@v2
         with:
           channels: bioconda, conda-forge
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,33 @@
+################## BASE IMAGE ######################
+
+FROM perl:5.26
+
+################## METADATA ######################
+
+LABEL base_image="perl:5.26"
+LABEL version="1"
+LABEL software="MIP"
+LABEL software.version="5.26"
+LABEL extra.binaries="mip, perl, prove, cpanm"
+LABEL maintainer="Clinical-Genomics/MIP"
+
+RUN apt-get update && apt-get install -y --no-install-recommends locales locales-all \
+ && apt-get clean \
+ && rm -rf /var/lib/apt/lists/*
+
+ENV LC_ALL en_US.UTF-8
+ENV LANG en_US.UTF-8
+ENV LANGUAGE en_US.UTF-8
+
+# Add MIP into image
+ENV MIP_INSTALL_DIR=/workspace/bin
+COPY . "$MIP_INSTALL_DIR"
+WORKDIR "$MIP_INSTALL_DIR"
+
+# Install MIP dependencies for CPANM modules
+RUN cpanm -f Net::DNS
+RUN cpanm --installdeps .
+
+# Make executable and add to binary to PATH
+RUN chmod a+x "$MIP_INSTALL_DIR/mip"
+ENV PATH "$PATH:$MIP_INSTALL_DIR"

--- a/containers/Dockerfile
+++ b/containers/Dockerfile
@@ -4,10 +4,10 @@ FROM ubuntu:16.04
 ################## METADATA ######################
 
 LABEL base_image="ubuntu:16.04"
-LABEL version="2"
-LABEL software="mip.base"
-LABEL software.version="8.2.0"
-LABEL about.summary="Base image for MIP's dependency tools"
+LABEL version="2.1"
+LABEL software="conda"
+LABEL software.version="4.7.12.1"
+LABEL about.summary="Base image for MIP's dependency tools docker containers"
 LABEL about.home="https://github.com/Clinical-Genomics/MIP"
 LABEL about.documentation="https://clinical-genomics.gitbook.io/project-mip/"
 LABEL about.license_file="https://github.com/Clinical-Genomics/MIP/blob/master/LICENSE"
@@ -48,7 +48,7 @@ RUN apt-get update --fix-missing && \
 
 # Install conda and give write permissions to conda folder
 RUN echo 'export PATH=/opt/conda/bin:$PATH' > /etc/profile.d/conda.sh && \
-    wget --quiet https://repo.continuum.io/miniconda/Miniconda3-4.7.12.1-Linux-x86_64.sh -O ~/miniconda.sh && \
+    wget --no-check-certificate https://repo.continuum.io/miniconda/Miniconda3-4.7.12.1-Linux-x86_64.sh -O ~/miniconda.sh && \
     /bin/bash ~/miniconda.sh -b -p /opt/conda && \
     rm ~/miniconda.sh
 

--- a/containers/bedtools/Dockerfile
+++ b/containers/bedtools/Dockerfile
@@ -1,10 +1,10 @@
 ################## BASE IMAGE ######################
 
-FROM clinicalgenomics/mip:2.0
+FROM clinicalgenomics/mip_base:2.1
 
 ################## METADATA ######################
 
-LABEL base_image="clinicalgenomics/mip:2.0"
+LABEL base_image="clinicalgenomics/mip_base:2.1"
 LABEL version="1"
 LABEL software="bedtools"
 LABEL software.version="2.29.0"

--- a/containers/blobfish/Dockerfile
+++ b/containers/blobfish/Dockerfile
@@ -1,10 +1,10 @@
 ################## BASE IMAGE ######################
 
-FROM clinicalgenomics/mip:2.0
+FROM clinicalgenomics/mip_base:2.1
 
 ################## METADATA ######################
 
-LABEL base_image="clinicalgenomics/mip:2.0"
+LABEL base_image="clinicalgenomics/mip_base:2.1"
 LABEL version="1"
 LABEL software="BlobFish"
 LABEL software.version="0.0.2"

--- a/containers/bootstrapann/Dockerfile
+++ b/containers/bootstrapann/Dockerfile
@@ -1,10 +1,10 @@
 ################## BASE IMAGE ######################
 
-FROM clinicalgenomics/mip:2.0
+FROM clinicalgenomics/mip_base:2.1
 
 ################## METADATA ######################
 
-LABEL base_image="clinicalgenomics/mip:2.0"
+LABEL base_image="clinicalgenomics/mip_base:2.1"
 LABEL version="1"
 LABEL software="BootstrapAnn"
 LABEL software.version="df02f35"

--- a/containers/bwa-mem2/Dockerfile
+++ b/containers/bwa-mem2/Dockerfile
@@ -1,10 +1,10 @@
 ################## BASE IMAGE ######################
 
-FROM clinicalgenomics/mip:2.0
+FROM clinicalgenomics/mip_base:2.1
 
 ################## METADATA ######################
 
-LABEL base_image="clinicalgenomics/mip:2.0"
+LABEL base_image="clinicalgenomics/mip_base:2.1"
 LABEL version="1"
 LABEL software="bwa-mem2"
 LABEL software.version="2.0"

--- a/containers/bwa/Dockerfile
+++ b/containers/bwa/Dockerfile
@@ -1,10 +1,10 @@
 ################## BASE IMAGE ######################
 
-FROM clinicalgenomics/mip:2.0
+FROM clinicalgenomics/mip_base:2.1
 
 ################## METADATA ######################
 
-LABEL base_image="clinicalgenomics/mip:2.0"
+LABEL base_image="clinicalgenomics/mip_base:2.1"
 LABEL version="1"
 LABEL software="bwa"
 LABEL software.version="0.7.17"

--- a/containers/bwakit/Dockerfile
+++ b/containers/bwakit/Dockerfile
@@ -1,10 +1,10 @@
 ################## BASE IMAGE ######################
 
-FROM clinicalgenomics/mip:2.0
+FROM clinicalgenomics/mip_base:2.1
 
 ################## METADATA ######################
 
-LABEL base_image="clinicalgenomics/mip:2.0"
+LABEL base_image="clinicalgenomics/mip_base:2.1"
 LABEL version="2"
 LABEL software="bwakit"
 LABEL software.version="0.7.17"

--- a/containers/cadd/Dockerfile
+++ b/containers/cadd/Dockerfile
@@ -1,10 +1,10 @@
 ################## BASE IMAGE ######################
 
-FROM clinicalgenomics/mip:2.0
+FROM clinicalgenomics/mip_base:2.1
 
 ################## METADATA ######################
 
-LABEL base_image="clinicalgenomics/mip:2.0"
+LABEL base_image="clinicalgenomics/mip_base:2.1"
 LABEL version="1"
 LABEL software="CADD"
 LABEL software.version="1.6"

--- a/containers/chanjo/Dockerfile
+++ b/containers/chanjo/Dockerfile
@@ -1,10 +1,10 @@
 ################## BASE IMAGE ######################
 
-FROM clinicalgenomics/mip:2.0
+FROM clinicalgenomics/mip_base:2.1
 
 ################## METADATA ######################
 
-LABEL base_image="clinicalgenomics/mip:2.0"
+LABEL base_image="clinicalgenomics/mip_base:2.1"
 LABEL version="1"
 LABEL software="chanjo"
 LABEL software.version="4.2.0"

--- a/containers/chromograph/Dockerfile
+++ b/containers/chromograph/Dockerfile
@@ -1,10 +1,10 @@
 ################## BASE IMAGE ######################
 
-FROM clinicalgenomics/mip:2.0
+FROM clinicalgenomics/mip_base:2.1
 
 ################## METADATA ######################
 
-LABEL base_image="clinicalgenomics/mip:2.0"
+LABEL base_image="clinicalgenomics/mip_base:2.1"
 LABEL version="8"
 LABEL software="chromograph"
 LABEL software.version="0.3.3"

--- a/containers/cyrius/Dockerfile
+++ b/containers/cyrius/Dockerfile
@@ -1,10 +1,10 @@
 ################## BASE IMAGE ######################
 
-FROM clinicalgenomics/mip:2.0
+FROM clinicalgenomics/mip_base:2.1
 
 ################## METADATA ######################
 
-LABEL base_image="clinicalgenomics/mip:2.0"
+LABEL base_image="clinicalgenomics/mip_base:2.1"
 LABEL version="1"
 LABEL software="Cyrius"
 LABEL software.version="1.0"

--- a/containers/delly/Dockerfile
+++ b/containers/delly/Dockerfile
@@ -1,10 +1,10 @@
 ################## BASE IMAGE ######################
 
-FROM clinicalgenomics/mip:2.0
+FROM clinicalgenomics/mip_base:2.1
 
 ################## METADATA ######################
 
-LABEL base_image="clinicalgenomics/mip:2.0"
+LABEL base_image="clinicalgenomics/mip_base:2.1"
 LABEL version="1"
 LABEL software="delly"
 LABEL software.version="0.8.1"

--- a/containers/expansionhunter/Dockerfile
+++ b/containers/expansionhunter/Dockerfile
@@ -1,10 +1,10 @@
 ################## BASE IMAGE ######################
 
-FROM clinicalgenomics/mip:2.0
+FROM clinicalgenomics/mip_base:2.1
 
 ################## METADATA ######################
 
-LABEL base_image="clinicalgenomics/mip:2.0"
+LABEL base_image="clinicalgenomics/mip_base:2.1"
 LABEL version="2"
 LABEL software="expansionhunter"
 LABEL software.version="3.2.2"

--- a/containers/fastqc/Dockerfile
+++ b/containers/fastqc/Dockerfile
@@ -1,10 +1,10 @@
 ################## BASE IMAGE ######################
 
-FROM clinicalgenomics/mip:2.0
+FROM clinicalgenomics/mip_base:2.1
 
 ################## METADATA ######################
 
-LABEL base_image="clinicalgenomics/mip:2.0"
+LABEL base_image="clinicalgenomics/mip_base:2.1"
 LABEL version="2"
 LABEL software="fastqc"
 LABEL software.version="0.11.9"

--- a/containers/genmod/Dockerfile
+++ b/containers/genmod/Dockerfile
@@ -1,10 +1,10 @@
 ################## BASE IMAGE ######################
 
-FROM clinicalgenomics/mip:2.0
+FROM clinicalgenomics/mip_base:2.1
 
 ################## METADATA ######################
 
-LABEL base_image="clinicalgenomics/mip:2.0"
+LABEL base_image="clinicalgenomics/mip_base:2.1"
 LABEL version="1"
 LABEL software="genmod"
 LABEL software.version="3.7.3"

--- a/containers/gffcompare/Dockerfile
+++ b/containers/gffcompare/Dockerfile
@@ -1,10 +1,10 @@
 ################## BASE IMAGE ######################
 
-FROM clinicalgenomics/mip:2.0
+FROM clinicalgenomics/mip_base:2.1
 
 ################## METADATA ######################
 
-LABEL base_image="clinicalgenomics/mip:2.0"
+LABEL base_image="clinicalgenomics/mip_base:2.1"
 LABEL version="1"
 LABEL software="gffcompare"
 LABEL software.version="0.11.2"

--- a/containers/htslib/Dockerfile
+++ b/containers/htslib/Dockerfile
@@ -1,10 +1,10 @@
 ################## BASE IMAGE ######################
 
-FROM clinicalgenomics/mip:2.0
+FROM clinicalgenomics/mip_base:2.1
 
 ################## METADATA ######################
 
-LABEL base_image="clinicalgenomics/mip:2.0"
+LABEL base_image="clinicalgenomics/mip_base:2.1"
 LABEL version="2"
 LABEL software="htslib"
 LABEL software.version="1.10"

--- a/containers/manta/Dockerfile
+++ b/containers/manta/Dockerfile
@@ -1,10 +1,10 @@
 ################## BASE IMAGE ######################
 
-FROM clinicalgenomics/mip:2.0
+FROM clinicalgenomics/mip_base:2.1
 
 ################## METADATA ######################
 
-LABEL base_image="clinicalgenomics/mip:2.0"
+LABEL base_image="clinicalgenomics/mip_base:2.1"
 LABEL version="1"
 LABEL software="manta"
 LABEL software.version="1.6.0"

--- a/containers/peddy/Dockerfile
+++ b/containers/peddy/Dockerfile
@@ -1,10 +1,10 @@
 ################## BASE IMAGE ######################
 
-FROM clinicalgenomics/mip:2.0
+FROM clinicalgenomics/mip_base:2.1
 
 ################## METADATA ######################
 
-LABEL base_image="clinicalgenomics/mip:2.0"
+LABEL base_image="clinicalgenomics/mip_base:2.1"
 LABEL version="1"
 LABEL software="peddy"
 LABEL software.version="0.4.3"

--- a/containers/plink/Dockerfile
+++ b/containers/plink/Dockerfile
@@ -1,10 +1,10 @@
 ################## BASE IMAGE ######################
 
-FROM clinicalgenomics/mip:2.0
+FROM clinicalgenomics/mip_base:2.1
 
 ################## METADATA ######################
 
-LABEL base_image="clinicalgenomics/mip:2.0"
+LABEL base_image="clinicalgenomics/mip_base:2.1"
 LABEL version="1"
 LABEL software="plink"
 LABEL software.version="1.90b3.35"

--- a/containers/preseq/Dockerfile
+++ b/containers/preseq/Dockerfile
@@ -1,10 +1,10 @@
 ################## BASE IMAGE ######################
 
-FROM clinicalgenomics/mip:2.0
+FROM clinicalgenomics/mip_base:2.1
 
 ################## METADATA ######################
 
-LABEL base_image="clinicalgenomics/mip:2.0"
+LABEL base_image="clinicalgenomics/mip_base:2.1"
 LABEL version="1"
 LABEL software="preseq"
 LABEL software.version="2.0.3"

--- a/containers/rhocall/Dockerfile
+++ b/containers/rhocall/Dockerfile
@@ -1,10 +1,10 @@
 ################## BASE IMAGE ######################
 
-FROM clinicalgenomics/mip:2.0
+FROM clinicalgenomics/mip_base:2.1
 
 ################## METADATA ######################
 
-LABEL base_image="clinicalgenomics/mip:2.0"
+LABEL base_image="clinicalgenomics/mip_base:2.1"
 LABEL version="1"
 LABEL software="rhocall"
 LABEL software.version="0.5.1"

--- a/containers/rseqc/Dockerfile
+++ b/containers/rseqc/Dockerfile
@@ -1,10 +1,10 @@
 ################## BASE IMAGE ######################
 
-FROM clinicalgenomics/mip:2.0
+FROM clinicalgenomics/mip_base:2.1
 
 ################## METADATA ######################
 
-LABEL base_image="clinicalgenomics/mip:2.0"
+LABEL base_image="clinicalgenomics/mip_base:2.1"
 LABEL version="1"
 LABEL software="rseqc"
 LABEL software.version="3.0.1"

--- a/containers/salmon/Dockerfile
+++ b/containers/salmon/Dockerfile
@@ -1,10 +1,10 @@
 ################## BASE IMAGE ######################
 
-FROM clinicalgenomics/mip:2.0
+FROM clinicalgenomics/mip_base:2.1
 
 ################## METADATA ######################
 
-LABEL base_image="clinicalgenomics/mip:2.0"
+LABEL base_image="clinicalgenomics/mip_base:2.1"
 LABEL version="1"
 LABEL software="salmon"
 LABEL software.version="0.12.0"

--- a/containers/sambamba/Dockerfile
+++ b/containers/sambamba/Dockerfile
@@ -1,10 +1,10 @@
 ################## BASE IMAGE ######################
 
-FROM clinicalgenomics/mip:2.0
+FROM clinicalgenomics/mip_base:2.1
 
 ################## METADATA ######################
 
-LABEL base_image="clinicalgenomics/mip:2.0"
+LABEL base_image="clinicalgenomics/mip_base:2.1"
 LABEL version="1"
 LABEL software="sambamba"
 LABEL software.version="0.6.8"

--- a/containers/smncopynumbercaller/Dockerfile
+++ b/containers/smncopynumbercaller/Dockerfile
@@ -1,10 +1,10 @@
 ################## BASE IMAGE ######################
 
-FROM clinicalgenomics/mip:2.0
+FROM clinicalgenomics/mip_base:2.1
 
 ################## METADATA ######################
 
-LABEL base_image="clinicalgenomics/mip:2.0"
+LABEL base_image="clinicalgenomics/mip_base:2.1"
 LABEL version="2"
 LABEL software="SMNCopyNumberCaller"
 LABEL software.version="1.0"

--- a/containers/star/Dockerfile
+++ b/containers/star/Dockerfile
@@ -1,10 +1,10 @@
 ################## BASE IMAGE ######################
 
-FROM clinicalgenomics/mip:2.0
+FROM clinicalgenomics/mip_base:2.1
 
 ################## METADATA ######################
 
-LABEL base_image="clinicalgenomics/mip:2.0"
+LABEL base_image="clinicalgenomics/mip_base:2.1"
 LABEL version="1"
 LABEL software="star"
 LABEL software.version="2.7.4a"

--- a/containers/stranger/Dockerfile
+++ b/containers/stranger/Dockerfile
@@ -1,10 +1,10 @@
 ################## BASE IMAGE ######################
 
-FROM clinicalgenomics/mip:2.0
+FROM clinicalgenomics/mip_base:2.1
 
 ################## METADATA ######################
 
-LABEL base_image="clinicalgenomics/mip:2.0"
+LABEL base_image="clinicalgenomics/mip_base:2.1"
 LABEL version="1"
 LABEL software="stranger"
 LABEL software.version="0.5.5"

--- a/containers/stringtie/Dockerfile
+++ b/containers/stringtie/Dockerfile
@@ -1,10 +1,10 @@
 ################## BASE IMAGE ######################
 
-FROM clinicalgenomics/mip:2.0
+FROM clinicalgenomics/mip_base:2.1
 
 ################## METADATA ######################
 
-LABEL base_image="clinicalgenomics/mip:2.0"
+LABEL base_image="clinicalgenomics/mip_base:2.1"
 LABEL version="1"
 LABEL software="stringtie"
 LABEL software.version="2.1.3b"

--- a/containers/trim_galore/Dockerfile
+++ b/containers/trim_galore/Dockerfile
@@ -1,10 +1,10 @@
 ################## BASE IMAGE ######################
 
-FROM clinicalgenomics/mip:2.0
+FROM clinicalgenomics/mip_base:2.1
 
 ################## METADATA ######################
 
-LABEL base_image="clinicalgenomics/mip:2.0"
+LABEL base_image="clinicalgenomics/mip_base:2.1"
 LABEL version="2"
 LABEL software="trim_galore"
 LABEL software.version="0.6.4"

--- a/containers/ucsc/Dockerfile
+++ b/containers/ucsc/Dockerfile
@@ -1,10 +1,10 @@
 ################## BASE IMAGE ######################
 
-FROM clinicalgenomics/mip:2.0
+FROM clinicalgenomics/mip_base:2.1
 
 ################## METADATA ######################
 
-LABEL base_image="clinicalgenomics/mip:2.0"
+LABEL base_image="clinicalgenomics/mip_base:2.1"
 LABEL version="2"
 LABEL software="ucsc-bedtobigbed, ucsc-gtftogenepred, ucsc-wigtobigwig"
 LABEL software.version="377"

--- a/containers/upd/Dockerfile
+++ b/containers/upd/Dockerfile
@@ -1,10 +1,10 @@
 ################## BASE IMAGE ######################
 
-FROM clinicalgenomics/mip:2.0
+FROM clinicalgenomics/mip_base:2.1
 
 ################## METADATA ######################
 
-LABEL base_image="clinicalgenomics/mip:2.0"
+LABEL base_image="clinicalgenomics/mip_base:2.1"
 LABEL version="1"
 LABEL software="upd"
 LABEL software.version="0.1"

--- a/containers/utilities/Dockerfile
+++ b/containers/utilities/Dockerfile
@@ -1,10 +1,10 @@
 ################## BASE IMAGE ######################
 
-FROM clinicalgenomics/mip:2.0
+FROM clinicalgenomics/mip_base:2.1
 
 ################## METADATA ######################
 
-LABEL base_image="clinicalgenomics/mip:2.0"
+LABEL base_image="clinicalgenomics/mip_base:2.1"
 LABEL version="2"
 LABEL software="utilities"
 LABEL extra.binaries="gtf2bed, pigz"

--- a/containers/varg/Dockerfile
+++ b/containers/varg/Dockerfile
@@ -1,10 +1,10 @@
 ################## BASE IMAGE ######################
 
-FROM clinicalgenomics/mip:2.0
+FROM clinicalgenomics/mip_base:2.1
 
 ################## METADATA ######################
 
-LABEL base_image="clinicalgenomics/mip:2.0"
+LABEL base_image="clinicalgenomics/mip_base:2.1"
 LABEL version="1"
 LABEL software="varg"
 LABEL software.version="1.2.0"

--- a/containers/vcfanno/Dockerfile
+++ b/containers/vcfanno/Dockerfile
@@ -1,10 +1,10 @@
 ################## BASE IMAGE ######################
 
-FROM clinicalgenomics/mip:2.0
+FROM clinicalgenomics/mip_base:2.1
 
 ################## METADATA ######################
 
-LABEL base_image="clinicalgenomics/mip:2.0"
+LABEL base_image="clinicalgenomics/mip_base:2.1"
 LABEL version="1"
 LABEL software="vcfanno"
 LABEL software.version="0.3.2"

--- a/containers/vt/Dockerfile
+++ b/containers/vt/Dockerfile
@@ -1,10 +1,10 @@
 ################## BASE IMAGE ######################
 
-FROM clinicalgenomics/mip:2.0
+FROM clinicalgenomics/mip_base:2.1
 
 ################## METADATA ######################
 
-LABEL base_image="clinicalgenomics/mip:2.0"
+LABEL base_image="clinicalgenomics/mip_base:2.1"
 LABEL version="1"
 LABEL software="vt"
 LABEL software.version="2015.11.10"

--- a/lib/MIP/Environment/Container.pm
+++ b/lib/MIP/Environment/Container.pm
@@ -23,7 +23,7 @@ BEGIN {
     use base qw{ Exporter };
 
     # Set the version for version checking
-    our $VERSION = 1.03;
+    our $VERSION = 1.04;
 
     # Functions and variables which can be optionally exported
     our @EXPORT_OK =
@@ -103,7 +103,7 @@ sub get_recipe_executable_bind_path {
                 }
             );
 
-            ## Special case for xdg_runtime_dir, which alwyas should be added
+            ## Special case for xdg_runtime_dir, which always should be added
             push @export_bind_paths, $xdg_runtime_dir;
 
             $recipe_executable_bind_path{$executable} = [@export_bind_paths];

--- a/lib/MIP/Program/Mip.pm
+++ b/lib/MIP/Program/Mip.pm
@@ -16,6 +16,7 @@ use Readonly;
 
 ## MIPs lib/
 use MIP::Constants qw{ $COMMA $SPACE };
+use MIP::Environment::Executable qw{ get_executable_base_command };
 use MIP::Unix::Standard_streams qw{ unix_standard_streams };
 use MIP::Unix::Write_to_file qw{ unix_write_to_file };
 
@@ -24,11 +25,13 @@ BEGIN {
     use base qw{ Exporter };
 
     # Set the version for version checking
-    our $VERSION = 1.06;
+    our $VERSION = 1.07;
 
     # Functions and variables which can be optionally exported
     our @EXPORT_OK = qw{ mip_download mip_qccollect mip_vcfparser mip_vercollect };
 }
+
+Readonly my $BASE_COMMAND => q{mip};
 
 sub mip_download {
 
@@ -103,8 +106,10 @@ sub mip_download {
 
     check( $tmpl, $arg_href, 1 ) or croak q{Could not parse arguments!};
 
-    # Stores commands depending on input parameters
-    my @commands = q{mip download};
+    my @commands = (
+        get_executable_base_command( { base_command => $BASE_COMMAND, } ),
+        qw{ download }
+    );
 
     push @commands, $pipeline;
 
@@ -220,8 +225,10 @@ sub mip_qccollect {
 
     check( $tmpl, $arg_href, 1 ) or croak q{Could not parse arguments!};
 
-    ## Stores commands depending on input parameters
-    my @commands = qw{ mip qccollect};
+    my @commands = (
+        get_executable_base_command( { base_command => $BASE_COMMAND, } ),
+        qw{ qccollect }
+    );
 
     if ($eval_metric_file) {
 
@@ -377,8 +384,10 @@ sub mip_vcfparser {
 
     check( $tmpl, $arg_href, 1 ) or croak q{Could not parse arguments!};
 
-    ## Stores commands depending on input parameters
-    my @commands = qw{ mip vcfparser };
+    my @commands = (
+        get_executable_base_command( { base_command => $BASE_COMMAND, } ),
+        qw{ vcfparser }
+    );
 
     ## Infile
     push @commands, $infile_path;
@@ -523,8 +532,10 @@ sub mip_vercollect {
 
     check( $tmpl, $arg_href, 1 ) or croak q{Could not parse arguments!};
 
-    ## Stores commands depending on input parameters
-    my @commands = qw{ mip vercollect};
+    my @commands = (
+        get_executable_base_command( { base_command => $BASE_COMMAND, } ),
+        qw{ vercollect }
+    );
 
     ## Options
     if ($log_file_path) {

--- a/lib/MIP/Recipes/Analysis/Mip_qccollect.pm
+++ b/lib/MIP/Recipes/Analysis/Mip_qccollect.pm
@@ -24,7 +24,7 @@ BEGIN {
     use base qw{ Exporter };
 
     # Set the version for version checking
-    our $VERSION = 1.11;
+    our $VERSION = 1.12;
 
     # Functions and variables which can be optionally exported
     our @EXPORT_OK = qw{ analysis_mip_qccollect };
@@ -170,16 +170,15 @@ sub analysis_mip_qccollect {
     ## Creates recipe directories (info & data & script), recipe script filenames and writes sbatch header
     my ($recipe_file_path) = setup_script(
         {
-            active_parameter_href           => $active_parameter_href,
-            core_number                     => $recipe_resource{core_number},
-            directory_id                    => $case_id,
-            filehandle                      => $filehandle,
-            job_id_href                     => $job_id_href,
-            memory_allocation               => $recipe_resource{memory},
-            recipe_directory                => $recipe_name,
-            recipe_name                     => $recipe_name,
-            process_time                    => $recipe_resource{time},
-            source_environment_commands_ref => $recipe_resource{load_env_ref},
+            active_parameter_href => $active_parameter_href,
+            core_number           => $recipe_resource{core_number},
+            directory_id          => $case_id,
+            filehandle            => $filehandle,
+            job_id_href           => $job_id_href,
+            memory_allocation     => $recipe_resource{memory},
+            recipe_directory      => $recipe_name,
+            recipe_name           => $recipe_name,
+            process_time          => $recipe_resource{time},
         }
     );
 

--- a/lib/MIP/Recipes/Analysis/Mip_vcfparser.pm
+++ b/lib/MIP/Recipes/Analysis/Mip_vcfparser.pm
@@ -26,7 +26,7 @@ BEGIN {
     use base qw{ Exporter };
 
     # Set the version for version checking
-    our $VERSION = 1.26;
+    our $VERSION = 1.27;
 
     # Functions and variables which can be optionally exported
     our @EXPORT_OK =
@@ -256,17 +256,16 @@ sub analysis_mip_vcfparser {
     ## Creates recipe directories (info & data & script), recipe script filenames and writes sbatch header
     my ( $recipe_file_path, $recipe_info_path ) = setup_script(
         {
-            active_parameter_href           => $active_parameter_href,
-            core_number                     => $core_number,
-            directory_id                    => $case_id,
-            filehandle                      => $filehandle,
-            job_id_href                     => $job_id_href,
-            memory_allocation               => $memory_allocation,
-            process_time                    => $recipe_resource{time},
-            recipe_directory                => $recipe_name,
-            recipe_name                     => $recipe_name,
-            source_environment_commands_ref => $recipe_resource{load_env_ref},
-            temp_directory                  => $temp_directory,
+            active_parameter_href => $active_parameter_href,
+            core_number           => $core_number,
+            directory_id          => $case_id,
+            filehandle            => $filehandle,
+            job_id_href           => $job_id_href,
+            memory_allocation     => $memory_allocation,
+            process_time          => $recipe_resource{time},
+            recipe_directory      => $recipe_name,
+            recipe_name           => $recipe_name,
+            temp_directory        => $temp_directory,
         }
     );
 
@@ -622,19 +621,18 @@ sub analysis_mip_vcfparser_panel {
     my $filehandle = IO::Handle->new();
 
     ## Creates recipe directories (info & data & script), recipe script filenames and writes sbatch header
-    my ( $recipe_file_path, $recipe_info_path ) = setup_script(
+    my ($recipe_file_path) = setup_script(
         {
-            active_parameter_href           => $active_parameter_href,
-            core_number                     => $recipe_resource{core_number},
-            directory_id                    => $case_id,
-            filehandle                      => $filehandle,
-            job_id_href                     => $job_id_href,
-            memory_allocation               => $recipe_resource{memory},
-            process_time                    => $recipe_resource{time},
-            recipe_directory                => $recipe_name,
-            recipe_name                     => $recipe_name,
-            source_environment_commands_ref => $recipe_resource{load_env_ref},
-            temp_directory                  => $temp_directory,
+            active_parameter_href => $active_parameter_href,
+            core_number           => $recipe_resource{core_number},
+            directory_id          => $case_id,
+            filehandle            => $filehandle,
+            job_id_href           => $job_id_href,
+            memory_allocation     => $recipe_resource{memory},
+            process_time          => $recipe_resource{time},
+            recipe_directory      => $recipe_name,
+            recipe_name           => $recipe_name,
+            temp_directory        => $temp_directory,
         }
     );
 
@@ -988,19 +986,18 @@ sub analysis_mip_vcfparser_sv_wes {
     my @outfile_suffixes    = @{ $io{out}{file_suffixes} };
 
     ## Creates recipe directories (info & data & script), recipe script filenames and writes sbatch header
-    my ( $recipe_file_path, $recipe_info_path ) = setup_script(
+    my ($recipe_file_path) = setup_script(
         {
-            active_parameter_href           => $active_parameter_href,
-            core_number                     => $CORE_NUMBER,
-            directory_id                    => $case_id,
-            filehandle                      => $filehandle,
-            job_id_href                     => $job_id_href,
-            memory_allocation               => $MEMORY_ALLOCATION,
-            process_time                    => $recipe_resource{time},
-            recipe_directory                => $recipe_name,
-            recipe_name                     => $recipe_name,
-            source_environment_commands_ref => $recipe_resource{load_env_ref},
-            temp_directory                  => $temp_directory,
+            active_parameter_href => $active_parameter_href,
+            core_number           => $CORE_NUMBER,
+            directory_id          => $case_id,
+            filehandle            => $filehandle,
+            job_id_href           => $job_id_href,
+            memory_allocation     => $MEMORY_ALLOCATION,
+            process_time          => $recipe_resource{time},
+            recipe_directory      => $recipe_name,
+            recipe_name           => $recipe_name,
+            temp_directory        => $temp_directory,
         }
     );
 
@@ -1303,17 +1300,16 @@ sub analysis_mip_vcfparser_sv_wgs {
     ## Creates recipe directories (info & data & script), recipe script filenames and writes sbatch header
     my ( $recipe_file_path, $recipe_info_path ) = setup_script(
         {
-            active_parameter_href           => $active_parameter_href,
-            core_number                     => $recipe_resource{core_number},
-            directory_id                    => $case_id,
-            filehandle                      => $filehandle,
-            job_id_href                     => $job_id_href,
-            memory_allocation               => $recipe_resource{memory},
-            process_time                    => $recipe_resource{time},
-            recipe_directory                => $recipe_name,
-            recipe_name                     => $recipe_name,
-            source_environment_commands_ref => $recipe_resource{load_env_ref},
-            temp_directory                  => $temp_directory,
+            active_parameter_href => $active_parameter_href,
+            core_number           => $recipe_resource{core_number},
+            directory_id          => $case_id,
+            filehandle            => $filehandle,
+            job_id_href           => $job_id_href,
+            memory_allocation     => $recipe_resource{memory},
+            process_time          => $recipe_resource{time},
+            recipe_directory      => $recipe_name,
+            recipe_name           => $recipe_name,
+            temp_directory        => $temp_directory,
         }
     );
 

--- a/lib/MIP/Recipes/Analysis/Mip_vercollect.pm
+++ b/lib/MIP/Recipes/Analysis/Mip_vercollect.pm
@@ -13,7 +13,6 @@ use warnings qw{ FATAL utf8 };
 
 ## CPANM
 use autodie qw{ :all };
-use Readonly;
 
 ## MIPs lib/
 use MIP::Constants qw{ %CONTAINER_CMD $LOG_NAME $NEWLINE $UNDERSCORE };
@@ -24,7 +23,7 @@ BEGIN {
     use base qw{ Exporter };
 
     # Set the version for version checking
-    our $VERSION = 1.10;
+    our $VERSION = 1.11;
 
     # Functions and variables which can be optionally exported
     our @EXPORT_OK = qw{ analysis_mip_vercollect };
@@ -164,16 +163,15 @@ sub analysis_mip_vercollect {
     ## Creates recipe directories (info & data & script), recipe script filenames and writes sbatch header
     my ($recipe_file_path) = setup_script(
         {
-            active_parameter_href           => $active_parameter_href,
-            core_number                     => $recipe_resource{core_number},
-            directory_id                    => $case_id,
-            filehandle                      => $filehandle,
-            job_id_href                     => $job_id_href,
-            memory_allocation               => $recipe_resource{memory},
-            recipe_directory                => $recipe_name,
-            recipe_name                     => $recipe_name,
-            process_time                    => $recipe_resource{time},
-            source_environment_commands_ref => $recipe_resource{load_env_ref},
+            active_parameter_href => $active_parameter_href,
+            core_number           => $recipe_resource{core_number},
+            directory_id          => $case_id,
+            filehandle            => $filehandle,
+            job_id_href           => $job_id_href,
+            memory_allocation     => $recipe_resource{memory},
+            recipe_directory      => $recipe_name,
+            recipe_name           => $recipe_name,
+            process_time          => $recipe_resource{time},
         }
     );
 

--- a/t/data/test_data/reference_info.yaml
+++ b/t/data/test_data/reference_info.yaml
@@ -1,5 +1,4 @@
 ---
 mip:
-  path: /Users/henrik.stranneheim/git/MIP/t/data/modules/miniconda/envs/mip_ci/bin/mip
+  path: /path/MIP/t/data/modules/miniconda/envs/mip_ci/bin/mip
   version: v7.1.4
-

--- a/t/data/test_data/reference_info.yaml
+++ b/t/data/test_data/reference_info.yaml
@@ -1,5 +1,5 @@
 ---
 mip:
-  path: /path/MIP/t/data/modules/miniconda/envs/mip_ci/bin/mip
+  path: /Users/henrik.stranneheim/git/MIP/t/data/modules/miniconda/envs/mip_ci/bin/mip
   version: v7.1.4
 

--- a/t/get_binary_version_cmd.t
+++ b/t/get_binary_version_cmd.t
@@ -1,0 +1,131 @@
+#!/usr/bin/env perl
+
+use 5.026;
+use Carp;
+use charnames qw{ :full :short };
+use English qw{ -no_match_vars };
+use File::Basename qw{ dirname };
+use File::Spec::Functions qw{ catdir };
+use FindBin qw{ $Bin };
+use open qw{ :encoding(UTF-8) :std };
+use Params::Check qw{ allow check last_error };
+use Test::More;
+use utf8;
+use warnings qw{ FATAL utf8 };
+
+## CPANM
+use autodie qw { :all };
+use Modern::Perl qw{ 2018 };
+use Readonly;
+
+## MIPs lib/
+use lib catdir( dirname($Bin), q{lib} );
+use MIP::Constants qw{ $COMMA $EMPTY_STR $SPACE };
+use MIP::Test::Fixtures qw{ test_standard_cli };
+
+my $VERBOSE = 1;
+our $VERSION = 1.00;
+
+$VERBOSE = test_standard_cli(
+    {
+        verbose => $VERBOSE,
+        version => $VERSION,
+    }
+);
+
+BEGIN {
+
+    use MIP::Test::Fixtures qw{ test_import };
+
+### Check all internal dependency modules and imports
+## Modules with import
+    my %perl_module = (
+        q{MIP::Constants}               => [qw{ set_container_cmd }],
+        q{MIP::Environment::Executable} => [qw{ get_binary_version_cmd }],
+        q{MIP::Test::Fixtures}          => [qw{ test_standard_cli }],
+    );
+
+    test_import( { perl_module_href => \%perl_module, } );
+}
+
+use MIP::Constants qw{ set_container_cmd };
+use MIP::Environment::Executable qw{ get_binary_version_cmd };
+
+diag(   q{Test get_binary_version_cmd from Executable.pm v}
+      . $MIP::Environment::Executable::VERSION
+      . $COMMA
+      . $SPACE . q{Perl}
+      . $SPACE
+      . $PERL_VERSION
+      . $SPACE
+      . $EXECUTABLE_NAME );
+
+## Given an executable name
+my @version_cmd = get_binary_version_cmd(
+    {
+        binary     => q{vep},
+        binary_cmd => q{vep}
+    }
+);
+
+my @expected_version_cmd = (
+    qw{ vep | perl -n -a -e },
+    q?'my ($version) = /ensembl-vep\s+:\s(\d+)/xms; if($version) {print $version;last;}'?,
+);
+
+## Then return version command
+is_deeply( \@version_cmd, \@expected_version_cmd, q{Got executable version command} );
+
+## Given an existing perl command in CONTAINER_CMD
+my $container_base_command =
+  q{singularity exec docker.io/clinicalgenomics/perl:5.26 perl};
+my %container_cmd = ( perl => $container_base_command, );
+
+set_container_cmd( { container_cmd_href => \%container_cmd, } );
+
+## When calling using container
+@version_cmd = get_binary_version_cmd(
+    {
+        binary        => q{vep},
+        binary_cmd    => q{vep},
+        use_container => 1,
+    }
+);
+
+my @expected_version_cmd_container = (
+    qw{ vep | },
+    q{singularity exec docker.io/clinicalgenomics/perl:5.26 perl},
+    qw{ -n -a -e },
+    q?'my ($version) = /ensembl-vep\s+:\s(\d+)/xms; if($version) {print $version;last;}'?,
+);
+
+## Then return version command
+is_deeply(
+    \@version_cmd,
+    \@expected_version_cmd_container,
+    q{Got executable version command with perl container}
+);
+
+## Given an executable name and stdoutfile path to append to
+my $stdoutfile_path = q{an_outfile_path};
+@version_cmd = get_binary_version_cmd(
+    {
+        binary                 => q{vep},
+        binary_cmd             => q{vep},
+        stdoutfile_path_append => $stdoutfile_path,
+    }
+);
+
+my @expected_version_cmd_stdout = (
+    qw{ vep | perl -n -a -e },
+    q?'my ($version) = /ensembl-vep\s+:\s(\d+)/xms; if($version) {print $version;last;}'?,
+    q{1>>} . $SPACE . $stdoutfile_path,
+);
+
+## Then return version command
+is_deeply(
+    \@version_cmd,
+    \@expected_version_cmd_stdout,
+    q{Got executable version command appending to stdout}
+);
+done_testing();

--- a/t/mip_download.t
+++ b/t/mip_download.t
@@ -16,7 +16,6 @@ use warnings qw{ FATAL utf8 };
 ## CPANM
 use autodie qw{ :all };
 use Modern::Perl qw{ 2018 };
-use Readonly;
 
 ## MIPs lib/
 use lib catdir( dirname($Bin), q{lib} );
@@ -24,7 +23,7 @@ use MIP::Constants qw{ $COMMA $SPACE };
 use MIP::Test::Fixtures qw{ test_standard_cli };
 
 my $VERBOSE = 1;
-our $VERSION = 1.03;
+our $VERSION = 1.04;
 
 $VERBOSE = test_standard_cli(
     {
@@ -60,7 +59,7 @@ diag(   q{Test mip_download from Mip.pm v}
       . $EXECUTABLE_NAME );
 
 ## Base arguments
-my @function_base_commands = q{mip download};
+my @function_base_commands = qw{ mip download };
 
 my %base_argument = (
     stdoutfile_path => {
@@ -135,7 +134,7 @@ my @arguments = ( \%base_argument, \%specific_argument );
 
 ARGUMENT_HASH_REF:
 foreach my $argument_href (@arguments) {
-    my @commands = test_function(
+    test_function(
         {
             argument_href              => $argument_href,
             do_test_base_command       => 1,

--- a/t/perl_nae_oneliners.t
+++ b/t/perl_nae_oneliners.t
@@ -25,7 +25,7 @@ use MIP::Test::Commands qw{ test_function };
 use MIP::Test::Fixtures qw{ test_standard_cli };
 
 my $VERBOSE = 1;
-our $VERSION = 1.02;
+our $VERSION = 1.03;
 
 $VERBOSE = test_standard_cli(
     {
@@ -78,6 +78,10 @@ my %base_argument = (
     stdoutfile_path => {
         input           => q{stdoutfile.test},
         expected_output => q{1> stdoutfile.test},
+    },
+    stdoutfile_path_append => {
+        input           => q{stdoutfile.test},
+        expected_output => q{1>> stdoutfile.test},
     },
 );
 

--- a/t/write_binaries_versions.t
+++ b/t/write_binaries_versions.t
@@ -1,0 +1,96 @@
+#!/usr/bin/env perl
+
+use 5.026;
+use Carp;
+use charnames qw{ :full :short };
+use English qw{ -no_match_vars };
+use File::Basename qw{ dirname };
+use File::Spec::Functions qw{ catdir };
+use FindBin qw{ $Bin };
+use open qw{ :encoding(UTF-8) :std };
+use Params::Check qw{ allow check last_error };
+use Test::More;
+use utf8;
+use warnings qw{ FATAL utf8 };
+
+## CPANM
+use autodie qw { :all };
+use Modern::Perl qw{ 2018 };
+use Readonly;
+
+## MIPs lib/
+use lib catdir( dirname($Bin), q{lib} );
+use MIP::Constants qw{ $COLON $COMMA $EMPTY_STR $SPACE };
+use MIP::Test::Fixtures qw{ test_standard_cli };
+
+my $VERBOSE = 1;
+our $VERSION = 1.00;
+
+$VERBOSE = test_standard_cli(
+    {
+        verbose => $VERBOSE,
+        version => $VERSION,
+    }
+);
+
+BEGIN {
+
+    use MIP::Test::Fixtures qw{ test_import };
+
+### Check all internal dependency modules and imports
+## Modules with import
+    my %perl_module = (
+        q{MIP::Environment::Executable} => [qw{ write_binaries_versions }],
+        q{MIP::Test::Fixtures}          => [qw{ test_standard_cli }],
+    );
+
+    test_import( { perl_module_href => \%perl_module, } );
+}
+
+use MIP::Environment::Executable qw{ write_binaries_versions };
+
+diag(   q{Test write_binaries_versions from Executable.pm v}
+      . $MIP::Environment::Executable::VERSION
+      . $COMMA
+      . $SPACE . q{Perl}
+      . $SPACE
+      . $PERL_VERSION
+      . $SPACE
+      . $EXECUTABLE_NAME );
+
+# For storing info to write
+my $file_content;
+
+## Store file content in memory by using referenced variable
+open my $filehandle, q{>}, \$file_content
+  or croak q{Cannot write to} . $SPACE . $file_content . $COLON . $SPACE . $OS_ERROR;
+
+## Given an existing perl command in CONTAINER_CMD
+my $container_perl_command =
+  q{singularity exec docker.io/clinicalgenomics/perl:5.26 perl};
+my $container_vep_command =
+  q{singularity exec docker.io/ensemblorg/ensembl-vep:release_100.2 vep};
+
+my %container_cmd = (
+    perl => $container_perl_command,
+    vep  => $container_vep_command,
+);
+
+## Given an executable name
+my $outfile_path = q{an_outfile};
+
+write_binaries_versions(
+    {
+        binary_info_href => \%container_cmd,
+        filehandle       => $filehandle,
+        outfile_path     => $outfile_path,
+    }
+);
+
+close $filehandle;
+
+## Then return version command
+my ($returned_base_command) = $file_content =~ /($outfile_path)/mxs;
+is( $returned_base_command, $outfile_path, q{Wrote binary version command} );
+
+done_testing();

--- a/templates/code/Dockerfile
+++ b/templates/code/Dockerfile
@@ -1,10 +1,10 @@
 ################## BASE IMAGE ######################
 
-FROM clinicalgenomics/mip:2.0
+FROM clinicalgenomics/mip_base:2.1
 
 ################## METADATA ######################
 
-LABEL base_image="clinicalgenomics/mip:2.0"
+LABEL base_image="clinicalgenomics/mip_base:2.1"
 LABEL version="1"
 LABEL software="SOFTWARE"
 LABEL software.version="VERSION"

--- a/templates/mip_install_config.yaml
+++ b/templates/mip_install_config.yaml
@@ -115,7 +115,7 @@ container:
   mip:
     executable:
       mip:
-    uri: docker.io/clinicalgenomics/mip
+    uri: docker.io/clinicalgenomics/mip:9.0.5
   multiqc:
     executable:
       multiqc:

--- a/templates/mip_install_config.yaml
+++ b/templates/mip_install_config.yaml
@@ -112,6 +112,10 @@ container:
       configManta.py:
       runWorkflow.py: "no_executable_in_image"
     uri: docker.io/clinicalgenomics/manta:1.6.0
+  mip:
+    executable:
+      mip:
+    uri: docker.io/clinicalgenomics/mip
   multiqc:
     executable:
       multiqc:


### PR DESCRIPTION
### This PR adds | fixes:

- Adds a full mip container to use when not interacting with SLURM
- Add github actions to build and push docker mip image
- Rename MIP base image to mip_base to avoid namespace clash in dockerhub and bump its version
- Use new MIP base image in the rest of the MIP dockerfiles
- Use new mip container in MIP specific recipes
- Remove sourcing of conda env form these MIP specific recipes

### How to test:

- Automatic and continuous test suite

### Expected outcome:
- [ ] Installation, unit and integration test suite pass

### Review:
- [ ] Code review
- [ ] Tests pass

This [version](https://semver.org/) is a:
- [ ] **MAJOR** - when you make incompatible API changes. If applicable record manual test results in PR header
- [x] **MINOR** - when you add functionality in a backwards compatible manner. If applicable record manual test results in PR header
- [ ] **PATCH** - when you make backwards compatible bug fixes or documentation/instructions
