### PR TITLE
Vercollect recipe

### DIFF
--- a/lib/MIP/Environment/Container.pm
+++ b/lib/MIP/Environment/Container.pm
@@ -23,7 +23,7 @@ BEGIN {
     use base qw{ Exporter };
 
     # Set the version for version checking
-    our $VERSION = 1.03;
+    our $VERSION = 1.04;
 
     # Functions and variables which can be optionally exported
     our @EXPORT_OK =
@@ -103,7 +103,7 @@ sub get_recipe_executable_bind_path {
                 }
             );
 
-            ## Special case for xdg_runtime_dir, which alwyas should be added
+            ## Special case for xdg_runtime_dir, which always should be added
             push @export_bind_paths, $xdg_runtime_dir;
 
             $recipe_executable_bind_path{$executable} = [@export_bind_paths];

--- a/lib/MIP/Environment/Executable.pm
+++ b/lib/MIP/Environment/Executable.pm
@@ -22,15 +22,17 @@ BEGIN {
     use base qw{ Exporter };
 
     # Set the version for version checking
-    our $VERSION = 1.12;
+    our $VERSION = 1.13;
 
     # Functions and variables which can be optionally exported
     our @EXPORT_OK = qw{
       build_binary_version_cmd
       get_binaries_versions
+      get_binary_version_cmd
       get_executable
       get_executable_base_command
       get_binary_version
+      write_binaries_versions
     };
 }
 
