### PR TITLE
feat(container_constants): move set sub

### DIFF
--- a/lib/MIP/Recipes/Pipeline/Analyse_dragen_rd_dna.pm
+++ b/lib/MIP/Recipes/Pipeline/Analyse_dragen_rd_dna.pm
@@ -26,7 +26,7 @@ BEGIN {
 
     # Set the version for version checking
 
-    our $VERSION = 1.18;
+    our $VERSION = 1.19;
 
     # Functions and variables which can be optionally exported
     our @EXPORT_OK = qw{ parse_dragen_rd_dna pipeline_analyse_dragen_rd_dna };
@@ -108,6 +108,7 @@ sub parse_dragen_rd_dna {
     };
     use MIP::Analysis qw{ broadcast_parameters };
     use MIP::Config qw{ write_mip_config };
+    use MIP::Constants qw{ set_container_constants };
     use MIP::Contigs qw{ update_contigs_for_run };
     use MIP::Environment::Container qw{ parse_containers };
     use MIP::Fastq qw{ parse_fastq_infiles };
@@ -125,6 +126,9 @@ sub parse_dragen_rd_dna {
     Readonly my @MIP_VEP_PLUGINS    => qw{ sv_vep_plugin vep_plugin };
     Readonly my @REMOVE_CONFIG_KEYS => qw{ associated_recipe };
 
+    ## Set analysis constants
+    set_container_constants( { active_parameter_href => $active_parameter_href, } );
+    
     parse_containers(
         {
             active_parameter_href => $active_parameter_href,
@@ -358,7 +362,6 @@ sub pipeline_analyse_dragen_rd_dna {
 
     check( $tmpl, $arg_href, 1 ) or croak q{Could not parse arguments!};
 
-    use MIP::Constants qw{ set_container_constants };
     use MIP::Parse::Reference qw{ parse_references };
     use MIP::Set::Analysis qw{ set_recipe_on_analysis_type set_rankvariants_ar };
 
@@ -403,9 +406,6 @@ sub pipeline_analyse_dragen_rd_dna {
             sample_info_href      => $sample_info_href,
         }
     );
-
-    ## Set analysis constants
-    set_container_constants( { active_parameter_href => $active_parameter_href, } );
 
     ### Build recipes
     $log->info(q{[Reference check - Reference prerequisites]});

--- a/lib/MIP/Recipes/Pipeline/Analyse_rd_dna_panel.pm
+++ b/lib/MIP/Recipes/Pipeline/Analyse_rd_dna_panel.pm
@@ -24,7 +24,7 @@ BEGIN {
     use base qw{ Exporter };
 
     # Set the version for version checking
-    our $VERSION = 1.22;
+    our $VERSION = 1.23;
 
     # Functions and variables which can be optionally exported
     our @EXPORT_OK = qw{ parse_rd_dna_panel pipeline_analyse_rd_dna_panel };
@@ -106,6 +106,7 @@ sub parse_rd_dna_panel {
       write_references
     };
     use MIP::Analysis qw{ broadcast_parameters parse_prioritize_variant_callers };
+    use MIP::Constants qw{ set_container_constants };
     use MIP::Config qw{ write_mip_config };
     use MIP::Environment::Container qw{ parse_containers };
     use MIP::Fastq qw{ parse_fastq_infiles };
@@ -121,6 +122,9 @@ sub parse_rd_dna_panel {
 
     ## Constants
     Readonly my @REMOVE_CONFIG_KEYS => qw{ associated_recipe };
+
+    ## Set analysis constants
+    set_container_constants( { active_parameter_href => $active_parameter_href, } );
 
     parse_containers(
         {
@@ -368,7 +372,6 @@ sub pipeline_analyse_rd_dna_panel {
 
     check( $tmpl, $arg_href, 1 ) or croak q{Could not parse arguments!};
 
-    use MIP::Constants qw{ set_container_constants };
     use MIP::Log::MIP_log4perl qw{ log_display_recipe_for_user };
     use MIP::Parse::Reference qw{ parse_references };
     use MIP::Set::Analysis qw{ set_recipe_bwa_mem };
@@ -422,9 +425,6 @@ sub pipeline_analyse_rd_dna_panel {
             sample_info_href      => $sample_info_href,
         }
     );
-
-    ## Set analysis constants
-    set_container_constants( { active_parameter_href => $active_parameter_href, } );
 
     ### Build recipes
     $log->info(q{[Reference check - Reference prerequisites]});

--- a/lib/MIP/Recipes/Pipeline/Analyse_rd_dna_vcf_rerun.pm
+++ b/lib/MIP/Recipes/Pipeline/Analyse_rd_dna_vcf_rerun.pm
@@ -24,7 +24,7 @@ BEGIN {
     use base qw{ Exporter };
 
     # Set the version for version checking
-    our $VERSION = 1.19;
+    our $VERSION = 1.20;
 
     # Functions and variables which can be optionally exported
     our @EXPORT_OK = qw{ parse_rd_dna_vcf_rerun pipeline_analyse_rd_dna_vcf_rerun };
@@ -105,6 +105,7 @@ sub parse_rd_dna_vcf_rerun {
     };
     use MIP::Analysis qw{ broadcast_parameters };
     use MIP::Config qw{ write_mip_config };
+    use MIP::Constants qw{ set_container_constants };
     use MIP::Contigs qw{ update_contigs_for_run };
     use MIP::Environment::Container qw{ parse_containers };
     use MIP::File_info qw{ check_parameter_metafiles parse_select_file_contigs };
@@ -119,6 +120,9 @@ sub parse_rd_dna_vcf_rerun {
     ## Constants
     Readonly my @MIP_VEP_PLUGINS    => qw{ sv_vep_plugin vep_plugin };
     Readonly my @REMOVE_CONFIG_KEYS => qw{ associated_recipe };
+
+    ## Set analysis constants
+    set_container_constants( { active_parameter_href => $active_parameter_href, } );
 
     parse_containers(
         {
@@ -327,7 +331,6 @@ sub pipeline_analyse_rd_dna_vcf_rerun {
 
     check( $tmpl, $arg_href, 1 ) or croak q{Could not parse arguments!};
 
-    use MIP::Constants qw{ set_container_constants };
     use MIP::Parse::Reference qw{ parse_references };
     use MIP::Set::Analysis qw{ set_recipe_on_analysis_type set_rankvariants_ar };
 
@@ -370,9 +373,6 @@ sub pipeline_analyse_rd_dna_vcf_rerun {
             sample_info_href      => $sample_info_href,
         }
     );
-
-    ## Set analysis constants
-    set_container_constants( { active_parameter_href => $active_parameter_href, } );
 
     ### Build recipes
     $log->info(q{[Reference check - Reference prerequisites]});

--- a/lib/MIP/Recipes/Pipeline/Analyse_rd_rna.pm
+++ b/lib/MIP/Recipes/Pipeline/Analyse_rd_rna.pm
@@ -22,7 +22,7 @@ BEGIN {
     use base qw{ Exporter };
 
     # Set the version for version checking
-    our $VERSION = 1.39;
+    our $VERSION = 1.40;
 
     # Functions and variables which can be optionally exported
     our @EXPORT_OK = qw{ parse_rd_rna pipeline_analyse_rd_rna };
@@ -105,6 +105,7 @@ sub parse_rd_rna {
       update_recipe_mode_for_fastq_compatibility
       update_recipe_mode_for_pedigree };
     use MIP::Config qw{ write_mip_config };
+    use MIP::Constants qw{ set_container_constants };
     use MIP::Contigs qw{ update_contigs_for_run };
     use MIP::Environment::Container qw{ parse_containers };
     use MIP::Fastq qw{ parse_fastq_infiles };
@@ -116,6 +117,9 @@ sub parse_rd_rna {
 
     ## Constants
     Readonly my @REMOVE_CONFIG_KEYS => qw{ associated_recipe };
+    
+    ## Set analysis constants
+    set_container_constants( { active_parameter_href => $active_parameter_href, } );
 
     parse_containers(
         {
@@ -365,8 +369,6 @@ sub pipeline_analyse_rd_rna {
 
     check( $tmpl, $arg_href, 1 ) or croak q{Could not parse arguments!};
 
-    use MIP::Constants qw{ set_container_constants };
-
     ## Recipes
     use MIP::Log::MIP_log4perl qw{ log_display_recipe_for_user };
     use MIP::Recipes::Analysis::Analysisrunstatus qw{ analysis_analysisrunstatus };
@@ -417,9 +419,6 @@ sub pipeline_analyse_rd_rna {
             sample_info_href      => $sample_info_href,
         }
     );
-
-    ## Set analysis constants
-    set_container_constants( { active_parameter_href => $active_parameter_href, } );
 
     ### Build recipes
     $log->info(q{[Reference check - Reference prerequisites]});


### PR DESCRIPTION
### This PR adds | fixes:

- move the setting of container constants as they are needed early

### How to test:

- Automatic and continuous test suite

### Expected outcome:
- [ ] Installation, unit and integration test suite pass

### Review:
- [ ] Code review
- [ ] Tests pass

This [version](https://semver.org/) is a:
- [ ] **MAJOR** - when you make incompatible API changes. If applicable record manual test results in PR header
- [ ] **MINOR** - when you add functionality in a backwards compatible manner. If applicable record manual test results in PR header
- [x] **PATCH** - when you make backwards compatible bug fixes or documentation/instructions
