### PR TITLE
Hotfix/slurm jobids

### DIFF
--- a/.github/workflows/conda_prod_install.yml
+++ b/.github/workflows/conda_prod_install.yml
@@ -10,7 +10,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
-      - uses: goanpeca/setup-miniconda@v1
+      - uses: conda-incubator/setup-miniconda@v2
         with:
           channels: bioconda, conda-forge
 

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -13,7 +13,7 @@ jobs:
       - uses: shogo82148/actions-setup-perl@v1
         with:
           perl-version: '5.26'
-      - uses: goanpeca/setup-miniconda@v1
+      - uses: conda-incubator/setup-miniconda@v2
         with:
           channels: bioconda, conda-forge
 

--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -13,7 +13,7 @@ jobs:
       - uses: shogo82148/actions-setup-perl@v1
         with:
           perl-version: '5.26'
-      - uses: goanpeca/setup-miniconda@v1
+      - uses: conda-incubator/setup-miniconda@v2
         with:
           channels: bioconda, conda-forge
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 All notable changes to this project will be documented in this file.
 This project adheres to [Semantic Versioning](http://semver.org/).
 
+## [9.0.6]
+- Use "PAN" key for slurm_jobs_ids file instead of "ALL" as "ALL" has a size constraint
+
 ## [9.0.5]
 - Predicted gender from wgs samples are now used in the generated fam files.
 - Restrict plink analysis to intersected target capture kits for mixed wgs/wes cases

--- a/lib/MIP/Constants.pm
+++ b/lib/MIP/Constants.pm
@@ -80,7 +80,7 @@ Readonly our %ANALYSIS => (
 );
 
 ## Set MIP version
-Readonly our $MIP_VERSION => q{v9.0.5};
+Readonly our $MIP_VERSION => q{v9.0.6};
 
 ## Cli
 Readonly our $MOOSEX_APP_SCEEN_WIDTH => 160;

--- a/lib/MIP/Processmanagement/Processes.pm
+++ b/lib/MIP/Processmanagement/Processes.pm
@@ -26,7 +26,7 @@ BEGIN {
     require Exporter;
 
     # Set the version for version checking
-    our $VERSION = 1.07;
+    our $VERSION = 1.08;
 
     # Functions and variables which can be optionally exported
     our @EXPORT_OK = qw{
@@ -1629,9 +1629,9 @@ sub get_all_job_ids {
 
     check( $tmpl, $arg_href, 1 ) or croak q{Could not parse arguments!};
 
-    return if ( not exists $job_id_href->{ALL} );
+    return if ( not exists $job_id_href->{PAN} );
 
-    return @{ $job_id_href->{ALL}{ALL} };
+    return @{ $job_id_href->{PAN}{PAN} };
 }
 
 sub limit_job_id_string {
@@ -1901,20 +1901,20 @@ sub write_job_ids_to_file {
     my $job_ids_file_path;
 
     my $tmpl = {
-        case_id         => {
+        case_id => {
             defined     => 1,
             required    => 1,
             store       => \$case_id,
             strict_type => 1,
         },
-        job_id_href     => {
+        job_id_href => {
             default     => {},
             defined     => 1,
             required    => 1,
             store       => \$job_id_href,
             strict_type => 1,
         },
-        job_ids_file_path    => => {
+        job_ids_file_path => => {
             defined     => 1,
             required    => 1,
             store       => \$job_ids_file_path,

--- a/lib/MIP/Processmanagement/Processes.pm
+++ b/lib/MIP/Processmanagement/Processes.pm
@@ -1914,7 +1914,7 @@ sub write_job_ids_to_file {
             store       => \$job_id_href,
             strict_type => 1,
         },
-        job_ids_file_path => => {
+        job_ids_file_path => {
             defined     => 1,
             required    => 1,
             store       => \$job_ids_file_path,

--- a/t/get_all_job_ids.t
+++ b/t/get_all_job_ids.t
@@ -23,7 +23,7 @@ use MIP::Constants qw{ $COMMA $SPACE };
 use MIP::Test::Fixtures qw{ test_standard_cli };
 
 my $VERBOSE = 1;
-our $VERSION = 1.00;
+our $VERSION = 1.01;
 
 $VERBOSE = test_standard_cli(
     {
@@ -58,11 +58,11 @@ diag(   q{Test get_all_job_ids from Processes.pm v}
       . $EXECUTABLE_NAME );
 
 ## Given
-my %job_id = ( ALL => { ALL => [ 0, 1, 2, ], }, );
+my %job_id = ( PAN => { PAN => [ 0, 1, 2, ], }, );
 
 my @all_job_ids = get_all_job_ids( { job_id_href => \%job_id, } );
 
 ## Then
-is_deeply( $job_id{ALL}{ALL}, \@all_job_ids, q{Got all job ids} );
+is_deeply( $job_id{PAN}{PAN}, \@all_job_ids, q{Got all PAN job ids} );
 
 done_testing();


### PR DESCRIPTION
### This PR fixes:

- That all slurm jobids are written to the slurm_jobids.yaml file. 
- Fix actions for master by updating action version for conda install on actions

### How to test:

- Automatic and continuous test suite
- Run case brightcaiman

### Expected outcome:
- [x] Installation, unit and integration test suite pass
- [x] All jobids that are returned from slurm also are present in slurm_jobids.yaml

### Review:
- [ ] Code review
- [ ] Tests pass HS

This [version](https://semver.org/) is a:
- [ ] **MAJOR** - when you make incompatible API changes. If applicable record manual test results in PR header
- [ ] **MINOR** - when you add functionality in a backwards compatible manner. If applicable record manual test results in PR header
- [x] **PATCH** - when you make backwards compatible bug fixes or documentation/instructions