@@ -38,22 +40,38 @@ sub build_binary_version_cmd {
 
 ## Function : Build binary version commands
 ## Returns  : @version_cmds
-## Arguments: $binary_path    => Executables (binary) file path
-##          : $version_cmd    => Version command line option
-##          : $version_regexp => Version reg exp to get version from system call
+## Arguments: $binary_path            => Executables (binary) file path
+##          : $stdoutfile_path_append => Append stdout info to file path
+##          : $use_container          => Use container perl
+##          : $version_cmd            => Version command line option
+##          : $version_regexp         => Version reg exp to get version from system call
 
     my ($arg_href) = @_;
 
     ## Flatten argument(s)
     my $binary_path;
+    my $stdoutfile_path_append;
     my $version_cmd;
     my $version_regexp;
+
+    ## Default(s)
+    my $use_container;
 
     my $tmpl = {
         binary_path => {
             defined     => 1,
             required    => 1,
             store       => \$binary_path,
+            strict_type => 1,
+        },
+        stdoutfile_path_append => {
+            store       => \$stdoutfile_path_append,
+            strict_type => 1,
+        },
+        use_container => => {
+            allow       => [ undef, 0, 1 ],
+            default     => 0,
+            store       => \$use_container,
             strict_type => 1,
         },
         version_cmd => {
@@ -75,7 +93,9 @@ sub build_binary_version_cmd {
     ## Get perl wrapper around regexp
     my @perl_commands = perl_nae_oneliners(
         {
-            oneliner_cmd => $version_regexp,
+            oneliner_cmd           => $version_regexp,
+            stdoutfile_path_append => $stdoutfile_path_append,
+            use_container          => $use_container,
         }
     );
 
@@ -138,6 +158,125 @@ sub get_binaries_versions {
         );
     }
     return %binary;
+}
+
+sub write_binaries_versions {
+
+## Function : Write executables/binaries versions
+## Returns  :
+## Arguments: $binary_info_href => Binary_Info_Href object
+##          : $filehandle       => Filehandle to write to
+##          : $outfile_path     => Outfile path
+
+    my ($arg_href) = @_;
+
+    ## Flatten argument(s)
+    my $binary_info_href;
+    my $filehandle;
+    my $outfile_path;
+
+    my $tmpl = {
+        binary_info_href => {
+            default     => {},
+            defined     => 1,
+            required    => 1,
+            store       => \$binary_info_href,
+            strict_type => 1,
+        },
+        filehandle => {
+            required => 1,
+            store    => \$filehandle,
+        },
+        outfile_path => {
+            defined     => 1,
+            required    => 1,
+            store       => \$outfile_path,
+            strict_type => 1,
+        },
+    };
+
+    check( $tmpl, $arg_href, 1 ) or croak q{Could not parse arguments!};
+
+    my %executable = get_executable( {} );
+
+  BINARY:
+    while ( my ( $binary, $binary_cmd ) = each %{$binary_info_href} ) {
+
+        ## No information on how to get version for this binary - skip
+        next BINARY if ( not exists $executable{$binary} );
+
+        my @version_cmds = get_binary_version_cmd(
+            {
+                binary                 => $binary,
+                binary_cmd             => $binary_cmd,
+                stdoutfile_path_append => $outfile_path,
+                use_container          => 1,
+            }
+        );
+
+        say {$filehandle} join $SPACE, @version_cmds;
+    }
+    return;
+}
+
+sub get_binary_version_cmd {
+
+## Function : Get binary version cmd
+## Returns  : @version_cmds
+## Arguments: $binary                 => Binary to get version of
+##          : $binary_cmd             => Path to binary
+##          : $stdoutfile_path_append => Append stdout info to file path
+##          : $use_container          => Use container perl
+
+    my ($arg_href) = @_;
+
+    ## Flatten argument(s)
+    my $binary;
+    my $binary_cmd;
+    my $stdoutfile_path_append;
+
+    ## Default(s)
+    my $use_container;
+
+    my $tmpl = {
+        binary => {
+            defined     => 1,
+            required    => 1,
+            store       => \$binary,
+            strict_type => 1,
+        },
+        binary_cmd => {
+            defined     => 1,
+            required    => 1,
+            store       => \$binary_cmd,
+            strict_type => 1,
+        },
+        stdoutfile_path_append =>
+          { store => \$stdoutfile_path_append, strict_type => 1, },
+        use_container => => {
+            allow       => [ undef, 0, 1 ],
+            default     => 0,
+            store       => \$use_container,
+            strict_type => 1,
+        },
+    };
+
+    check( $tmpl, $arg_href, 1 ) or croak q{Could not parse arguments!};
+
+    my %executable = get_executable( { executable_name => $binary, } );
+
+    ## Get version command
+    my @version_cmds = build_binary_version_cmd(
+        {
+            binary_path            => $binary_cmd,
+            stdoutfile_path_append => $stdoutfile_path_append,
+            use_container          => $use_container,
+            version_cmd            => $executable{version_cmd},
+            version_regexp         => $executable{version_regexp},
+        }
+    );
+
+    return @version_cmds;
 }
 
 sub get_binary_version {

--- a/lib/MIP/Language/Perl.pm
+++ b/lib/MIP/Language/Perl.pm
@@ -24,7 +24,7 @@ BEGIN {
     use base qw{ Exporter };
 
     # Set the version for version checking
-    our $VERSION = 1.15;
+    our $VERSION = 1.16;
 
     our @EXPORT_OK =
       qw{ check_modules_existance get_cpan_file_modules perl_base perl_nae_oneliners };
@@ -149,31 +149,31 @@ sub perl_base {
     my $use_container;
 
     my $tmpl = {
-        autosplit     => {
+        autosplit => {
             allow       => [ undef, 0, 1 ],
             default     => 0,
             store       => \$autosplit,
             strict_type => 1,
         },
-        command_line  => {
+        command_line => {
             allow       => [ undef, 0, 1 ],
             default     => 0,
             store       => \$command_line,
             strict_type => 1,
         },
-        inplace       => {
+        inplace => {
             allow       => [ undef, 0, 1 ],
             default     => 0,
             store       => \$inplace,
             strict_type => 1,
         },
-        n             => {
+        n => {
             allow       => [ undef, 0, 1 ],
             default     => 0,
             store       => \$n,
             strict_type => 1,
         },
-        print         => {
+        print => {
             allow       => [ undef, 0, 1 ],
             default     => 0,
             store       => \$print,
@@ -189,9 +189,12 @@ sub perl_base {
 
     check( $tmpl, $arg_href, 1 ) or croak q{Could not parse arguments!};
 
-     use MIP::Environment::Executable qw{ get_executable_base_command };
+    use MIP::Environment::Executable qw{ get_executable_base_command };
 
-    my @commands = $use_container ? (get_executable_base_command({ base_command => q{perl}, }),) : qw{ perl };
+    my @commands =
+      $use_container
+      ? ( get_executable_base_command( { base_command => q{perl}, } ), )
+      : qw{ perl };
 
     if ($n) {
 
@@ -233,6 +236,7 @@ sub perl_nae_oneliners {
 ##          : $stderrfile_path_append => Append stderr info to file path
 ##          : $stdinfile_path         => Stdinfile path
 ##          : $stdoutfile_path        => Stdoutfile path
+##          : $stdoutfile_path_append => Append stdout info to file path
 ##          : $use_container          => Use container perl instead of main (this) process perl
 
     my ($arg_href) = @_;
@@ -247,6 +251,7 @@ sub perl_nae_oneliners {
     my $stderrfile_path_append;
     my $stdinfile_path;
     my $stdoutfile_path;
+    my $stdoutfile_path_append;
 
     ## Default(s)
     my $autosplit;
@@ -304,6 +309,10 @@ sub perl_nae_oneliners {
         stdinfile_path  => { store => \$stdinfile_path, strict_type => 1, },
         stdoutfile_path => {
             store       => \$stdoutfile_path,
+            strict_type => 1,
+        },
+        stdoutfile_path_append => {
+            store       => \$stdoutfile_path_append,
             strict_type => 1,
         },
         use_container => => {
@@ -390,6 +399,7 @@ sub perl_nae_oneliners {
             stderrfile_path_append => $stderrfile_path_append,
             stdinfile_path         => $stdinfile_path,
             stdoutfile_path        => $stdoutfile_path,
+            stdoutfile_path_append => $stdoutfile_path_append,
         }
       );
 

--- a/lib/MIP/Language/Perl.pm
+++ b/lib/MIP/Language/Perl.pm
@@ -15,7 +15,7 @@ use autodie qw{ :all };
 use Readonly;
 
 ## MIPs lib/
-use MIP::Constants qw{ $BACKWARD_SLASH $DASH $DOT $NEWLINE $SPACE $SINGLE_QUOTE };
+use MIP::Constants qw{ $BACKWARD_SLASH $DASH $DOT $COLON $NEWLINE $SPACE $SINGLE_QUOTE };
 use MIP::Unix::Standard_streams qw{ unix_standard_streams };
 use MIP::Unix::Write_to_file qw{ unix_write_to_file };
 
@@ -327,6 +327,7 @@ sub perl_nae_oneliners {
 
     ## Oneliner dispatch table
     my %oneliner = (
+        add_binary                           => \&_add_binary,
         build_md5sum_check                   => \&_build_md5sum_check,
         genepred_to_refflat                  => \&_genepred_to_refflat,
         get_dict_contigs                     => \&_get_dict_contigs,
@@ -348,6 +349,9 @@ sub perl_nae_oneliners {
     );
 
     my %oneliner_option = (
+        add_binary => {
+            binary => $oneliner_parameter,
+        },
         build_md5sum_check => {
             file_path => $oneliner_parameter,
         },
@@ -412,6 +416,33 @@ sub perl_nae_oneliners {
         }
     );
     return @commands;
+}
+
+sub _add_binary {
+
+## Function : Add "binary: " to stdin
+## Returns  : $add_binary
+## Arguments: $binary => Binary to add
+
+    my ($arg_href) = @_;
+
+    ## Flatten argument(s)
+    my $binary;
+
+    my $tmpl = {
+        binary => {
+            defined     => 1,
+            required    => 1,
+            store       => \$binary,
+            strict_type => 1,
+        },
+    };
+
+    check( $tmpl, $arg_href, 1 ) or croak q{Could not parse arguments!};
+
+    my $add_binary = q?'say STDOUT qq{? . $binary . $COLON . $SPACE . q?$_}'?;
+
+    return $add_binary;
 }
 
 sub _build_md5sum_check {

--- a/lib/MIP/Recipes/Analysis/Mip_vercollect.pm
+++ b/lib/MIP/Recipes/Analysis/Mip_vercollect.pm
@@ -190,7 +190,7 @@ sub analysis_mip_vercollect {
         }
     );
     say {$filehandle} $NEWLINE;
-    ## Write executable versions
+
     write_binaries_versions(
         {
             binary_info_href => \%CONTAINER_CMD,
@@ -198,30 +198,6 @@ sub analysis_mip_vercollect {
             outfile_path     => $outfile_path,
         }
     );
-
-#    my $binary_path_file_path = $outfile_path_prefix . $UNDERSCORE . q{binary_paths.yaml};
-
-    ## Writes a YAML hash to file
-    #    write_to_file(
-    #        {
-    #            data_href => \%CONTAINER_CMD,
-    #            format    => q{yaml},
-    #            path      => $binary_path_file_path,
-    #        }
-    #    );
-    #    $log->info( q{Wrote: } . $binary_path_file_path );
-
-    #    my $log_file_path = $outfile_path_prefix . $UNDERSCORE . q{vercollect.log};
-
-    #    mip_vercollect(
-    #       {
-    #           filehandle    => $filehandle,
-    #           infile_path   => $binary_path_file_path,
-    #           log_file_path => $log_file_path,
-    #           outfile_path  => $outfile_path,
-    #       }
-    #   );
-    #   say {$filehandle} $NEWLINE;
 
     close $filehandle or $log->logcroak(q{Could not close filehandle});
 

--- a/lib/MIP/Recipes/Analysis/Mip_vercollect.pm
+++ b/lib/MIP/Recipes/Analysis/Mip_vercollect.pm
@@ -23,7 +23,7 @@ BEGIN {
     use base qw{ Exporter };
 
     # Set the version for version checking
-    our $VERSION = 1.11;
+    our $VERSION = 1.12;
 
     # Functions and variables which can be optionally exported
     our @EXPORT_OK = qw{ analysis_mip_vercollect };
@@ -175,31 +175,52 @@ sub analysis_mip_vercollect {
         }
     );
 
+    use MIP::Environment::Executable qw{ write_binaries_versions };
+    use MIP::Program::Gnu::Coreutils qw{ gnu_rm };
+
     ### SHELL:
 
-    my $binary_path_file_path = $outfile_path_prefix . $UNDERSCORE . q{binary_paths.yaml};
-
-    ## Writes a YAML hash to file
-    write_to_file(
+    say {$filehandle} q{## Remove potential previous mip version collect file};
+    gnu_rm(
         {
-            data_href => \%CONTAINER_CMD,
-            format    => q{yaml},
-            path      => $binary_path_file_path,
-        }
-    );
-    $log->info( q{Wrote: } . $binary_path_file_path );
-
-    my $log_file_path = $outfile_path_prefix . $UNDERSCORE . q{vercollect.log};
-
-    mip_vercollect(
-        {
-            filehandle    => $filehandle,
-            infile_path   => $binary_path_file_path,
-            log_file_path => $log_file_path,
-            outfile_path  => $outfile_path,
+            filehandle  => $filehandle,
+            force       => 1,
+            infile_path => $outfile_path,
         }
     );
     say {$filehandle} $NEWLINE;
+    ## Write executable versions
+    write_binaries_versions(
+        {
+            binary_info_href => \%CONTAINER_CMD,
+            filehandle       => $filehandle,
+            outfile_path     => $outfile_path,
+        }
+    );
+
+#    my $binary_path_file_path = $outfile_path_prefix . $UNDERSCORE . q{binary_paths.yaml};
+
+    ## Writes a YAML hash to file
+    #    write_to_file(
+    #        {
+    #            data_href => \%CONTAINER_CMD,
+    #            format    => q{yaml},
+    #            path      => $binary_path_file_path,
+    #        }
+    #    );
+    #    $log->info( q{Wrote: } . $binary_path_file_path );
+
+    #    my $log_file_path = $outfile_path_prefix . $UNDERSCORE . q{vercollect.log};
+
+    #    mip_vercollect(
+    #       {
+    #           filehandle    => $filehandle,
+    #           infile_path   => $binary_path_file_path,
+    #           log_file_path => $log_file_path,
+    #           outfile_path  => $outfile_path,
+    #       }
+    #   );
+    #   say {$filehandle} $NEWLINE;
 
     close $filehandle or $log->logcroak(q{Could not close filehandle});
 

--- a/lib/MIP/Recipes/Analysis/Mip_vercollect.pm
+++ b/lib/MIP/Recipes/Analysis/Mip_vercollect.pm
@@ -169,9 +169,10 @@ sub analysis_mip_vercollect {
             filehandle            => $filehandle,
             job_id_href           => $job_id_href,
             memory_allocation     => $recipe_resource{memory},
+            process_time          => $recipe_resource{time},
             recipe_directory      => $recipe_name,
             recipe_name           => $recipe_name,
-            process_time          => $recipe_resource{time},
+            set_pipefail          => 0,
         }
     );
 

--- a/t/get_binary_version_cmd.t
+++ b/t/get_binary_version_cmd.t
@@ -1,0 +1,131 @@
+#!/usr/bin/env perl
+
+use 5.026;
+use Carp;
+use charnames qw{ :full :short };
+use English qw{ -no_match_vars };
+use File::Basename qw{ dirname };
+use File::Spec::Functions qw{ catdir };
+use FindBin qw{ $Bin };
+use open qw{ :encoding(UTF-8) :std };
+use Params::Check qw{ allow check last_error };
+use Test::More;
+use utf8;
+use warnings qw{ FATAL utf8 };
+
+## CPANM
+use autodie qw { :all };
+use Modern::Perl qw{ 2018 };
+use Readonly;
+
+## MIPs lib/
+use lib catdir( dirname($Bin), q{lib} );
+use MIP::Constants qw{ $COMMA $EMPTY_STR $SPACE };
+use MIP::Test::Fixtures qw{ test_standard_cli };
+
+my $VERBOSE = 1;
+our $VERSION = 1.00;
+
+$VERBOSE = test_standard_cli(
+    {
+        verbose => $VERBOSE,
+        version => $VERSION,
+    }
+);
+
+BEGIN {
+
+    use MIP::Test::Fixtures qw{ test_import };
+
+### Check all internal dependency modules and imports
+## Modules with import
+    my %perl_module = (
+        q{MIP::Constants}               => [qw{ set_container_cmd }],
+        q{MIP::Environment::Executable} => [qw{ get_binary_version_cmd }],
+        q{MIP::Test::Fixtures}          => [qw{ test_standard_cli }],
+    );
+
+    test_import( { perl_module_href => \%perl_module, } );
+}
+
+use MIP::Constants qw{ set_container_cmd };
+use MIP::Environment::Executable qw{ get_binary_version_cmd };
+
+diag(   q{Test get_binary_version_cmd from Executable.pm v}
+      . $MIP::Environment::Executable::VERSION
+      . $COMMA
+      . $SPACE . q{Perl}
+      . $SPACE
+      . $PERL_VERSION
+      . $SPACE
+      . $EXECUTABLE_NAME );
+
+## Given an executable name
+my @version_cmd = get_binary_version_cmd(
+    {
+        binary     => q{vep},
+        binary_cmd => q{vep}
+    }
+);
+
+my @expected_version_cmd = (
+    qw{ vep | perl -n -a -e },
+    q?'my ($version) = /ensembl-vep\s+:\s(\d+)/xms; if($version) {print $version;last;}'?,
+);
+
+## Then return version command
+is_deeply( \@version_cmd, \@expected_version_cmd, q{Got executable version command} );
+
+## Given an existing perl command in CONTAINER_CMD
+my $container_base_command =
+  q{singularity exec docker.io/clinicalgenomics/perl:5.26 perl};
+my %container_cmd = ( perl => $container_base_command, );
+
+set_container_cmd( { container_cmd_href => \%container_cmd, } );
+
+## When calling using container
+@version_cmd = get_binary_version_cmd(
+    {
+        binary        => q{vep},
+        binary_cmd    => q{vep},
+        use_container => 1,
+    }
+);
+
+my @expected_version_cmd_container = (
+    qw{ vep | },
+    q{singularity exec docker.io/clinicalgenomics/perl:5.26 perl},
+    qw{ -n -a -e },
+    q?'my ($version) = /ensembl-vep\s+:\s(\d+)/xms; if($version) {print $version;last;}'?,
+);
+
+## Then return version command
+is_deeply(
+    \@version_cmd,
+    \@expected_version_cmd_container,
+    q{Got executable version command with perl container}
+);
+
+## Given an executable name and stdoutfile path to append to
+my $stdoutfile_path = q{an_outfile_path};
+@version_cmd = get_binary_version_cmd(
+    {
+        binary                 => q{vep},
+        binary_cmd             => q{vep},
+        stdoutfile_path_append => $stdoutfile_path,
+    }
+);
+
+my @expected_version_cmd_stdout = (
+    qw{ vep | perl -n -a -e },
+    q?'my ($version) = /ensembl-vep\s+:\s(\d+)/xms; if($version) {print $version;last;}'?,
+    q{1>>} . $SPACE . $stdoutfile_path,
+);
+
+## Then return version command
+is_deeply(
+    \@version_cmd,
+    \@expected_version_cmd_stdout,
+    q{Got executable version command appending to stdout}
+);
+done_testing();

--- a/t/perl_nae_oneliners.t
+++ b/t/perl_nae_oneliners.t
@@ -25,7 +25,7 @@ use MIP::Test::Commands qw{ test_function };
 use MIP::Test::Fixtures qw{ test_standard_cli };
 
 my $VERBOSE = 1;
-our $VERSION = 1.02;
+our $VERSION = 1.03;
 
 $VERBOSE = test_standard_cli(
     {
@@ -78,6 +78,10 @@ my %base_argument = (
     stdoutfile_path => {
         input           => q{stdoutfile.test},
         expected_output => q{1> stdoutfile.test},
+    },
+    stdoutfile_path_append => {
+        input           => q{stdoutfile.test},
+        expected_output => q{1>> stdoutfile.test},
     },
 );
 

--- a/t/write_binaries_versions.t
+++ b/t/write_binaries_versions.t
@@ -1,0 +1,96 @@
+#!/usr/bin/env perl
+
+use 5.026;
+use Carp;
+use charnames qw{ :full :short };
+use English qw{ -no_match_vars };
+use File::Basename qw{ dirname };
+use File::Spec::Functions qw{ catdir };
+use FindBin qw{ $Bin };
+use open qw{ :encoding(UTF-8) :std };
+use Params::Check qw{ allow check last_error };
+use Test::More;
+use utf8;
+use warnings qw{ FATAL utf8 };
+
+## CPANM
+use autodie qw { :all };
+use Modern::Perl qw{ 2018 };
+use Readonly;
+
+## MIPs lib/
+use lib catdir( dirname($Bin), q{lib} );
+use MIP::Constants qw{ $COLON $COMMA $EMPTY_STR $SPACE };
+use MIP::Test::Fixtures qw{ test_standard_cli };
+
+my $VERBOSE = 1;
+our $VERSION = 1.00;
+
+$VERBOSE = test_standard_cli(
+    {
+        verbose => $VERBOSE,
+        version => $VERSION,
+    }
+);
+
+BEGIN {
+
+    use MIP::Test::Fixtures qw{ test_import };
+
+### Check all internal dependency modules and imports
+## Modules with import
+    my %perl_module = (
+        q{MIP::Environment::Executable} => [qw{ write_binaries_versions }],
+        q{MIP::Test::Fixtures}          => [qw{ test_standard_cli }],
+    );
+
+    test_import( { perl_module_href => \%perl_module, } );
+}
+
+use MIP::Environment::Executable qw{ write_binaries_versions };
+
+diag(   q{Test write_binaries_versions from Executable.pm v}
+      . $MIP::Environment::Executable::VERSION
+      . $COMMA
+      . $SPACE . q{Perl}
+      . $SPACE
+      . $PERL_VERSION
+      . $SPACE
+      . $EXECUTABLE_NAME );
+
+# For storing info to write
+my $file_content;
+
+## Store file content in memory by using referenced variable
+open my $filehandle, q{>}, \$file_content
+  or croak q{Cannot write to} . $SPACE . $file_content . $COLON . $SPACE . $OS_ERROR;
+
+## Given an existing perl command in CONTAINER_CMD
+my $container_perl_command =
+  q{singularity exec docker.io/clinicalgenomics/perl:5.26 perl};
+my $container_vep_command =
+  q{singularity exec docker.io/ensemblorg/ensembl-vep:release_100.2 vep};
+
+my %container_cmd = (
+    perl => $container_perl_command,
+    vep  => $container_vep_command,
+);
+
+## Given an executable name
+my $outfile_path = q{an_outfile};
+
+write_binaries_versions(
+    {
+        binary_info_href => \%container_cmd,
+        filehandle       => $filehandle,
+        outfile_path     => $outfile_path,
+    }
+);
+
+close $filehandle;
+
+## Then return version command
+my ($returned_base_command) = $file_content =~ /($outfile_path)/mxs;
+is( $returned_base_command, $outfile_path, q{Wrote binary version command} );
+
+done_testing();


### PR DESCRIPTION
### This PR adds | fixes:

- Writes commands to get binary versions directly in recipe instead of going via mip_vercollect. This avoids the challenge of calling a container from a container.
- Fixed picard and vcfcytosure version commands
- Leaved mip_vercollect functionality intact for use in mip_install later

### How to test:

- Automatic and continuous test suite

### Expected outcome:
- [ ] Installation, unit and integration test suite pass

### Review:
- [ ] Code review
- [ ] Tests pass

This [version](https://semver.org/) is a:
- [ ] **MAJOR** - when you make incompatible API changes. If applicable record manual test results in PR header
- [ ] **MINOR** - when you add functionality in a backwards compatible manner. If applicable record manual test results in PR header
- [ ] **PATCH** - when you make backwards compatible bug fixes or documentation/instructions
