### PR TITLE
feat(refactor): Remove use of 'use strict' as this is now automatical…

### DIFF
--- a/lib/MIP/Active_parameter.pm
+++ b/lib/MIP/Active_parameter.pm
@@ -9,7 +9,6 @@ use File::Spec::Functions qw{ catfile splitpath };
 use FindBin qw{ $Bin };
 use open qw{ :encoding(UTF-8) :std };
 use Params::Check qw{ allow check last_error };
-use strict;
 use utf8;
 use warnings;
 use warnings qw{ FATAL utf8 };
@@ -20,8 +19,7 @@ use List::MoreUtils qw { any };
 use Readonly;
 
 ## MIPs lib/
-use MIP::Constants
-  qw{ $COLON $COMMA $DOT $LOG_NAME $PIPE $SINGLE_QUOTE $SPACE $TAB $UNDERSCORE };
+use MIP::Constants qw{ $COLON $COMMA $DOT $LOG_NAME $PIPE $SINGLE_QUOTE $SPACE $TAB $UNDERSCORE };
 
 BEGIN {
     require Exporter;
@@ -166,8 +164,7 @@ sub add_recipe_bind_paths {
 
     return if ( not $active_parameter_href->{recipe_bind_path}{$recipe_name} );
 
-    push @{$export_bind_paths_ref},
-      @{ $active_parameter_href->{recipe_bind_path}{$recipe_name} };
+    push @{$export_bind_paths_ref}, @{ $active_parameter_href->{recipe_bind_path}{$recipe_name} };
 
     @{$export_bind_paths_ref} = reduce_dir_paths(
         {
@@ -570,8 +567,7 @@ sub check_sample_id_in_hash_parameter {
                     parameter_name        => $parameter_name,
                 }
             );
-            my $parameter_name_sample_ids = join $COMMA . $SPACE,
-              ( keys %parameter_name_hash );
+            my $parameter_name_sample_ids = join $COMMA . $SPACE, ( keys %parameter_name_hash );
 
             $log->fatal( q{Could not find value for }
                   . $sample_id
@@ -874,10 +870,8 @@ sub get_not_allowed_temp_dirs {
     check( $tmpl, $arg_href, 1 ) or croak q{Could not parse arguments!};
 
     my @is_not_allowed_temp_dirs = (
-        $active_parameter_href->{cluster_constant_path},
-        $active_parameter_href->{outdata_dir},
-        $active_parameter_href->{outscript_dir},
-        $active_parameter_href->{reference_dir},
+        $active_parameter_href->{cluster_constant_path}, $active_parameter_href->{outdata_dir},
+        $active_parameter_href->{outscript_dir},         $active_parameter_href->{reference_dir},
     );
     return @is_not_allowed_temp_dirs;
 }
@@ -1115,35 +1109,30 @@ sub parse_recipe_resources {
 
     check( $tmpl, $arg_href, 1 ) or croak q{Could not parse arguments!};
 
-    use MIP::Environment::Cluster
-      qw{ check_max_core_number check_recipe_memory_allocation };
+    use MIP::Environment::Cluster qw{ check_max_core_number check_recipe_memory_allocation };
 
     ## Check that the recipe core number do not exceed the maximum per node
     foreach my $recipe_name ( keys %{ $active_parameter_href->{recipe_core_number} } ) {
 
         ## Limit number of cores requested to the maximum number of cores available per node
-        $active_parameter_href->{recipe_core_number}{$recipe_name} =
-          check_max_core_number(
+        $active_parameter_href->{recipe_core_number}{$recipe_name} = check_max_core_number(
             {
-                max_cores_per_node => $active_parameter_href->{max_cores_per_node},
-                core_number_requested =>
-                  $active_parameter_href->{recipe_core_number}{$recipe_name},
+                max_cores_per_node    => $active_parameter_href->{max_cores_per_node},
+                core_number_requested => $active_parameter_href->{recipe_core_number}{$recipe_name},
             }
-          );
+        );
     }
 
     ## Check that the recipe memory do not exceed the maximum per node
     ## Limit recipe_memory to node max memory if required
     foreach my $recipe_name ( keys %{ $active_parameter_href->{recipe_memory} } ) {
 
-        $active_parameter_href->{recipe_memory}{$recipe_name} =
-          check_recipe_memory_allocation(
+        $active_parameter_href->{recipe_memory}{$recipe_name} = check_recipe_memory_allocation(
             {
-                node_ram_memory => $active_parameter_href->{node_ram_memory},
-                recipe_memory_allocation =>
-                  $active_parameter_href->{recipe_memory}{$recipe_name},
+                node_ram_memory          => $active_parameter_href->{node_ram_memory},
+                recipe_memory_allocation => $active_parameter_href->{recipe_memory}{$recipe_name},
             }
-          );
+        );
     }
 
     return 1;
@@ -1297,8 +1286,7 @@ sub set_default_human_genome {
     check( $tmpl, $arg_href, 1 ) or croak q{Could not parse arguments!};
 
     ## Now we now what human genome reference to build from
-    $active_parameter_href->{$parameter_name} =
-      $active_parameter_href->{human_genome_reference};
+    $active_parameter_href->{$parameter_name} = $active_parameter_href->{human_genome_reference};
 
     return;
 }
@@ -1342,8 +1330,7 @@ sub set_default_infile_dirs {
             $active_parameter_href->{cluster_constant_path},
             $active_parameter_href->{case_id},
             $active_parameter_href->{analysis_type}{$sample_id},
-            $sample_id,
-            q{fastq}
+            $sample_id, q{fastq}
         );
 
         $active_parameter_href->{infile_dirs}{$path} = $sample_id;
@@ -1565,8 +1552,7 @@ sub set_default_transcript_annotation {
     check( $tmpl, $arg_href, 1 ) or croak q{Could not parse arguments!};
 
     ## Now we now what transcript annotation reference to build from
-    $active_parameter_href->{$parameter_name} =
-      $active_parameter_href->{transcript_annotation};
+    $active_parameter_href->{$parameter_name} = $active_parameter_href->{transcript_annotation};
 
     return;
 }
@@ -1681,8 +1667,7 @@ sub set_exome_target_bed {
     check( $tmpl, $arg_href, 1 ) or croak q{Could not parse arguments!};
 
     ## Add sample_ids as string to exome_target_bed_file
-    $active_parameter_href->{exome_target_bed}{$exome_target_bed_file} =
-      $sample_id_string;
+    $active_parameter_href->{exome_target_bed}{$exome_target_bed_file} = $sample_id_string;
 
     return;
 }
@@ -1765,9 +1750,8 @@ sub set_load_env_environment {
         ## Retrieve logger object
         my $log = Log::Log4perl->get_logger($LOG_NAME);
 
-        $log->warn( q{Could not use }
-              . $env_name
-              . q{ as there are multiple environments to update} );
+        $log->warn(
+            q{Could not use } . $env_name . q{ as there are multiple environments to update} );
         return;
     }
 
@@ -2202,9 +2186,7 @@ sub set_recipe_resource {
     while ( my ( $set_hash_key, $target_hash_key ) = each %set_hash_key_map ) {
 
       RECIPE:
-        while ( my ( $recipe, $core_number ) =
-            each %{ $active_parameter_href->{$set_hash_key} } )
-        {
+        while ( my ( $recipe, $core_number ) = each %{ $active_parameter_href->{$set_hash_key} } ) {
 
             $active_parameter_href->{$target_hash_key}{$recipe} = $core_number;
         }
@@ -2252,12 +2234,11 @@ sub set_vcfparser_outfile_counter {
             each %{ $vcfparser_select_file{$recipe} } )
         {
 
-            $active_parameter_href->{$parameter_name_counter} =
-              _set_vcfparser_file_counter(
+            $active_parameter_href->{$parameter_name_counter} = _set_vcfparser_file_counter(
                 {
                     parameter_name => $active_parameter_href->{$parameter_name},
                 }
-              );
+            );
         }
     }
     return;
@@ -2507,8 +2488,7 @@ sub update_to_absolute_path {
         if ( ref $active_parameter_href->{$parameter_name} eq q{ARRAY} ) {
 
           VALUE:
-            foreach my $parameter_value ( @{ $active_parameter_href->{$parameter_name} } )
-            {
+            foreach my $parameter_value ( @{ $active_parameter_href->{$parameter_name} } ) {
 
                 $parameter_value = get_absolute_path(
                     {
@@ -2536,8 +2516,7 @@ sub update_to_absolute_path {
                     }
                 );
 
-                $parameter_name_href->{$updated_key} =
-                  delete $parameter_name_href->{$key};
+                $parameter_name_href->{$updated_key} = delete $parameter_name_href->{$key};
             }
             next DYNAMIC_PARAMETER;
         }
@@ -2677,8 +2656,7 @@ sub _check_infile_directory {
 
     return if ( defined $infile_directory );
 
-    $log->fatal(
-        q{Could not detect any supplied '--infile_dirs' for sample: } . $sample_id );
+    $log->fatal( q{Could not detect any supplied '--infile_dirs' for sample: } . $sample_id );
     exit 1;
 }
 
@@ -2694,8 +2672,7 @@ sub _set_vcfparser_file_counter {
     my $parameter_name;
 
     my $tmpl =
-      { parameter_name => { required => 1, store => \$parameter_name, strict_type => 1, },
-      };
+      { parameter_name => { required => 1, store => \$parameter_name, strict_type => 1, }, };
 
     check( $tmpl, $arg_href, 1 ) or croak q{Could not parse arguments!};
 

--- a/lib/MIP/Analysis.pm
+++ b/lib/MIP/Analysis.pm
@@ -9,7 +9,6 @@ use File::Spec::Functions qw{ catdir catfile };
 use FindBin qw{ $Bin };
 use open qw{ :encoding(UTF-8) :std };
 use Params::Check qw{ check allow last_error };
-use strict;
 use utf8;
 use warnings;
 use warnings qw{ FATAL utf8 };
@@ -127,10 +126,10 @@ sub check_analysis_type_to_pipeline {
             strict_type => 1,
         },
         pipeline => {
-            allow    => [qw{ dragen_rd_dna rd_dna rd_dna_panel rd_dna_vcf_rerun rd_rna }],
-            defined  => 1,
-            required => 1,
-            store    => \$pipeline,
+            allow       => [qw{ dragen_rd_dna rd_dna rd_dna_panel rd_dna_vcf_rerun rd_rna }],
+            defined     => 1,
+            required    => 1,
+            store       => \$pipeline,
             strict_type => 1,
         },
     };
@@ -153,11 +152,9 @@ sub check_analysis_type_to_pipeline {
     if ( $analysis_pipeline_map{$analysis_type} ne $pipeline ) {
 
         $log->fatal(
-qq{Analysis type: $analysis_type is not compatible with MIP pipeline: $pipeline}
-        );
+            qq{Analysis type: $analysis_type is not compatible with MIP pipeline: $pipeline});
         $log->fatal(
-qq{Start MIP pipeline: $analysis_pipeline_map{$analysis_type} for this analysis type}
-        );
+            qq{Start MIP pipeline: $analysis_pipeline_map{$analysis_type} for this analysis type});
         $log->fatal(q{Aborting run});
         exit 1;
     }
@@ -554,8 +551,7 @@ sub parse_prioritize_variant_callers {
                 {
                     active_parameter_href => $active_parameter_href,
                     parameter_href        => $parameter_href,
-                    priority_name_str =>
-                      $active_parameter_href->{$prioritize_parameter_name},
+                    priority_name_str     => $active_parameter_href->{$prioritize_parameter_name},
                     variant_caller_recipes_ref => \@variant_caller_recipes,
                 }
             );
@@ -599,8 +595,7 @@ sub set_ase_chain_recipes {
         qw{ gatk_baserecalibration gatk_haplotypecaller gatk_splitncigarreads gatk_variantfiltration }
     );
 
-    my @recipes =
-      $active_parameter_href->{dna_vcf_file} ? @RNA_VC_RECIPES : @DNA_VC_RECIPES;
+    my @recipes = $active_parameter_href->{dna_vcf_file} ? @RNA_VC_RECIPES : @DNA_VC_RECIPES;
 
     set_recipe_mode(
         {

--- a/lib/MIP/Cli/Mip/Analyse.pm
+++ b/lib/MIP/Cli/Mip/Analyse.pm
@@ -5,7 +5,6 @@ use Carp;
 use File::Basename qw{ dirname };
 use open qw{ :encoding(UTF-8) :std };
 use Params::Check qw{ check allow last_error };
-use strict;
 use utf8;
 use warnings;
 use warnings qw{ FATAL utf8 };
@@ -50,7 +49,7 @@ sub _build_usage {
 
     option(
         q{analysisrunstatus} => (
-            cmd_tags => [q{Analysis recipe switch}],
+            cmd_tags      => [q{Analysis recipe switch}],
             documentation =>
 q{Check analysis output and sets the analysis run status flag to finished in sample_info_file},
             is  => q{rw},
@@ -105,11 +104,10 @@ q{Check analysis output and sets the analysis run status flag to finished in sam
 
     option(
         q{dry_run_all} => (
-            cmd_aliases => [qw{ dra }],
-            documentation =>
-              q{Sets all recipes to dry run mode i.e. no sbatch submission},
-            is  => q{rw},
-            isa => Bool,
+            cmd_aliases   => [qw{ dra }],
+            documentation => q{Sets all recipes to dry run mode i.e. no sbatch submission},
+            is            => q{rw},
+            isa           => Bool,
         )
     );
 
@@ -278,11 +276,10 @@ q{Check analysis output and sets the analysis run status flag to finished in sam
 
     option(
         q{sacct} => (
-            cmd_tags => [q{Analysis recipe switch}],
-            documentation =>
-              q{Generating sbatch script for SLURM info on each submitted job},
-            is  => q{rw},
-            isa => enum( [ 0, 1, 2 ] ),
+            cmd_tags      => [q{Analysis recipe switch}],
+            documentation => q{Generating sbatch script for SLURM info on each submitted job},
+            is            => q{rw},
+            isa           => enum( [ 0, 1, 2 ] ),
         )
     );
 

--- a/lib/MIP/Cli/Mip/Analyse/Dragen_rd_dna.pm
+++ b/lib/MIP/Cli/Mip/Analyse/Dragen_rd_dna.pm
@@ -3,7 +3,6 @@ package MIP::Cli::Mip::Analyse::Dragen_rd_dna;
 use 5.026;
 use Carp;
 use open qw{ :encoding(UTF-8) :std };
-use strict;
 use utf8;
 use warnings;
 use warnings qw{ FATAL utf8 };
@@ -403,7 +402,7 @@ q{Default: hgvs, symbol, numbers, sift, polyphen, humdiv, domains, protein, ccds
 
     option(
         q{sv_genmod_annotate_regions} => (
-            cmd_flag => q{sv_genmod_ann_reg},
+            cmd_flag      => q{sv_genmod_ann_reg},
             documentation =>
               q{Use predefined gene annotation supplied with genmod for defining genes},
             is  => q{rw},
@@ -467,10 +466,10 @@ q{Default: hgvs, symbol, numbers, sift, polyphen, humdiv, domains, protein, ccds
 
     option(
         q{prepareforvariantannotationblock} => (
-            cmd_flag => q{prep_for_var_ann_bl},
-            cmd_tags => [q{Analysis recipe switch}],
+            cmd_flag      => q{prep_for_var_ann_bl},
+            cmd_tags      => [q{Analysis recipe switch}],
             documentation =>
-q{Prepare for variant annotation block by copying and splitting files per contig},
+              q{Prepare for variant annotation block by copying and splitting files per contig},
             is  => q{rw},
             isa => enum( [ 0, 1, 2 ] ),
         )
@@ -478,17 +477,16 @@ q{Prepare for variant annotation block by copying and splitting files per contig
 
     option(
         q{rhocall_ar} => (
-            cmd_tags => [q{Analysis recipe switch}],
-            documentation =>
-              q{Rhocall performs annotation of variants in autozygosity regions},
-            is  => q{rw},
-            isa => enum( [ 0, 1, 2 ] ),
+            cmd_tags      => [q{Analysis recipe switch}],
+            documentation => q{Rhocall performs annotation of variants in autozygosity regions},
+            is            => q{rw},
+            isa           => enum( [ 0, 1, 2 ] ),
         )
     );
 
     option(
         q{rhocall_frequency_file} => (
-            cmd_tags => [q{Default: grch37_anon_swegen_snp_-2016-10-19-.tab.gz; tsv}],
+            cmd_tags      => [q{Default: grch37_anon_swegen_snp_-2016-10-19-.tab.gz; tsv}],
             documentation => q{Frequency file for bcftools roh calculation},
             is            => q{rw},
             isa           => Str,
@@ -743,7 +741,7 @@ q{Default: hgvs, symbol, numbers, sift, polyphen, humdiv, domains, protein, ccds
 
     option(
         q{genmod_annotate_regions} => (
-            cmd_flag => q{genmod_ann_reg},
+            cmd_flag      => q{genmod_ann_reg},
             documentation =>
               q{Use predefined gene annotation supplied with genmod for defining genes},
             is  => q{rw},

--- a/lib/MIP/Cli/Mip/Download.pm
+++ b/lib/MIP/Cli/Mip/Download.pm
@@ -3,7 +3,6 @@ package MIP::Cli::Mip::Download;
 use 5.026;
 use Carp;
 use open qw{ :encoding(UTF-8) :std };
-use strict;
 use utf8;
 use warnings;
 use warnings qw{ FATAL utf8 };
@@ -113,11 +112,10 @@ sub _build_usage {
 
     option(
         q{dry_run_all} => (
-            cmd_aliases => [qw{ dra }],
-            documentation =>
-              q{Sets all recipes to dry run mode i.e. no sbatch submission},
-            is  => q{rw},
-            isa => Bool,
+            cmd_aliases   => [qw{ dra }],
+            documentation => q{Sets all recipes to dry run mode i.e. no sbatch submission},
+            is            => q{rw},
+            isa           => Bool,
         )
     );
 

--- a/lib/MIP/Cli/Mip/Qccollect.pm
+++ b/lib/MIP/Cli/Mip/Qccollect.pm
@@ -5,7 +5,6 @@ use Carp;
 use Cwd;
 use File::Spec::Functions qw{ catfile };
 use open qw{ :encoding(UTF-8) :std };
-use strict;
 use utf8;
 use warnings;
 use warnings qw{ FATAL utf8 };

--- a/lib/MIP/Cluster.pm
+++ b/lib/MIP/Cluster.pm
@@ -7,7 +7,6 @@ use English qw{ -no_match_vars };
 use open qw{ :encoding(UTF-8) :std };
 use Params::Check qw{ allow check last_error };
 use POSIX qw{ floor };
-use strict;
 use utf8;
 use warnings;
 use warnings qw{ FATAL utf8 };
@@ -130,8 +129,7 @@ sub get_parallel_processes {
 
     check( $tmpl, $arg_href, 1 ) or croak q{Could not parse arguments!};
 
-    my $parallel_processes =
-      floor( $recipe_memory_allocation / $process_memory_allocation );
+    my $parallel_processes = floor( $recipe_memory_allocation / $process_memory_allocation );
 
     ## Check that the number of processes doesn't exceed the number of available cores
     if ( $parallel_processes > $core_number ) {

--- a/lib/MIP/Config.pm
+++ b/lib/MIP/Config.pm
@@ -5,7 +5,6 @@ use charnames qw{ :full :short };
 use English qw{ -no_match_vars };
 use open qw{ :encoding(UTF-8) :std };
 use Params::Check qw{ allow check last_error };
-use strict;
 use utf8;
 use warnings;
 use warnings qw{ FATAL utf8 };
@@ -64,8 +63,7 @@ sub check_cmd_config_vs_definition_file {
 
     check( $tmpl, $arg_href, 1 ) or croak q{Could not parse arguments!};
 
-    my @allowed_unique_keys =
-      ( q{vcfparser_outfile_count}, $active_parameter_href->{case_id} );
+    my @allowed_unique_keys = ( q{vcfparser_outfile_count}, $active_parameter_href->{case_id} );
     my @unique;
 
   ACTIVE_PARAMETER:
@@ -263,9 +261,8 @@ sub parse_dynamic_config_parameters {
         ## Updates the dynamic config parameters using supplied $case_id
         update_dynamic_config_parameters(
             {
-                active_parameter_ref => \$active_parameter_href->{$dynamic_param_name},
-                dynamic_parameter_href =>
-                  { case_id => $active_parameter_href->{case_id}, },
+                active_parameter_ref   => \$active_parameter_href->{$dynamic_param_name},
+                dynamic_parameter_href => { case_id => $active_parameter_href->{case_id}, },
             }
         );
     }
@@ -339,8 +336,7 @@ sub set_config_to_active_parameters {
 
         ### No input from cmd
         ## Add to active_parameter
-        $active_parameter_href->{$parmeter_name} =
-          $config_parameter_href->{$parmeter_name};
+        $active_parameter_href->{$parmeter_name} = $config_parameter_href->{$parmeter_name};
     }
     return;
 }
@@ -467,8 +463,7 @@ sub write_mip_config {
             path      => $active_parameter_href->{config_file_analysis},
         }
     );
-    $log->info(
-        q{Wrote config file to: } . $active_parameter_href->{config_file_analysis} );
+    $log->info( q{Wrote config file to: } . $active_parameter_href->{config_file_analysis} );
 
     ## Add to sample_info for use downstream
     set_in_sample_info(

--- a/lib/MIP/Constants.pm
+++ b/lib/MIP/Constants.pm
@@ -6,7 +6,6 @@ use charnames qw{ :full :short };
 use English qw{ -no_match_vars };
 use open qw{ :encoding(UTF-8) :std };
 use Params::Check qw{ allow check last_error };
-use strict;
 use utf8;
 use warnings;
 use warnings qw{ FATAL utf8 };

--- a/lib/MIP/Definition.pm
+++ b/lib/MIP/Definition.pm
@@ -8,7 +8,6 @@ use File::Spec::Functions qw{ catfile };
 use FindBin qw{ $Bin };
 use open qw{ :encoding(UTF-8) :std };
 use Params::Check qw{ allow check last_error };
-use strict;
 use utf8;
 use warnings;
 use warnings qw{ FATAL utf8 };
@@ -310,8 +309,7 @@ sub get_parameter_from_definition_files {
 
     check( $tmpl, $arg_href, 1 ) or croak q{Could not parse arguments!};
 
-    my @definition_file_paths =
-      get_parameter_definition_file_paths( { level => $level, } );
+    my @definition_file_paths = get_parameter_definition_file_paths( { level => $level, } );
 
     ## Not required parameter definition keys to check
     my $not_required_definition_file_path =
@@ -330,10 +328,9 @@ sub get_parameter_from_definition_files {
             %parameter,
             check_definition_file(
                 {
-                    define_parameters_path => $definition_file,
-                    not_required_definition_file_path =>
-                      $not_required_definition_file_path,
-                    required_definition_file_path => $required_definition_file_path,
+                    define_parameters_path            => $definition_file,
+                    not_required_definition_file_path => $not_required_definition_file_path,
+                    required_definition_file_path     => $required_definition_file_path,
                 }
             ),
         );

--- a/lib/MIP/Dependency_tree.pm
+++ b/lib/MIP/Dependency_tree.pm
@@ -6,7 +6,6 @@ use charnames qw{ :full :short };
 use English qw{ -no_match_vars };
 use open qw{ :encoding(UTF-8) :std };
 use Params::Check qw{ allow check last_error };
-use strict;
 use utf8;
 use warnings;
 use warnings qw{ FATAL utf8 };

--- a/lib/MIP/Download.pm
+++ b/lib/MIP/Download.pm
@@ -6,7 +6,6 @@ use charnames qw{ :full :short };
 use English qw{ -no_match_vars };
 use open qw{ :encoding(UTF-8) :std };
 use Params::Check qw{ allow check last_error };
-use strict;
 use utf8;
 use warnings;
 use warnings qw{ FATAL utf8 };
@@ -160,8 +159,7 @@ sub get_download_reference_attributes {
 
     use Data::Diver qw{ Dive };
 
-    my $reference_file_attribute_href =
-      Dive( $reference_href, ( $id, $genome_version, $version ) );
+    my $reference_file_attribute_href = Dive( $reference_href, ( $id, $genome_version, $version ) );
 
     return if ( not $reference_file_attribute_href );
 

--- a/lib/MIP/Environment/Child_process.pm
+++ b/lib/MIP/Environment/Child_process.pm
@@ -6,7 +6,6 @@ use charnames qw{ :full :short };
 use English qw{ -no_match_vars };
 use open qw{ :encoding(UTF-8) :std };
 use Params::Check qw{ allow check last_error };
-use strict;
 use utf8;
 use warnings;
 use warnings qw{ FATAL utf8 };
@@ -81,8 +80,8 @@ sub child_process {
         },
     );
 
-    my %process_return = $process_api{$process_type}{method}
-      ->( { %{ $process_api{$process_type}{arg_href} } } );
+    my %process_return =
+      $process_api{$process_type}{method}->( { %{ $process_api{$process_type}{arg_href} } } );
 
     return %process_return;
 }

--- a/lib/MIP/Environment/Cluster.pm
+++ b/lib/MIP/Environment/Cluster.pm
@@ -7,7 +7,6 @@ use English qw{ -no_match_vars };
 use List::Util qw{ min };
 use open qw{ :encoding(UTF-8) :std };
 use Params::Check qw{ allow check last_error };
-use strict;
 use utf8;
 use warnings;
 use warnings qw{ FATAL utf8 };

--- a/lib/MIP/Environment/Manager.pm
+++ b/lib/MIP/Environment/Manager.pm
@@ -6,7 +6,6 @@ use charnames qw{ :full :short };
 use English qw{ -no_match_vars };
 use open qw{ :encoding(UTF-8) :std };
 use Params::Check qw{ allow check last_error };
-use strict;
 use utf8;
 use warnings;
 use warnings qw{ FATAL utf8 };
@@ -68,7 +67,7 @@ sub get_env_method_cmds {
 
     my %method_cmd = (
         conda => {
-            load   => [ ( conda_activate(   { env_name => $env_name, } ), ) ],
+            load   => [ ( conda_activate( { env_name => $env_name, } ), ) ],
             unload => [ ( conda_deactivate( {} ), ) ],
         },
     );

--- a/lib/MIP/Environment/User.pm
+++ b/lib/MIP/Environment/User.pm
@@ -6,7 +6,6 @@ use charnames qw{ :full :short };
 use English qw{ -no_match_vars };
 use open qw{ :encoding(UTF-8) :std };
 use Params::Check qw{ allow check last_error };
-use strict;
 use utf8;
 use warnings;
 use warnings qw{ FATAL utf8 };

--- a/lib/MIP/Fastq.pm
+++ b/lib/MIP/Fastq.pm
@@ -8,7 +8,6 @@ use File::Spec::Functions qw{ catfile };
 use List::Util qw { any sum };
 use open qw{ :encoding(UTF-8) :std };
 use Params::Check qw{ allow check last_error };
-use strict;
 use utf8;
 use warnings;
 use warnings qw{ FATAL utf8 };
@@ -47,8 +46,7 @@ sub casava_header_features {
     my ($arg_href) = @_;
 
     my %casava_header_feature = (
-        q{1.4} =>
-          [qw{ instrument_id run_number flowcell lane tile x_pos y_pos direction }],
+        q{1.4} => [qw{ instrument_id run_number flowcell lane tile x_pos y_pos direction }],
         q{1.8} => [
             qw{ instrument_id run_number flowcell lane tile x_pos y_pos direction filtered control_bit index }
         ],
@@ -94,8 +92,7 @@ sub check_interleaved {
     my $log = Log::Log4perl->get_logger($LOG_NAME);
 
     ## Select relevant regexps to use
-    my @regexps =
-      qw{ get_fastq_header_v1.8_interleaved get_fastq_header_v1.4_interleaved };
+    my @regexps = qw{ get_fastq_header_v1.8_interleaved get_fastq_header_v1.4_interleaved };
 
     ## Store return from regexp
     my $fastq_read_direction;
@@ -221,8 +218,7 @@ sub define_mip_fastq_file_features {
     my $mip_file_format = join $UNDERSCORE,
       ( $sample_id, $date, $flowcell, $index, q{lane} . $lane );
 
-    my $mip_file_format_with_direction = join $UNDERSCORE,
-      ( $mip_file_format, $direction );
+    my $mip_file_format_with_direction = join $UNDERSCORE, ( $mip_file_format, $direction );
 
     my $original_file_name_prefix = substr $original_file_name, 0,
       index $original_file_name, q{.fastq};
@@ -347,9 +343,7 @@ sub parse_fastq_file_header_attributes {
     if ( not $fastq_info_header_string ) {
 
         $log->fatal( q{Error parsing file header: } . $file_path );
-        $log->fatal(
-            q{Could not detect required sample sequencing run info from fastq file header}
-        );
+        $log->fatal(q{Could not detect required sample sequencing run info from fastq file header});
         $log->fatal(q{Please proved MIP file in MIP file convention format to proceed});
         exit 1;
     }
@@ -622,15 +616,13 @@ sub parse_fastq_infiles_format {
     }
     if (@missing_feature) {
         $log->warn(qq{Could not detect MIP file name convention for file: $file_name });
-        $log->warn( q{Missing file name feature: } . join $COMMA . $SPACE,
-            @missing_feature );
+        $log->warn( q{Missing file name feature: } . join $COMMA . $SPACE, @missing_feature );
 
         ## Check that file name at least contains sample id
         return if ( $file_name =~ /$sample_id/sxm );
 
         $log->fatal(
-qq{Please check that the file name: $file_name contains the sample_id: $sample_id}
-        );
+            qq{Please check that the file name: $file_name contains the sample_id: $sample_id});
         exit 1;
     }
     ## Check that the sample_id provided and sample_id in infile name match

--- a/lib/MIP/File/Format/Dragen.pm
+++ b/lib/MIP/File/Format/Dragen.pm
@@ -8,7 +8,6 @@ use File::Basename qw{ dirname };
 use File::Path qw{ make_path };
 use open qw{ :encoding(UTF-8) :std };
 use Params::Check qw{ allow check last_error };
-use strict;
 use utf8;
 use warnings;
 use warnings qw{ FATAL utf8 };

--- a/lib/MIP/File/Format/Feature_file.pm
+++ b/lib/MIP/File/Format/Feature_file.pm
@@ -6,7 +6,6 @@ use charnames qw{ :full :short };
 use English qw{ -no_match_vars };
 use open qw{ :encoding(UTF-8) :std };
 use Params::Check qw{ allow check last_error };
-use strict;
 use utf8;
 use warnings;
 use warnings qw{ FATAL utf8 };
@@ -16,8 +15,7 @@ use autodie qw{ :all };
 use Readonly;
 
 ## MIPs lib/
-use MIP::Constants
-  qw{ $COLON $COMMA $EMPTY_STR $NEWLINE $SEMICOLON $SPACE $TAB $UNDERSCORE };
+use MIP::Constants qw{ $COLON $COMMA $EMPTY_STR $NEWLINE $SEMICOLON $SPACE $TAB $UNDERSCORE };
 
 BEGIN {
     require Exporter;
@@ -78,9 +76,8 @@ sub parse_feature_file_data {
             store       => \$feature_file_type,
             strict_type => 1,
         },
-        feature_matching_column =>
-          { store => \$feature_matching_column, strict_type => 1, },
-        padding => {
+        feature_matching_column => { store => \$feature_matching_column, strict_type => 1, },
+        padding                 => {
             defined     => 1,
             required    => 1,
             store       => \$padding,
@@ -261,9 +258,8 @@ sub read_feature_file {
             store       => \$feature_file_type,
             strict_type => 1,
         },
-        feature_matching_column =>
-          { store => \$feature_matching_column, strict_type => 1, },
-        log => {
+        feature_matching_column => { store => \$feature_matching_column, strict_type => 1, },
+        log                     => {
             defined  => 1,
             required => 1,
             store    => \$log,
@@ -286,16 +282,14 @@ sub read_feature_file {
     check( $tmpl, $arg_href, 1 ) or croak q{Could not parse arguments!};
 
     use MIP::Vcfparser qw{ build_interval_tree };
-    use MIP::File::Format::Feature_file
-      qw{ parse_feature_file_data parse_feature_file_header };
+    use MIP::File::Format::Feature_file qw{ parse_feature_file_data parse_feature_file_header };
 
     return if ( not $feature_file_path );
 
     my $filehandle = IO::Handle->new();
 
     open $filehandle, q{<}, $feature_file_path
-      or
-      $log->logdie( q{Cannot open } . $feature_file_path . $COLON . $OS_ERROR, $NEWLINE );
+      or $log->logdie( q{Cannot open } . $feature_file_path . $COLON . $OS_ERROR, $NEWLINE );
 
   LINE:
     while (<$filehandle>) {
@@ -579,8 +573,8 @@ sub tree_annotations {
               if ( not $feature_header_col_index eq $annotation_index );
 
             ## Set annotation to vcf record
-            $record_href->{ q{INFO_addition_} . $feature_file_type }{$feature_header} =
-              join $COMMA, @{$annotations_ref};
+            $record_href->{ q{INFO_addition_} . $feature_file_type }{$feature_header} = join $COMMA,
+              @{$annotations_ref};
         }
     }
     return %noid_region;

--- a/lib/MIP/File/Format/Star_fusion.pm
+++ b/lib/MIP/File/Format/Star_fusion.pm
@@ -7,7 +7,6 @@ use English qw{ -no_match_vars };
 use File::Spec::Functions qw{ catfile };
 use open qw{ :encoding(UTF-8) :std };
 use Params::Check qw{ allow check last_error };
-use strict;
 use utf8;
 use warnings;
 use warnings qw{ FATAL utf8 };
@@ -121,8 +120,7 @@ sub create_star_fusion_sample_file {
             $paired_end_tracker++;
 
             ## Add read two file index array
-            push @{ $sample_line{$infile_prefix} },
-              $infile_paths_ref->[$paired_end_tracker];
+            push @{ $sample_line{$infile_prefix} }, $infile_paths_ref->[$paired_end_tracker];
         }
 
         ## Increment paired end tracker

--- a/lib/MIP/File/Format/Vcf.pm
+++ b/lib/MIP/File/Format/Vcf.pm
@@ -6,7 +6,6 @@ use charnames qw{ :full :short };
 use English qw{ -no_match_vars };
 use open qw{ :encoding(UTF-8) :std };
 use Params::Check qw{ allow check last_error };
-use strict;
 use utf8;
 use warnings;
 use warnings qw{ FATAL utf8 };
@@ -82,8 +81,7 @@ sub get_vcf_header_line_by_id {
     my @check_header_cmds;
 
     ## Stream vcf using bcftools
-    push @check_header_cmds,
-      $bcftools_binary_path . $SPACE . q{view} . $SPACE . $vcf_file_path;
+    push @check_header_cmds, $bcftools_binary_path . $SPACE . q{view} . $SPACE . $vcf_file_path;
     push @check_header_cmds, $PIPE;
 
     ## Assemble perl regexp for detecting keys in vcf

--- a/lib/MIP/File/Format/Vep.pm
+++ b/lib/MIP/File/Format/Vep.pm
@@ -8,7 +8,6 @@ use File::Basename qw{ dirname };
 use File::Path qw{ make_path };
 use open qw{ :encoding(UTF-8) :std };
 use Params::Check qw{ allow check last_error };
-use strict;
 use utf8;
 use warnings;
 use warnings qw{ FATAL utf8 };

--- a/lib/MIP/File/Path.pm
+++ b/lib/MIP/File/Path.pm
@@ -9,7 +9,6 @@ use File::Basename qw{ fileparse };
 use File::Spec::Functions qw{ splitpath };
 use open qw{ :encoding(UTF-8) :std };
 use Params::Check qw{ allow check last_error };
-use strict;
 use utf8;
 use warnings;
 use warnings qw{ FATAL utf8 };
@@ -137,8 +136,7 @@ sub check_filesystem_objects_existance {
         ## Directory was found
         return 1 if ( -d $object_name );
 
-        $error_msg =
-          q{Could not find intended } . $parameter_name . q{ directory: } . $object_name;
+        $error_msg = q{Could not find intended } . $parameter_name . q{ directory: } . $object_name;
         return ( 0, $error_msg );
     }
     ## Then object type must be file
@@ -147,8 +145,7 @@ sub check_filesystem_objects_existance {
     ## File was found
     return 1 if ( -f $object_name );
 
-    $error_msg =
-      q{Could not find intended } . $parameter_name . q{ file: } . $object_name;
+    $error_msg = q{Could not find intended } . $parameter_name . q{ file: } . $object_name;
     return 0, $error_msg;
 }
 

--- a/lib/MIP/File_info.pm
+++ b/lib/MIP/File_info.pm
@@ -8,7 +8,6 @@ use File::Basename qw{ dirname fileparse };
 use File::Spec::Functions qw{ catfile };
 use open qw{ :encoding(UTF-8) :std };
 use Params::Check qw{ allow check last_error };
-use strict;
 use utf8;
 use warnings;
 use warnings qw{ FATAL utf8 };
@@ -149,8 +148,7 @@ sub add_sample_no_direction_infile_prefixes {
     check( $tmpl, $arg_href, 1 ) or croak q{Could not parse arguments!};
 
     ## Add no_direction_infile_prefixes
-    push @{ $file_info_href->{$sample_id}{no_direction_infile_prefixes} },
-      $mip_file_format;
+    push @{ $file_info_href->{$sample_id}{no_direction_infile_prefixes} }, $mip_file_format;
 
     return;
 }
@@ -228,12 +226,11 @@ sub check_parameter_metafiles {
                 ## Checks files to be built by combining filename stub with fileendings
                 parse_meta_file_suffixes(
                     {
-                        active_parameter_href => $active_parameter_href,
-                        file_name             => $path,
-                        meta_file_suffixes_ref =>
-                          \@{ $file_info_href->{$parameter_name} },
-                        parameter_href => $parameter_href,
-                        parameter_name => $parameter_name,
+                        active_parameter_href  => $active_parameter_href,
+                        file_name              => $path,
+                        meta_file_suffixes_ref => \@{ $file_info_href->{$parameter_name} },
+                        parameter_href         => $parameter_href,
+                        parameter_name         => $parameter_name,
                     }
                 );
 
@@ -314,8 +311,7 @@ sub get_consensus_sequence_run_type {
         );
 
       INFILE_PREFIX:
-        foreach my $infile_prefix ( @{ $file_info_sample{no_direction_infile_prefixes} } )
-        {
+        foreach my $infile_prefix ( @{ $file_info_sample{no_direction_infile_prefixes} } ) {
 
             my $sequence_run_type = get_sample_file_attribute(
                 {
@@ -1083,7 +1079,7 @@ sub set_human_genome_reference_features {
     if ( not $file_info_href->{human_genome_reference_version} ) {
 
         $log->fatal(
-            q{MIP cannot detect what version of human_genome_reference you have supplied.}
+                q{MIP cannot detect what version of human_genome_reference you have supplied.}
               . $SPACE
               . q{Please supply the reference on this format: [sourceversion]_[species] e.g. 'grch37_homo_sapiens' or 'hg19_homo_sapiens'}
               . $NEWLINE );
@@ -1358,8 +1354,7 @@ sub set_sample_max_parallel_processes_count {
 
     check( $tmpl, $arg_href, 1 ) or croak q{Could not parse arguments!};
 
-    $file_info_href->{max_parallel_processes_count}{$sample_id} =
-      $max_parallel_processes_count;
+    $file_info_href->{max_parallel_processes_count}{$sample_id} = $max_parallel_processes_count;
     return;
 }
 

--- a/lib/MIP/Gatk.pm
+++ b/lib/MIP/Gatk.pm
@@ -6,7 +6,6 @@ use charnames qw{ :full :short };
 use English qw{ -no_match_vars };
 use open qw{ :encoding(UTF-8) :std };
 use Params::Check qw{ allow check last_error };
-use strict;
 use utf8;
 use warnings;
 use warnings qw{ FATAL utf8 };
@@ -76,8 +75,7 @@ sub check_gatk_sample_map_paths {
         ## Make sure that we get what we expect
         if ( defined $unexpected_data ) {
 
-            $log->logcarp(
-                q{Unexpected trailing garbage at end of line '} . $line . q{':},
+            $log->logcarp( q{Unexpected trailing garbage at end of line '} . $line . q{':},
                 $NEWLINE . $TAB . $unexpected_data . $NEWLINE );
         }
 

--- a/lib/MIP/Get/File.pm
+++ b/lib/MIP/Get/File.pm
@@ -8,7 +8,6 @@ use English qw{ -no_match_vars };
 use File::Spec::Functions qw{ catfile };
 use open qw{ :encoding(UTF-8) :std };
 use Params::Check qw{ check allow last_error };
-use strict;
 use utf8;
 use warnings;
 use warnings qw{ FATAL utf8 };
@@ -216,10 +215,7 @@ sub get_io_files {
               if (
                 not Dive(
                     $file_info_href,
-                    (
-                        q{io},            $upstream_chain_id, $id,
-                        $upstream_recipe, $upstream_direction
-                    )
+                    ( q{io}, $upstream_chain_id, $id, $upstream_recipe, $upstream_direction )
                 )
               );
 
@@ -253,10 +249,7 @@ sub get_io_files {
             if (
                 Dive(
                     $file_info_href,
-                    (
-                        q{io},            $upstream_chain_id, $id,
-                        $upstream_recipe, $upstream_direction
-                    )
+                    ( q{io}, $upstream_chain_id, $id, $upstream_recipe, $upstream_direction )
                 )
               )
             {
@@ -500,8 +493,8 @@ sub _collect_outfile {
             store       => \$outfiles_ref,
             strict_type => 1,
         },
-        value => { defined => 1, required => 1, store => \$value, },
-        key   => { defined => 1, store => \$key, required => 1, strict_type => 1, },
+        value => { defined => 1, required => 1,     store    => \$value, },
+        key   => { defined => 1, store    => \$key, required => 1, strict_type => 1, },
     };
 
     check( $tmpl, $arg_href, 1 ) or croak q{Could not parse arguments!};

--- a/lib/MIP/Io/Read.pm
+++ b/lib/MIP/Io/Read.pm
@@ -6,7 +6,6 @@ use charnames qw{ :full :short };
 use English qw{ -no_match_vars };
 use open qw{ :encoding(UTF-8) :std };
 use Params::Check qw{ allow check last_error };
-use strict;
 use utf8;
 use warnings;
 use warnings qw{ FATAL utf8 };

--- a/lib/MIP/Io/Recipes.pm
+++ b/lib/MIP/Io/Recipes.pm
@@ -6,7 +6,6 @@ use charnames qw{ :full :short };
 use English qw{ -no_match_vars };
 use open qw{ :encoding(UTF-8) :std };
 use Params::Check qw{ allow check last_error };
-use strict;
 use utf8;
 use warnings;
 use warnings qw{ FATAL utf8 };

--- a/lib/MIP/Io/Write.pm
+++ b/lib/MIP/Io/Write.pm
@@ -6,7 +6,6 @@ use charnames qw{ :full :short };
 use English qw{ -no_match_vars };
 use open qw{ :encoding(UTF-8) :std };
 use Params::Check qw{ allow check last_error };
-use strict;
 use utf8;
 use warnings;
 use warnings qw{ FATAL utf8 };

--- a/lib/MIP/Language/Awk.pm
+++ b/lib/MIP/Language/Awk.pm
@@ -6,7 +6,6 @@ use charnames qw{ :full :short };
 use English qw{ -no_match_vars };
 use open qw{ :encoding(UTF-8) :std };
 use Params::Check qw{ allow check last_error };
-use strict;
 use utf8;
 use warnings;
 use warnings qw{ FATAL utf8 };

--- a/lib/MIP/Language/Java.pm
+++ b/lib/MIP/Language/Java.pm
@@ -6,7 +6,6 @@ use charnames qw{ :full :short };
 use English qw{ -no_match_vars };
 use open qw{ :encoding(UTF-8) :std };
 use Params::Check qw{ allow check last_error };
-use strict;
 use utf8;
 use warnings;
 use warnings qw{ FATAL utf8 };

--- a/lib/MIP/Language/Python.pm
+++ b/lib/MIP/Language/Python.pm
@@ -6,7 +6,6 @@ use charnames qw{ :full :short };
 use English qw{ -no_match_vars };
 use open qw{ :encoding(UTF-8) :std };
 use Params::Check qw{ allow check last_error };
-use strict;
 use utf8;
 use warnings;
 use warnings qw{ FATAL utf8 };

--- a/lib/MIP/Log/MIP_log4perl.pm
+++ b/lib/MIP/Log/MIP_log4perl.pm
@@ -9,7 +9,6 @@ use File::Spec::Functions qw{ catfile };
 use File::Path qw{ make_path };
 use open qw{ :encoding(UTF-8) :std };
 use Params::Check qw{ check allow last_error };
-use strict;
 use utf8;
 use warnings;
 use warnings qw{ FATAL utf8 };

--- a/lib/MIP/Main/Vcfparser.pm
+++ b/lib/MIP/Main/Vcfparser.pm
@@ -6,7 +6,6 @@ use charnames qw{ :full :short };
 use English qw{ -no_match_vars };
 use open qw{ :encoding(UTF-8) :std };
 use Params::Check qw{ allow check last_error };
-use strict;
 use utf8;
 use warnings;
 use warnings qw{ FATAL utf8 };

--- a/lib/MIP/Parameter.pm
+++ b/lib/MIP/Parameter.pm
@@ -7,7 +7,6 @@ use English qw{ -no_match_vars };
 use File::Spec::Functions qw{ catfile };
 use open qw{ :encoding(UTF-8) :std };
 use Params::Check qw{ allow check last_error };
-use strict;
 use utf8;
 use warnings;
 use warnings qw{ FATAL utf8 };
@@ -18,8 +17,7 @@ use List::MoreUtils qw { any uniq };
 use Readonly;
 
 ## MIPs lib/
-use MIP::Constants
-  qw{ $COMMA $COLON $LOG_NAME $NEWLINE $SINGLE_QUOTE $SPACE $TAB $UNDERSCORE };
+use MIP::Constants qw{ $COMMA $COLON $LOG_NAME $NEWLINE $SINGLE_QUOTE $SPACE $TAB $UNDERSCORE };
 
 BEGIN {
     require Exporter;
@@ -531,8 +529,8 @@ sub parse_parameter_recipe_names {
             check_recipe_exists_in_hash(
                 {
                     parameter_name => $parameter_name,
-                    query_ref  => \@{ $parameter_href->{$parameter}{$parameter_name} },
-                    truth_href => $parameter_href,
+                    query_ref      => \@{ $parameter_href->{$parameter}{$parameter_name} },
+                    truth_href     => $parameter_href,
                 }
             );
         }
@@ -583,7 +581,7 @@ sub parse_reference_path {
 
         update_reference_parameters(
             {
-                active_parameter_href => $active_parameter_href,
+                active_parameter_href  => $active_parameter_href,
                 associated_recipes_ref =>
                   \@{ $parameter_href->{$parameter_name}{associated_recipe} },
                 parameter_name => $parameter_name,
@@ -1102,7 +1100,7 @@ sub set_default {
         ## Checks and sets user input or default values to active_parameters
         set_default_to_active_parameter(
             {
-                active_parameter_href => $active_parameter_href,
+                active_parameter_href  => $active_parameter_href,
                 associated_recipes_ref =>
                   \@{ $parameter_href->{$parameter_name}{associated_recipe} },
                 parameter_href => $parameter_href,
@@ -1201,10 +1199,8 @@ sub set_default_to_active_parameter {
           if ( not $active_parameter_href->{$associated_recipe} );
 
         ## Mandatory parameter not supplied
-        $log->fatal( q{Supply '-}
-              . $parameter_name
-              . q{' if you want to run }
-              . $associated_recipe );
+        $log->fatal(
+            q{Supply '-} . $parameter_name . q{' if you want to run } . $associated_recipe );
         exit 1;
     }
     return;
@@ -1594,9 +1590,8 @@ sub _set_default_capture_kit {
     ## Return a default capture kit as user supplied no info
     my $capture_kit = get_capture_kit(
         {
-            capture_kit => q{latest},
-            supported_capture_kit_href =>
-              $parameter_href->{supported_capture_kit}{default},
+            capture_kit                => q{latest},
+            supported_capture_kit_href => $parameter_href->{supported_capture_kit}{default},
         }
     );
 

--- a/lib/MIP/Parse/File.pm
+++ b/lib/MIP/Parse/File.pm
@@ -7,7 +7,6 @@ use English qw{ -no_match_vars };
 use File::Spec::Functions qw{ catdir catfile };
 use open qw{ :encoding(UTF-8) :std };
 use Params::Check qw{ allow check last_error };
-use strict;
 use utf8;
 use warnings;
 use warnings qw{ FATAL utf8 };
@@ -151,7 +150,7 @@ sub parse_io_outfiles {
         );
         my $outfile_tag    = $rec_atr{file_tag}       //= $EMPTY_STR;
         my $outfile_suffix = $rec_atr{outfile_suffix} //= $EMPTY_STR;
-        my $directory = catdir( $outdata_dir, $id, $recipe_name );
+        my $directory      = catdir( $outdata_dir, $id, $recipe_name );
 
         ## Default paths with iterators
         if ( @{$iterators_ref} and $file_name_prefix ) {
@@ -167,10 +166,8 @@ sub parse_io_outfiles {
                 }
             }
             @file_paths =
-              map {
-                catfile( $directory,
-                    $file_name_prefix . $outfile_tag . $_ . $outfile_suffix )
-              } @iterators;
+              map { catfile( $directory, $file_name_prefix . $outfile_tag . $_ . $outfile_suffix ) }
+              @iterators;
         }
         ## Default paths without iterators
         else {

--- a/lib/MIP/Parse/Gender.pm
+++ b/lib/MIP/Parse/Gender.pm
@@ -8,7 +8,6 @@ use File::Spec::Functions qw{ catfile };
 use FindBin qw{ $Bin };
 use open qw{ :encoding(UTF-8) :std };
 use Params::Check qw{ allow check last_error };
-use strict;
 use utf8;
 use warnings;
 use warnings qw{ FATAL utf8 };
@@ -136,16 +135,11 @@ sub get_number_of_male_reads {
     my $random_integer = int rand $MAX_RANDOM_NUMBER;
 
     ## Temporary bash file for commands
-    my $bash_temp_file = catfile( $Bin,
-        q{estimate_gender_from_reads} . $UNDERSCORE . $random_integer . q{.sh} );
+    my $bash_temp_file =
+      catfile( $Bin, q{estimate_gender_from_reads} . $UNDERSCORE . $random_integer . q{.sh} );
 
     open my $filehandle, q{>}, $bash_temp_file
-      or croak q{Cannot write to}
-      . $SPACE
-      . $bash_temp_file
-      . $COLON
-      . $SPACE
-      . $OS_ERROR;
+      or croak q{Cannot write to} . $SPACE . $bash_temp_file . $COLON . $SPACE . $OS_ERROR;
 
     ## Write to file
     say {$filehandle} join $SPACE, @{$commands_ref};
@@ -205,14 +199,11 @@ sub get_sampling_fastq_files {
     my $paired_end_tracker = 0;
 
   INFILE_PREFIX:
-    foreach
-      my $infile_prefix ( @{ $file_info_sample_href->{no_direction_infile_prefixes} } )
-    {
+    foreach my $infile_prefix ( @{ $file_info_sample_href->{no_direction_infile_prefixes} } ) {
 
         push @fastq_files, $infile_paths_ref->[$paired_end_tracker];
 
-        my $sequence_run_type =
-          $file_info_sample_href->{$infile_prefix}{sequence_run_type};
+        my $sequence_run_type = $file_info_sample_href->{$infile_prefix}{sequence_run_type};
 
         # If second read direction is present
         if ( $sequence_run_type eq q{paired-end} ) {
@@ -360,10 +351,7 @@ sub parse_fastq_for_gender {
           gnu_grep(
             {
                 count   => 1,
-                pattern => $DOUBLE_QUOTE . q{chrY}
-                  . $BACKWARD_SLASH
-                  . $PIPE . q{Y}
-                  . $DOUBLE_QUOTE,
+                pattern => $DOUBLE_QUOTE . q{chrY} . $BACKWARD_SLASH . $PIPE . q{Y} . $DOUBLE_QUOTE,
             }
           );
 

--- a/lib/MIP/Parse/Reference.pm
+++ b/lib/MIP/Parse/Reference.pm
@@ -6,7 +6,6 @@ use charnames qw{ :full :short };
 use English qw{ -no_match_vars };
 use open qw{ :encoding(UTF-8) :std };
 use Params::Check qw{ allow check last_error };
-use strict;
 use utf8;
 use warnings;
 use warnings qw{ FATAL utf8 };
@@ -23,8 +22,7 @@ BEGIN {
     use base qw{ Exporter };
 
     # Functions and variables which can be optionally exported
-    our @EXPORT_OK =
-      qw{ parse_references parse_reference_for_vt parse_toml_config_for_vcf_tags };
+    our @EXPORT_OK = qw{ parse_references parse_reference_for_vt parse_toml_config_for_vcf_tags };
 }
 
 sub parse_references {
@@ -146,8 +144,7 @@ sub parse_reference_for_vt {
         {
             active_parameter_href => $active_parameter_href,
             parameter_href        => $parameter_href,
-            vt_references_ref =>
-              \@{ $active_parameter_href->{decompose_normalize_references} },
+            vt_references_ref     => \@{ $active_parameter_href->{decompose_normalize_references} },
         }
     );
 

--- a/lib/MIP/Pedigree.pm
+++ b/lib/MIP/Pedigree.pm
@@ -9,7 +9,6 @@ use File::Path qw{ make_path };
 use List::Util qw{ none };
 use open qw{ :encoding(UTF-8) :std };
 use Params::Check qw{ allow check last_error};
-use strict;
 use utf8;
 use warnings;
 use warnings qw{ FATAL utf8 };
@@ -676,8 +675,7 @@ sub is_sample_proband_in_trio {
     return 0 if ( $phenotype eq q{unaffected} );
 
     ## Get family hash
-    my %family_member_id =
-      get_family_member_id( { sample_info_href => $sample_info_href } );
+    my %family_member_id = get_family_member_id( { sample_info_href => $sample_info_href } );
 
     ## Check if the sample is an affected child
     return 0 if ( none { $_ eq $sample_id } @{ $family_member_id{children} } );
@@ -1134,10 +1132,9 @@ sub set_pedigree_capture_kit_info {
         ## Return a capture kit depending on user info
         my $exome_target_bed_file = get_capture_kit(
             {
-                capture_kit => $capture_kit,
-                supported_capture_kit_href =>
-                  $parameter_href->{supported_capture_kit}{default},
-                is_set_by_user => $is_user_supplied_href->{exome_target_bed},
+                capture_kit                => $capture_kit,
+                supported_capture_kit_href => $parameter_href->{supported_capture_kit}{default},
+                is_set_by_user             => $is_user_supplied_href->{exome_target_bed},
             }
         );
 

--- a/lib/MIP/Pipeline.pm
+++ b/lib/MIP/Pipeline.pm
@@ -6,7 +6,6 @@ use charnames qw{ :full :short };
 use English qw{ -no_match_vars };
 use open qw{ :encoding(UTF-8) :std };
 use Params::Check qw{ allow check last_error };
-use strict;
 use utf8;
 use warnings;
 use warnings qw{ FATAL utf8 };
@@ -22,8 +21,7 @@ BEGIN {
     use base qw{ Exporter };
 
     # Functions and variables which can be optionally exported
-    our @EXPORT_OK =
-      qw{ run_analyse_pipeline run_download_pipeline run_install_pipeline };
+    our @EXPORT_OK = qw{ run_analyse_pipeline run_download_pipeline run_install_pipeline };
 }
 
 sub run_analyse_pipeline {
@@ -121,13 +119,11 @@ sub run_analyse_pipeline {
     check( $tmpl, $arg_href, 1 ) or croak q{Could not parse arguments!};
 
     ## Recipes
-    use MIP::Recipes::Pipeline::Analyse_dragen_rd_dna
-      qw{ pipeline_analyse_dragen_rd_dna };
+    use MIP::Recipes::Pipeline::Analyse_dragen_rd_dna qw{ pipeline_analyse_dragen_rd_dna };
     use MIP::Recipes::Pipeline::Analyse_rd_dna qw{ pipeline_analyse_rd_dna };
     use MIP::Recipes::Pipeline::Analyse_rd_dna_panel qw{ pipeline_analyse_rd_dna_panel };
     use MIP::Recipes::Pipeline::Analyse_rd_rna qw{ pipeline_analyse_rd_rna };
-    use MIP::Recipes::Pipeline::Analyse_rd_dna_vcf_rerun
-      qw{ pipeline_analyse_rd_dna_vcf_rerun };
+    use MIP::Recipes::Pipeline::Analyse_rd_dna_vcf_rerun qw{ pipeline_analyse_rd_dna_vcf_rerun };
 
     ## Retrieve logger object
     my $log = Log::Log4perl->get_logger($LOG_NAME);
@@ -225,10 +221,7 @@ sub run_install_pipeline {
     ## Retrieve logger object
     my $log = Log::Log4perl->get_logger($LOG_NAME);
 
-    $log->info(
-        q{Installing pipelines: } . join $SPACE,
-        @{ $active_parameter_href->{pipelines} }
-    );
+    $log->info( q{Installing pipelines: } . join $SPACE, @{ $active_parameter_href->{pipelines} } );
     pipeline_install(
         {
             active_parameter_href => $active_parameter_href,

--- a/lib/MIP/Program/Docker.pm
+++ b/lib/MIP/Program/Docker.pm
@@ -6,7 +6,6 @@ use charnames qw{ :full :short };
 use English qw{ -no_match_vars };
 use open qw{ :encoding(UTF-8) :std };
 use Params::Check qw{ allow check last_error };
-use strict;
 use utf8;
 use warnings;
 use warnings qw{ FATAL utf8 };

--- a/lib/MIP/Program/Dragen.pm
+++ b/lib/MIP/Program/Dragen.pm
@@ -6,7 +6,6 @@ use charnames qw{ :full :short };
 use English qw{ -no_match_vars };
 use open qw{ :encoding(UTF-8) :std };
 use Params::Check qw{ allow check last_error };
-use strict;
 use utf8;
 use warnings;
 use warnings qw{ FATAL utf8 };

--- a/lib/MIP/Program/Gnu/Findutils.pm
+++ b/lib/MIP/Program/Gnu/Findutils.pm
@@ -1,7 +1,6 @@
 package MIP::Program::Gnu::Findutils;
 
 use 5.026;
-use strict;
 use warnings;
 use warnings qw{ FATAL utf8 };
 use utf8;    #Allow unicode characters in this script

--- a/lib/MIP/Program/Gnu/Software/Gnu_grep.pm
+++ b/lib/MIP/Program/Gnu/Software/Gnu_grep.pm
@@ -6,7 +6,6 @@ use charnames qw{ :full :short };
 use English qw{ -no_match_vars };
 use open qw{ :encoding(UTF-8) :std };
 use Params::Check qw{ allow check last_error };
-use strict;
 use utf8;
 use warnings;
 use warnings qw{ FATAL utf8 };
@@ -68,7 +67,7 @@ sub gnu_grep {
         },
         filehandle       => { store => \$filehandle, },
         filter_file_path => { store => \$filter_file_path, strict_type => 1, },
-        infile_path => {
+        infile_path      => {
             store       => \$infile_path,
             strict_type => 1,
         },
@@ -78,11 +77,10 @@ sub gnu_grep {
             store       => \$invert_match,
             strict_type => 1,
         },
-        pattern         => { store => \$pattern,         strict_type => 1, },
-        stderrfile_path => { store => \$stderrfile_path, strict_type => 1, },
-        stderrfile_path_append =>
-          { store => \$stderrfile_path_append, strict_type => 1, },
-        stdoutfile_path => {
+        pattern                => { store => \$pattern,                strict_type => 1, },
+        stderrfile_path        => { store => \$stderrfile_path,        strict_type => 1, },
+        stderrfile_path_append => { store => \$stderrfile_path_append, strict_type => 1, },
+        stdoutfile_path        => {
             store       => \$stdoutfile_path,
             strict_type => 1,
         },

--- a/lib/MIP/Program/Gnu/Software/Gnu_less.pm
+++ b/lib/MIP/Program/Gnu/Software/Gnu_less.pm
@@ -1,6 +1,5 @@
 package MIP::Program::Gnu::Software::Gnu_less;
 
-use strict;
 use warnings;
 use warnings qw( FATAL utf8 );
 use utf8;    #Allow unicode characters in this script
@@ -10,7 +9,7 @@ use Carp;
 use autodie;
 use Params::Check qw[check allow last_error];
 
-use FindBin qw($Bin);                 #Find directory of script
+use FindBin qw($Bin);    #Find directory of script
 use File::Basename qw(dirname);
 use File::Spec::Functions qw(catdir);
 

--- a/lib/MIP/Program/Gnu/Software/Gnu_make.pm
+++ b/lib/MIP/Program/Gnu/Software/Gnu_make.pm
@@ -1,6 +1,5 @@
 package MIP::Program::Gnu::Software::Gnu_make;
 
-use strict;
 use warnings;
 use warnings qw{ FATAL utf8 };
 use utf8;

--- a/lib/MIP/Program/Gnu/Software/Gnu_sed.pm
+++ b/lib/MIP/Program/Gnu/Software/Gnu_sed.pm
@@ -5,7 +5,6 @@ use charnames qw{ :full :short };
 use English qw{ -no_match_vars };
 use open qw{ :encoding(UTF-8) :std };
 use Params::Check qw{ allow check last_error };
-use strict;
 use utf8;
 use warnings;
 use warnings qw{ FATAL utf8 };

--- a/lib/MIP/Program/Pip.pm
+++ b/lib/MIP/Program/Pip.pm
@@ -6,7 +6,6 @@ use charnames qw{ :full :short };
 use English qw{ -no_match_vars };
 use open qw{ :encoding(UTF-8) :std };
 use Params::Check qw{ allow check last_error };
-use strict;
 use utf8;
 use warnings;
 use warnings qw{ FATAL utf8 };

--- a/lib/MIP/Program/Rsync.pm
+++ b/lib/MIP/Program/Rsync.pm
@@ -6,7 +6,6 @@ use charnames qw{ :full :short };
 use English qw{ -no_match_vars };
 use open qw{ :encoding(UTF-8) :std };
 use Params::Check qw{ allow check last_error };
-use strict;
 use utf8;
 use warnings;
 use warnings qw{ FATAL utf8 };

--- a/lib/MIP/Program/Singularity.pm
+++ b/lib/MIP/Program/Singularity.pm
@@ -6,7 +6,6 @@ use charnames qw{ :full :short };
 use English qw{ -no_match_vars };
 use open qw{ :encoding(UTF-8) :std };
 use Params::Check qw{ allow check last_error };
-use strict;
 use utf8;
 use warnings;
 use warnings qw{ FATAL utf8 };

--- a/lib/MIP/Program/Ssh.pm
+++ b/lib/MIP/Program/Ssh.pm
@@ -6,7 +6,6 @@ use charnames qw{ :full :short };
 use English qw{ -no_match_vars };
 use open qw{ :encoding(UTF-8) :std };
 use Params::Check qw{ allow check last_error };
-use strict;
 use utf8;
 use warnings;
 use warnings qw{ FATAL utf8 };

--- a/lib/MIP/Program/Tar.pm
+++ b/lib/MIP/Program/Tar.pm
@@ -1,7 +1,6 @@
 package MIP::Program::Tar;
 
 use 5.026;
-use strict;
 use warnings;
 use warnings qw{ FATAL utf8 };
 use utf8;

--- a/lib/MIP/Program/Wget.pm
+++ b/lib/MIP/Program/Wget.pm
@@ -6,7 +6,6 @@ use charnames qw{ :full :short };
 use English qw{ -no_match_vars };
 use open qw{ :encoding(UTF-8) :std };
 use Params::Check qw{ allow check last_error };
-use strict;
 use utf8;
 use warnings;
 use warnings qw{ FATAL utf8 };
@@ -78,7 +77,7 @@ sub wget {
         },
         filehandle   => { store => \$filehandle, },
         outfile_path => { store => \$outfile_path, strict_type => 1, },
-        quiet => {
+        quiet        => {
             allow       => [ undef, 0, 1 ],
             default     => 0,
             store       => \$quiet,
@@ -95,11 +94,10 @@ sub wget {
             store       => \$retry_connrefused,
             strict_type => 1,
         },
-        stdoutfile_path => { store => \$stdoutfile_path, strict_type => 1, },
-        stderrfile_path => { store => \$stderrfile_path, strict_type => 1, },
-        stderrfile_path_append =>
-          { store => \$stderrfile_path_append, strict_type => 1, },
-        timeout => {
+        stdoutfile_path        => { store => \$stdoutfile_path,        strict_type => 1, },
+        stderrfile_path        => { store => \$stderrfile_path,        strict_type => 1, },
+        stderrfile_path_append => { store => \$stderrfile_path_append, strict_type => 1, },
+        timeout                => {
             allow       => [ undef, qr{ \A\d+\z }sxm ],
             store       => \$timeout,
             strict_type => 1,

--- a/lib/MIP/Program/Zip.pm
+++ b/lib/MIP/Program/Zip.pm
@@ -6,7 +6,6 @@ use charnames qw{ :full :short };
 use English qw{ -no_match_vars };
 use open qw{ :encoding(UTF-8) :std };
 use Params::Check qw{ allow check last_error };
-use strict;
 use utf8;
 use warnings;
 use warnings qw{ FATAL utf8 };

--- a/lib/MIP/Qc_data.pm
+++ b/lib/MIP/Qc_data.pm
@@ -7,7 +7,6 @@ use English qw{ -no_match_vars };
 use File::Spec::Functions qw{ catfile };
 use open qw{ :encoding(UTF-8) :std };
 use Params::Check qw{ allow check last_error };
-use strict;
 use utf8;
 use warnings;
 use warnings qw{ FATAL utf8 };
@@ -148,8 +147,7 @@ sub add_qc_data_recipe_info {
     if ( $sample_id and $infile ) {
 
         ## Add to array
-        push @{ $qc_data_href->{sample}{$sample_id}{$infile}{$recipe_name}{$key} },
-          $value;
+        push @{ $qc_data_href->{sample}{$sample_id}{$infile}{$recipe_name}{$key} }, $value;
         return;
     }
 
@@ -641,8 +639,7 @@ sub parse_qc_recipe_data {
 
     check( $tmpl, $arg_href, 1 ) or croak q{Could not parse arguments!};
 
-    use MIP::Qc_data
-      qw{ add_to_qc_data parse_qc_recipe_table_data set_header_metrics_to_qc_data };
+    use MIP::Qc_data qw{ add_to_qc_data parse_qc_recipe_table_data set_header_metrics_to_qc_data };
 
   REG_EXP_ATTRIBUTE:
     for my $attribute ( keys %{ $regexp_href->{$recipe} } ) {

--- a/lib/MIP/Qcc_regexp.pm
+++ b/lib/MIP/Qcc_regexp.pm
@@ -6,7 +6,6 @@ use charnames qw{ :full :short };
 use English qw{ -no_match_vars };
 use open qw{ :encoding(UTF-8) :std };
 use Params::Check qw{ allow check last_error };
-use strict;
 use utf8;
 use warnings;
 use warnings qw{ FATAL utf8 };
@@ -111,11 +110,11 @@ sub regexp_to_yaml {
 
     # Return Uniquely mapped reads %
     $regexp{star_log}{percentage_uniquely_mapped_reads} =
-q?perl -nae 'if(m/Uniquely\smapped\sreads\s%\s\|\t(\d+\.\d+) /xms) {print $1; last;}' ?;
+      q?perl -nae 'if(m/Uniquely\smapped\sreads\s%\s\|\t(\d+\.\d+) /xms) {print $1; last;}' ?;
 
     ## Return percentage of reads with adapters
     $regexp{trim_galore_stats}{percentage_reads_with_adapter} =
-q?perl -nae 'if( m/Reads\swith\sadapters[^(]+\((\d+\.\d+) /xms ){ print $1; last;}' ?;
+      q?perl -nae 'if( m/Reads\swith\sadapters[^(]+\((\d+\.\d+) /xms ){ print $1; last;}' ?;
 
     ## Return percentage of reads after trimming
     $regexp{trim_galore_stats}{percentage_reads_after_trimming} =
@@ -218,8 +217,7 @@ q?perl -nae 'my @sexCheckFactor; if ($. > 1) {my @temp = split(/\s+/,$_);push(@s
       q?perl -nae 'if($_=~/Fraction Duplicates\: (\S+)/) {print $1;}' ?;
 
     # Get BAIT_SET line from header
-    $regexp{collecthsmetrics}{header} =
-      q?perl -nae' if ($_ =~/^BAIT_SET/ ) {print $_;last;}' ?;
+    $regexp{collecthsmetrics}{header} = q?perl -nae' if ($_ =~/^BAIT_SET/ ) {print $_;last;}' ?;
 
     # Return line and only look at line 8 in file, where the data action is
     $regexp{collecthsmetrics}{data} =
@@ -238,8 +236,7 @@ q?perl -nae 'my @sexCheckFactor; if ($. > 1) {my @temp = split(/\s+/,$_);push(@s
       q?perl -nae' if ($_ =~/^SECOND_OF_PAIR/ ) {print $_;last;}' ?;
 
     # Return PAIR line
-    $regexp{collectmultiplemetrics}{pair} =
-      q?perl -nae' if ($_ =~/^PAIR/ ) {print $_;last;}'  ?;
+    $regexp{collectmultiplemetrics}{pair} = q?perl -nae' if ($_ =~/^PAIR/ ) {print $_;last;}'  ?;
 
     # Return MEDIAN_INSERT_SIZE line from header
     $regexp{collectmultiplemetricsinsertsize}{header} =
@@ -250,8 +247,7 @@ q?perl -nae 'my @sexCheckFactor; if ($. > 1) {my @temp = split(/\s+/,$_);push(@s
       q?perl -nae' if ( ($. ==8) && ($_ =~/(\S+)/) ) {print $_;last;}' ?;
 
     # Get PF_BASES line from header
-    $regexp{collectrnaseqmetrics}{header} =
-      q?perl -nae' if ($_ =~/^PF_BASES/ ) {print $_;last;}' ?;
+    $regexp{collectrnaseqmetrics}{header} = q?perl -nae' if ($_ =~/^PF_BASES/ ) {print $_;last;}' ?;
 
     # Return line and only look at line 8 in file, where the data action is
     $regexp{collectrnaseqmetrics}{data} =
@@ -263,7 +259,7 @@ q?perl -nae 'my @sexCheckFactor; if ($. > 1) {my @temp = split(/\s+/,$_);push(@s
 
     # Return CompOverlap and all and none line
     $regexp{variantevalall}{comp_overlap_data_all} =
-q?perl -nae' if ( ($_ =~/^CompOverlap/) && ($_ =~/all/) && ($_ =~/none/)) {print $_;last;}' ?;
+      q?perl -nae' if ( ($_ =~/^CompOverlap/) && ($_ =~/all/) && ($_ =~/none/)) {print $_;last;}' ?;
 
     # Return CompOverlap and known line
     $regexp{variantevalall}{comp_overlap_data_known} =
@@ -307,35 +303,35 @@ q?perl -nae' if ( ($_ =~/^CompOverlap/) && ($_ =~/all/) && ($_ =~/none/)) {print
 
     # Return MultiallelicSummary and CompFeatureInput line from header
     $regexp{variantevalall}{multiallelic_summary_data_header} =
-q?perl -nae' if ($_ =~/^MultiallelicSummary\s+CompFeatureInput/ ) {print $_;last;}' ?;
+      q?perl -nae' if ($_ =~/^MultiallelicSummary\s+CompFeatureInput/ ) {print $_;last;}' ?;
 
     # Return MultiallelicSummary and all line
     $regexp{variantevalall}{multiallelic_summary_data_all} =
-q?perl -nae' if ( ($_ =~/^MultiallelicSummary/) && ($_ =~/all\s/) ) {print $_;last;}' ?;
+      q?perl -nae' if ( ($_ =~/^MultiallelicSummary/) && ($_ =~/all\s/) ) {print $_;last;}' ?;
 
     # Return MultiallelicSummary and known line
     $regexp{variantevalall}{multiallelic_summary_data_known} =
-q?perl -nae' if ( ($_ =~/^MultiallelicSummary/) && ($_ =~/known\s/) ) {print $_;last;}' ?;
+      q?perl -nae' if ( ($_ =~/^MultiallelicSummary/) && ($_ =~/known\s/) ) {print $_;last;}' ?;
 
     # Return MultiallelicSummary and novel line
     $regexp{variantevalall}{multiallelic_summary_data_novel} =
-q?perl -nae' if ( ($_ =~/^MultiallelicSummary/) && ($_ =~/novel\s/) ) {print $_;last;}' ?;
+      q?perl -nae' if ( ($_ =~/^MultiallelicSummary/) && ($_ =~/novel\s/) ) {print $_;last;}' ?;
 
     # Return TiTvVariantEvaluator and CompFeatureInput line from header
     $regexp{variantevalall}{titv_variant_evaluator_data_header} =
-q?perl -nae' if ($_ =~/^TiTvVariantEvaluator\s+CompFeatureInput/ ) {print $_;last;}' ?;
+      q?perl -nae' if ($_ =~/^TiTvVariantEvaluator\s+CompFeatureInput/ ) {print $_;last;}' ?;
 
     # Return TiTvVariantEvaluator and all line
     $regexp{variantevalall}{titv_variant_evaluator_data_all} =
-q?perl -nae' if ( ($_ =~/^TiTvVariantEvaluator/) && ($_ =~/all\s/) ) {print $_;last;}' ?;
+      q?perl -nae' if ( ($_ =~/^TiTvVariantEvaluator/) && ($_ =~/all\s/) ) {print $_;last;}' ?;
 
     # Return TiTvVariantEvaluator and known line
     $regexp{variantevalall}{titv_variant_evaluator_data_known} =
-q?perl -nae' if ( ($_ =~/^TiTvVariantEvaluator/) && ($_ =~/known\s/) ) {print $_;last;}' ?;
+      q?perl -nae' if ( ($_ =~/^TiTvVariantEvaluator/) && ($_ =~/known\s/) ) {print $_;last;}' ?;
 
     # Return TiTvVariantEvaluator and novel line
     $regexp{variantevalall}{titv_variant_evaluator_data_novel} =
-q?perl -nae' if ( ($_ =~/^TiTvVariantEvaluator/) && ($_ =~/novel\s/) ) {print $_;last;}' ?;
+      q?perl -nae' if ( ($_ =~/^TiTvVariantEvaluator/) && ($_ =~/novel\s/) ) {print $_;last;}' ?;
 
     # Return ValidationReport and CompFeatureInput line from header
     $regexp{variantevalall}{validation_report_header} =
@@ -347,11 +343,11 @@ q?perl -nae' if ( ($_ =~/^ValidationReport/) && ($_ =~/all\s/) && ($_ =~/none\s/
 
     # Return ValidationReport and known line
     $regexp{variantevalall}{validation_report_data_known} =
-q?perl -nae' if ( ($_ =~/^ValidationReport/) && ($_ =~/known\s/) ) {print $_;last;}' ?;
+      q?perl -nae' if ( ($_ =~/^ValidationReport/) && ($_ =~/known\s/) ) {print $_;last;}' ?;
 
     # Return ValidationReport and novel line
     $regexp{variantevalall}{validation_report_data_novel} =
-q?perl -nae' if ( ($_ =~/^ValidationReport/) && ($_ =~/novel\s/) ) {print $_;last;}' ?;
+      q?perl -nae' if ( ($_ =~/^ValidationReport/) && ($_ =~/novel\s/) ) {print $_;last;}' ?;
 
     # Return VariantSummary and CompFeatureInput line from header
     $regexp{variantevalall}{variant_summary_header} =
@@ -363,11 +359,11 @@ q?perl -nae' if ( ($_ =~/^ValidationReport/) && ($_ =~/novel\s/) ) {print $_;las
 
     # Return VariantSummary and known line
     $regexp{variantevalall}{variant_summary_data_known} =
-q?perl -nae' if ( ($_ =~/^VariantSummary/) && ($_ =~/known\s/) ) {print $_;last;}' ?;
+      q?perl -nae' if ( ($_ =~/^VariantSummary/) && ($_ =~/known\s/) ) {print $_;last;}' ?;
 
     # Return VariantSummary and novel line
     $regexp{variantevalall}{variant_summary_data_novel} =
-q?perl -nae' if ( ($_ =~/^VariantSummary/) && ($_ =~/novel\s/) ) {print $_;last;}' ?;
+      q?perl -nae' if ( ($_ =~/^VariantSummary/) && ($_ =~/novel\s/) ) {print $_;last;}' ?;
 
     $regexp{variantevalexome} = $regexp{variantevalall};
 

--- a/lib/MIP/Qccollect.pm
+++ b/lib/MIP/Qccollect.pm
@@ -7,7 +7,6 @@ use English qw{ -no_match_vars };
 use List::Util qw{ any };
 use open qw{ :encoding(UTF-8) :std };
 use Params::Check qw{ allow check last_error };
-use strict;
 use utf8;
 use warnings;
 use warnings qw{ FATAL utf8 };
@@ -66,7 +65,7 @@ sub check_qc_metric {
     my $reference_metric_href;
 
     my $tmpl = {
-        metric => { defined => 1, required => 1, store => \$metric, strict_type => 1, },
+        metric       => { defined => 1, required => 1, store => \$metric, strict_type => 1, },
         qc_data_href => {
             default     => {},
             defined     => 1,
@@ -370,9 +369,7 @@ sub plink_relation_check {
 
     ## Set FAIL status
     my $status =
-        q{Status:}
-      . $recipe_name . q{:}
-      . $qc_data_href->{sample}{$sample_id}{$recipe_name};
+      q{Status:} . $recipe_name . q{:} . $qc_data_href->{sample}{$sample_id}{$recipe_name};
 
     ## Add to QC data at case level
     add_qc_data_evaluation_info(
@@ -647,8 +644,7 @@ sub get_case_pairwise_comparison {
     foreach my $relationship (@relationship_values) {
 
         ## Splices array into each sample_ids line
-        my @pairwise_comparisons = splice @relationship_values, 0,
-          scalar @{$sample_orders_ref};
+        my @pairwise_comparisons = splice @relationship_values, 0, scalar @{$sample_orders_ref};
 
         ## All columns in .mibs file
       COLUMN:
@@ -869,10 +865,10 @@ sub parse_sample_qc_metric {
 
             check_qc_metric(
                 {
-                    metric          => $metric,
-                    qc_data_href    => $qc_data_href,
-                    qc_metric_value => $qc_data_recipe_href->{$metric},
-                    recipe          => $recipe_name,
+                    metric                => $metric,
+                    qc_data_href          => $qc_data_href,
+                    qc_metric_value       => $qc_data_recipe_href->{$metric},
+                    recipe                => $recipe_name,
                     reference_metric_href =>
                       $evaluate_metric_href->{$sample_id}{$recipe_name}{$metric},
                 }
@@ -892,11 +888,10 @@ sub parse_sample_qc_metric {
 
             check_qc_metric(
                 {
-                    metric       => $metric,
-                    qc_data_href => $qc_data_href,
-                    qc_metric_value =>
-                      $qc_data_recipe_href->{header}{$data_header}{$metric},
-                    recipe => $recipe_name,
+                    metric                => $metric,
+                    qc_data_href          => $qc_data_href,
+                    qc_metric_value       => $qc_data_recipe_href->{header}{$data_header}{$metric},
+                    recipe                => $recipe_name,
                     reference_metric_href =>
                       $evaluate_metric_href->{$sample_id}{$recipe_name}{$metric},
                 }

--- a/lib/MIP/Recipes/Analysis/Split_fastq_file.pm
+++ b/lib/MIP/Recipes/Analysis/Split_fastq_file.pm
@@ -7,7 +7,6 @@ use File::Basename qw{fileparse};
 use File::Spec::Functions qw{ catdir catfile };
 use open qw{ :encoding(UTF-8) :std };
 use Params::Check qw{ allow check last_error };
-use strict;
 use utf8;
 use warnings;
 use warnings qw{ FATAL utf8 };
@@ -17,8 +16,7 @@ use autodie qw{:all};
 use Readonly;
 
 ## MIPs lib/
-use MIP::Constants
-  qw{ $ASTERISK $DOT $EMPTY_STR $LOG_NAME $NEWLINE $PIPE $SPACE $TAB $UNDERSCORE };
+use MIP::Constants qw{ $ASTERISK $DOT $EMPTY_STR $LOG_NAME $NEWLINE $PIPE $SPACE $TAB $UNDERSCORE };
 
 BEGIN {
 
@@ -246,9 +244,9 @@ sub analysis_split_fastq_file {
 
         gnu_split(
             {
-                filehandle  => $filehandle,
-                infile_path => q{-},
-                lines       => ( $sequence_read_batch * $FASTQC_SEQUENCE_LINE_BLOCK ),
+                filehandle       => $filehandle,
+                infile_path      => q{-},
+                lines            => ( $sequence_read_batch * $FASTQC_SEQUENCE_LINE_BLOCK ),
                 numeric_suffixes => 1,
                 prefix           => $temp_infile_path_prefixes[$infile_index]
                   . $UNDERSCORE
@@ -281,10 +279,7 @@ sub analysis_split_fastq_file {
         pigz(
             {
                 filehandle  => $filehandle,
-                infile_path => $splitted_flowcell_name_prefix
-                  . q{*-SP*}
-                  . $DOT
-                  . $splitted_suffix,
+                infile_path => $splitted_flowcell_name_prefix . q{*-SP*} . $DOT . $splitted_suffix,
             }
         );
         say {$filehandle} $NEWLINE;
@@ -292,8 +287,8 @@ sub analysis_split_fastq_file {
         ## Copies files from temporary folder to source
         gnu_cp(
             {
-                filehandle  => $filehandle,
-                infile_path => $splitted_flowcell_name_prefix . q{*-SP*} . $infile_suffix,
+                filehandle   => $filehandle,
+                infile_path  => $splitted_flowcell_name_prefix . q{*-SP*} . $infile_suffix,
                 outfile_path => $indir_path_prefix,
             }
         );
@@ -301,24 +296,21 @@ sub analysis_split_fastq_file {
 
         gnu_mkdir(
             {
-                filehandle => $filehandle,
-                indirectory_path =>
-                  catfile( $indir_path_prefix, q{original_fastq_files}, ),
-                parents => 1,
+                filehandle       => $filehandle,
+                indirectory_path => catfile( $indir_path_prefix, q{original_fastq_files}, ),
+                parents          => 1,
             }
         );
         say {$filehandle} $NEWLINE;
 
         ## Move original file to not be included in subsequent analysis
-        say {$filehandle}
-          q{## Move original file to not be included in subsequent analysis};
+        say {$filehandle} q{## Move original file to not be included in subsequent analysis};
         gnu_mv(
             {
                 filehandle   => $filehandle,
                 infile_path  => $infile_path,
                 outfile_path => catfile(
-                    $indir_path_prefix, q{original_fastq_files},
-                    $infile_names[$infile_index]
+                    $indir_path_prefix, q{original_fastq_files}, $infile_names[$infile_index]
                 ),
             }
         );
@@ -328,14 +320,13 @@ sub analysis_split_fastq_file {
 
             submit_recipe(
                 {
-                    base_command      => $profile_base_command,
-                    case_id           => $case_id,
-                    dependency_method => q{sample_to_island},
-                    job_id_chain      => $job_id_chain,
-                    job_id_href       => $job_id_href,
-                    job_reservation_name =>
-                      $active_parameter_href->{job_reservation_name},
-                    log => $log,
+                    base_command         => $profile_base_command,
+                    case_id              => $case_id,
+                    dependency_method    => q{sample_to_island},
+                    job_id_chain         => $job_id_chain,
+                    job_id_href          => $job_id_href,
+                    job_reservation_name => $active_parameter_href->{job_reservation_name},
+                    log                  => $log,
                     max_parallel_processes_count_href =>
                       $file_info_href->{max_parallel_processes_count},
                     recipe_file_path   => $recipe_file_path,

--- a/lib/MIP/Recipes/Build/Bwa_prerequisites.pm
+++ b/lib/MIP/Recipes/Build/Bwa_prerequisites.pm
@@ -7,7 +7,6 @@ use English qw{ -no_match_vars };
 use File::Spec::Functions qw{ catdir catfile };
 use open qw{ :encoding(UTF-8) :std };
 use Params::Check qw{ allow check last_error };
-use strict;
 use utf8;
 use warnings;
 use warnings qw{ FATAL utf8 };
@@ -146,8 +145,7 @@ sub build_bwa_prerequisites {
     use MIP::Language::Shell qw{ check_exist_and_move_file };
     use MIP::Processmanagement::Processes qw{ submit_recipe };
     use MIP::Program::Bwa qw{ bwa_index };
-    use MIP::Recipes::Build::Human_genome_prerequisites
-      qw{ build_human_genome_prerequisites };
+    use MIP::Recipes::Build::Human_genome_prerequisites qw{ build_human_genome_prerequisites };
     use MIP::Script::Setup_script qw{ setup_script };
 
     ## Constants
@@ -187,11 +185,11 @@ sub build_bwa_prerequisites {
 
     build_human_genome_prerequisites(
         {
-            active_parameter_href => $active_parameter_href,
-            filehandle            => $filehandle,
-            file_info_href        => $file_info_href,
-            job_id_href           => $job_id_href,
-            log                   => $log,
+            active_parameter_href        => $active_parameter_href,
+            filehandle                   => $filehandle,
+            file_info_href               => $file_info_href,
+            job_id_href                  => $job_id_href,
+            log                          => $log,
             parameter_build_suffixes_ref =>
               \@{ $file_info_href->{human_genome_reference_file_endings} },
             parameter_href   => $parameter_href,
@@ -381,8 +379,7 @@ sub build_bwa_mem2_prerequisites {
     use MIP::Language::Shell qw{ check_exist_and_move_file };
     use MIP::Processmanagement::Processes qw{ submit_recipe };
     use MIP::Program::Bwa qw{ bwa_mem2_index };
-    use MIP::Recipes::Build::Human_genome_prerequisites
-      qw{ build_human_genome_prerequisites };
+    use MIP::Recipes::Build::Human_genome_prerequisites qw{ build_human_genome_prerequisites };
     use MIP::Script::Setup_script qw{ setup_script };
 
     ## Constants
@@ -424,11 +421,11 @@ sub build_bwa_mem2_prerequisites {
 
     build_human_genome_prerequisites(
         {
-            active_parameter_href => $active_parameter_href,
-            filehandle            => $filehandle,
-            file_info_href        => $file_info_href,
-            job_id_href           => $job_id_href,
-            log                   => $log,
+            active_parameter_href        => $active_parameter_href,
+            filehandle                   => $filehandle,
+            file_info_href               => $file_info_href,
+            job_id_href                  => $job_id_href,
+            log                          => $log,
             parameter_build_suffixes_ref =>
               \@{ $file_info_href->{human_genome_reference_file_endings} },
             parameter_href   => $parameter_href,

--- a/lib/MIP/Recipes/Build/Capture_file_prerequisites.pm
+++ b/lib/MIP/Recipes/Build/Capture_file_prerequisites.pm
@@ -7,7 +7,6 @@ use English qw{ -no_match_vars };
 use File::Spec::Functions qw{ catdir catfile };
 use open qw{ :encoding(UTF-8) :std };
 use Params::Check qw{ allow check last_error };
-use strict;
 use warnings;
 use warnings qw{ FATAL utf8 };
 
@@ -186,9 +185,7 @@ sub build_capture_file_prerequisites {
     my $random_integer = int rand $MAX_RANDOM_NUMBER;
 
   BED_FILE:
-    foreach
-      my $exome_target_bed_file ( keys %{ $active_parameter_href->{exome_target_bed} } )
-    {
+    foreach my $exome_target_bed_file ( keys %{ $active_parameter_href->{exome_target_bed} } ) {
 
         $log->warn( q{Will try to create required }
               . $exome_target_bed_file
@@ -196,16 +193,14 @@ sub build_capture_file_prerequisites {
               . $recipe_name );
 
         ## Add random integer
-        my $exome_target_bed_file_random =
-          $exome_target_bed_file . $UNDERSCORE . $random_integer;
+        my $exome_target_bed_file_random = $exome_target_bed_file . $UNDERSCORE . $random_integer;
 
         say {$filehandle} q{## CreateSequenceDictionary from reference};
 
         picardtools_createsequencedictionary(
             {
                 filehandle => $filehandle,
-                java_jar =>
-                  catfile( $active_parameter_href->{picardtools_path}, q{picard.jar} ),
+                java_jar   => catfile( $active_parameter_href->{picardtools_path}, q{picard.jar} ),
                 java_use_large_pages => $active_parameter_href->{java_use_large_pages},
                 memory_allocation    => q{Xmx2g},
                 outfile_path         => $exome_target_bed_file_random . $DOT . q{dict},
@@ -219,10 +214,8 @@ sub build_capture_file_prerequisites {
         gnu_cat(
             {
                 filehandle       => $filehandle,
-                infile_paths_ref => [
-                    $exome_target_bed_file_random . $DOT . q{dict},
-                    $exome_target_bed_file
-                ],
+                infile_paths_ref =>
+                  [ $exome_target_bed_file_random . $DOT . q{dict}, $exome_target_bed_file ],
                 stdoutfile_path => $exome_target_bed_file_random . $DOT . q{dict_body},
             }
         );
@@ -250,8 +243,7 @@ sub build_capture_file_prerequisites {
             {
                 filehandle       => $filehandle,
                 infile_paths_ref => \@infile_paths_ref,
-                java_jar =>
-                  catfile( $active_parameter_href->{picardtools_path}, q{picard.jar} ),
+                java_jar => catfile( $active_parameter_href->{picardtools_path}, q{picard.jar} ),
                 java_use_large_pages => $active_parameter_href->{java_use_large_pages},
                 memory_allocation    => q{Xmx2g},
                 outfile_path         => $interval_list_outfile_path,
@@ -281,16 +273,12 @@ sub build_capture_file_prerequisites {
         say {$filehandle} q{#Create} . $padded_interval_list_suffix;
 
         my $padded_interval_list_outfile_path =
-            $exome_target_bed_file_random
-          . $DOT
-          . q{dict_body_col_5}
-          . $padded_interval_list_suffix;
+          $exome_target_bed_file_random . $DOT . q{dict_body_col_5} . $padded_interval_list_suffix;
         picardtools_intervallisttools(
             {
                 filehandle       => $filehandle,
                 infile_paths_ref => \@infile_paths_ref,
-                java_jar =>
-                  catfile( $active_parameter_href->{picardtools_path}, q{picard.jar} ),
+                java_jar => catfile( $active_parameter_href->{picardtools_path}, q{picard.jar} ),
                 java_use_large_pages => $active_parameter_href->{java_use_large_pages},
                 memory_allocation    => q{Xmx2g},
                 outfile_path         => $padded_interval_list_outfile_path,
@@ -303,10 +291,7 @@ sub build_capture_file_prerequisites {
 
         $intended_file_path = $exome_target_bed_file . $padded_interval_list_suffix;
         $temporary_file_path =
-            $exome_target_bed_file_random
-          . $DOT
-          . q{dict_body_col_5}
-          . $padded_interval_list_suffix;
+          $exome_target_bed_file_random . $DOT . q{dict_body_col_5} . $padded_interval_list_suffix;
 
         ## Checks if a file exists and moves the file in place if file is lacking or has a size of 0 bytes.
         check_exist_and_move_file(
@@ -393,8 +378,7 @@ sub _reformat_capture_file {
     check( $tmpl, $arg_href, 1 ) or croak q{Could not parse arguments!};
 
     ## Remove unnecessary info and reformat
-    say {$filehandle}
-      q{#Remove target annotations, 'track', 'browse' and keep only 5 columns};
+    say {$filehandle} q{#Remove target annotations, 'track', 'browse' and keep only 5 columns};
 
     ## Execute perl
     print {$filehandle} q?perl -nae '?;
@@ -413,15 +397,15 @@ sub _reformat_capture_file {
 
     ## Else print reformated line to stdout
     print {$filehandle}
-q?else {print @F[0], "\t", (@F[1] + 1), "\t", @F[2], "\t", "+", "\t", "-", "\n";}' ?;
+      q?else {print @F[0], "\t", (@F[1] + 1), "\t", @F[2], "\t", "+", "\t", "-", "\n";}' ?;
 
     ## Infile
     print {$filehandle} $exome_target_bed_file_random . $DOT . q{dict_body} . $SPACE;
 
     ## Write to
     print {$filehandle} q{>} . $SPACE;
-    say   {$filehandle} $exome_target_bed_file_random . $DOT
-      . q{dict_body_col_5.interval_list}, $NEWLINE;
+    say {$filehandle} $exome_target_bed_file_random . $DOT . q{dict_body_col_5.interval_list},
+      $NEWLINE;
 
     return;
 }

--- a/lib/MIP/Recipes/Build/Dragen_rd_dna.pm
+++ b/lib/MIP/Recipes/Build/Dragen_rd_dna.pm
@@ -6,7 +6,6 @@ use charnames qw{ :full :short };
 use English qw{ -no_match_vars };
 use open qw{ :encoding(UTF-8) :std };
 use Params::Check qw{ allow check last_error };
-use strict;
 use utf8;
 use warnings;
 use warnings qw{ FATAL utf8 };
@@ -89,8 +88,7 @@ sub build_dragen_rd_dna_meta_files {
 
     check( $tmpl, $arg_href, 1 ) or croak q{Could not parse arguments!};
 
-    use MIP::Recipes::Build::Human_genome_prerequisites
-      qw{ build_human_genome_prerequisites };
+    use MIP::Recipes::Build::Human_genome_prerequisites qw{ build_human_genome_prerequisites };
 
     my %build_recipe =
       ( human_genome_reference_file_endings => \&build_human_genome_prerequisites, );
@@ -99,9 +97,7 @@ sub build_dragen_rd_dna_meta_files {
     foreach my $parameter_build_name ( keys %build_recipe ) {
 
       RECIPE:
-        foreach
-          my $recipe ( @{ $parameter_href->{$parameter_build_name}{associated_recipe} } )
-        {
+        foreach my $recipe ( @{ $parameter_href->{$parameter_build_name}{associated_recipe} } ) {
 
             next RECIPE if ( not $active_parameter_href->{$recipe} );
 
@@ -110,15 +106,14 @@ sub build_dragen_rd_dna_meta_files {
 
             $build_recipe{$parameter_build_name}->(
                 {
-                    active_parameter_href => $active_parameter_href,
-                    file_info_href        => $file_info_href,
-                    job_id_href           => $job_id_href,
-                    log                   => $log,
-                    parameter_build_suffixes_ref =>
-                      \@{ $file_info_href->{$parameter_build_name} },
-                    parameter_href   => $parameter_href,
-                    recipe_name      => $recipe,
-                    sample_info_href => $sample_info_href,
+                    active_parameter_href        => $active_parameter_href,
+                    file_info_href               => $file_info_href,
+                    job_id_href                  => $job_id_href,
+                    log                          => $log,
+                    parameter_build_suffixes_ref => \@{ $file_info_href->{$parameter_build_name} },
+                    parameter_href               => $parameter_href,
+                    recipe_name                  => $recipe,
+                    sample_info_href             => $sample_info_href,
                 }
             );
 

--- a/lib/MIP/Recipes/Build/Human_genome_prerequisites.pm
+++ b/lib/MIP/Recipes/Build/Human_genome_prerequisites.pm
@@ -7,7 +7,6 @@ use English qw{ -no_match_vars };
 use File::Spec::Functions qw{ catdir catfile };
 use open qw{ :encoding(UTF-8) :std };
 use Params::Check qw{ check allow last_error };
-use strict;
 use utf8;
 use warnings;
 use warnings qw{ FATAL utf8 };
@@ -152,8 +151,7 @@ sub build_human_genome_prerequisites {
     use MIP::Program::Samtools qw{ samtools_faidx };
     use MIP::Program::Picardtools qw{ picardtools_createsequencedictionary };
     use MIP::Processmanagement::Processes qw{ submit_recipe };
-    use MIP::Recipes::Build::Capture_file_prerequisites
-      qw{ build_capture_file_prerequisites };
+    use MIP::Recipes::Build::Capture_file_prerequisites qw{ build_capture_file_prerequisites };
     use MIP::Script::Setup_script qw{ setup_script };
 
     ## Constants
@@ -254,22 +252,19 @@ sub build_human_genome_prerequisites {
                       . q{ before executing }
                       . $recipe_name );
 
-                my $filename_prefix = catfile( $reference_dir,
-                    $file_info_href->{human_genome_reference_name_prefix} );
+                my $filename_prefix =
+                  catfile( $reference_dir, $file_info_href->{human_genome_reference_name_prefix} );
 
                 say {$filehandle} q{#CreateSequenceDictionary from reference};
 
                 picardtools_createsequencedictionary(
                     {
                         filehandle => $filehandle,
-                        java_jar   => catfile(
-                            $active_parameter_href->{picardtools_path},
-                            q{picard.jar}
-                        ),
-                        java_use_large_pages =>
-                          $active_parameter_href->{java_use_large_pages},
-                        memory_allocation => q{Xmx2g},
-                        outfile_path      => $filename_prefix
+                        java_jar   =>
+                          catfile( $active_parameter_href->{picardtools_path}, q{picard.jar} ),
+                        java_use_large_pages => $active_parameter_href->{java_use_large_pages},
+                        memory_allocation    => q{Xmx2g},
+                        outfile_path         => $filename_prefix
                           . $UNDERSCORE
                           . $random_integer
                           . $file_ending,
@@ -324,9 +319,8 @@ sub build_human_genome_prerequisites {
                 );
                 say {$filehandle} $NEWLINE;
 
-                my $intended_file_path = $human_genome_reference . $file_ending;
-                my $temporary_file_path =
-                  $human_genome_reference_temp_file . $file_ending;
+                my $intended_file_path  = $human_genome_reference . $file_ending;
+                my $temporary_file_path = $human_genome_reference_temp_file . $file_ending;
 
                 ## Checks if a file exists and moves the file in place if file is lacking or has a size of 0 bytes.
                 check_exist_and_move_file(

--- a/lib/MIP/Recipes/Build/Rd_dna.pm
+++ b/lib/MIP/Recipes/Build/Rd_dna.pm
@@ -6,7 +6,6 @@ use charnames qw{ :full :short };
 use English qw{ -no_match_vars };
 use open qw{ :encoding(UTF-8) :std };
 use Params::Check qw{ allow check last_error };
-use strict;
 use utf8;
 use warnings;
 use warnings qw{ FATAL utf8 };
@@ -94,10 +93,8 @@ sub build_rd_dna_meta_files {
 
     use MIP::Recipes::Build::Bwa_prerequisites
       qw{ build_bwa_prerequisites build_bwa_mem2_prerequisites };
-    use MIP::Recipes::Build::Capture_file_prerequisites
-      qw{ build_capture_file_prerequisites };
-    use MIP::Recipes::Build::Human_genome_prerequisites
-      qw{ build_human_genome_prerequisites };
+    use MIP::Recipes::Build::Capture_file_prerequisites qw{ build_capture_file_prerequisites };
+    use MIP::Recipes::Build::Human_genome_prerequisites qw{ build_human_genome_prerequisites };
     use MIP::Recipes::Build::Rtg_prerequisites qw{ build_rtg_prerequisites };
 
     my %build_recipe = (
@@ -112,9 +109,7 @@ sub build_rd_dna_meta_files {
     foreach my $parameter_build_name ( keys %build_recipe ) {
 
       RECIPE:
-        foreach
-          my $recipe ( @{ $parameter_href->{$parameter_build_name}{associated_recipe} } )
-        {
+        foreach my $recipe ( @{ $parameter_href->{$parameter_build_name}{associated_recipe} } ) {
 
             next RECIPE if ( not $active_parameter_href->{$recipe} );
 
@@ -123,15 +118,14 @@ sub build_rd_dna_meta_files {
 
             $build_recipe{$parameter_build_name}->(
                 {
-                    active_parameter_href => $active_parameter_href,
-                    file_info_href        => $file_info_href,
-                    job_id_href           => $job_id_href,
-                    log                   => $log,
-                    parameter_build_suffixes_ref =>
-                      \@{ $file_info_href->{$parameter_build_name} },
-                    parameter_href   => $parameter_href,
-                    recipe_name      => $recipe,
-                    sample_info_href => $sample_info_href,
+                    active_parameter_href        => $active_parameter_href,
+                    file_info_href               => $file_info_href,
+                    job_id_href                  => $job_id_href,
+                    log                          => $log,
+                    parameter_build_suffixes_ref => \@{ $file_info_href->{$parameter_build_name} },
+                    parameter_href               => $parameter_href,
+                    recipe_name                  => $recipe,
+                    sample_info_href             => $sample_info_href,
                 }
             );
 

--- a/lib/MIP/Recipes/Build/Rd_dna_vcf_rerun.pm
+++ b/lib/MIP/Recipes/Build/Rd_dna_vcf_rerun.pm
@@ -6,7 +6,6 @@ use charnames qw{ :full :short };
 use English qw{ -no_match_vars };
 use open qw{ :encoding(UTF-8) :std };
 use Params::Check qw{ allow check last_error };
-use strict;
 use utf8;
 use warnings;
 use warnings qw{ FATAL utf8 };
@@ -94,8 +93,7 @@ sub build_rd_dna_vcf_rerun_meta_files {
 
     check( $tmpl, $arg_href, 1 ) or croak q{Could not parse arguments!};
 
-    use MIP::Recipes::Build::Human_genome_prerequisites
-      qw{ build_human_genome_prerequisites };
+    use MIP::Recipes::Build::Human_genome_prerequisites qw{ build_human_genome_prerequisites };
 
     my %build_recipe =
       ( human_genome_reference_file_endings => \&build_human_genome_prerequisites, );
@@ -104,9 +102,7 @@ sub build_rd_dna_vcf_rerun_meta_files {
     foreach my $parameter_build_name ( keys %build_recipe ) {
 
       RECIPE:
-        foreach
-          my $recipe ( @{ $parameter_href->{$parameter_build_name}{associated_recipe} } )
-        {
+        foreach my $recipe ( @{ $parameter_href->{$parameter_build_name}{associated_recipe} } ) {
 
             next RECIPE if ( not $active_parameter_href->{$recipe} );
 
@@ -115,15 +111,14 @@ sub build_rd_dna_vcf_rerun_meta_files {
 
             $build_recipe{$parameter_build_name}->(
                 {
-                    active_parameter_href => $active_parameter_href,
-                    file_info_href        => $file_info_href,
-                    job_id_href           => $job_id_href,
-                    log                   => $log,
-                    parameter_build_suffixes_ref =>
-                      \@{ $file_info_href->{$parameter_build_name} },
-                    parameter_href   => $parameter_href,
-                    recipe_name      => $recipe,
-                    sample_info_href => $sample_info_href,
+                    active_parameter_href        => $active_parameter_href,
+                    file_info_href               => $file_info_href,
+                    job_id_href                  => $job_id_href,
+                    log                          => $log,
+                    parameter_build_suffixes_ref => \@{ $file_info_href->{$parameter_build_name} },
+                    parameter_href               => $parameter_href,
+                    recipe_name                  => $recipe,
+                    sample_info_href             => $sample_info_href,
                 }
             );
 

--- a/lib/MIP/Recipes/Build/Rd_rna.pm
+++ b/lib/MIP/Recipes/Build/Rd_rna.pm
@@ -6,7 +6,6 @@ use charnames qw{ :full :short };
 use English qw{ -no_match_vars };
 use open qw{ :encoding(UTF-8) :std };
 use Params::Check qw{ allow check last_error };
-use strict;
 use utf8;
 use warnings;
 use warnings qw{ FATAL utf8 };
@@ -92,12 +91,9 @@ sub build_rd_rna_meta_files {
 
     check( $tmpl, $arg_href, 1 ) or croak q{Could not parse arguments!};
 
-    use MIP::Recipes::Build::Human_genome_prerequisites
-      qw{ build_human_genome_prerequisites };
-    use MIP::Recipes::Build::Salmon_quant_prerequisites
-      qw{ build_salmon_quant_prerequisites };
-    use MIP::Recipes::Build::Star_fusion_prerequisites
-      qw{ build_star_fusion_prerequisites };
+    use MIP::Recipes::Build::Human_genome_prerequisites qw{ build_human_genome_prerequisites };
+    use MIP::Recipes::Build::Salmon_quant_prerequisites qw{ build_salmon_quant_prerequisites };
+    use MIP::Recipes::Build::Star_fusion_prerequisites qw{ build_star_fusion_prerequisites };
     use MIP::Recipes::Build::Star_prerequisites qw{ build_star_prerequisites };
     use MIP::Recipes::Build::Transcript_annotation_prerequisites
       qw{ build_transcript_annotation_prerequisites };
@@ -116,9 +112,7 @@ sub build_rd_rna_meta_files {
     foreach my $parameter_build_name ( keys %build_recipe ) {
 
       RECIPE:
-        foreach
-          my $recipe ( @{ $parameter_href->{$parameter_build_name}{associated_recipe} } )
-        {
+        foreach my $recipe ( @{ $parameter_href->{$parameter_build_name}{associated_recipe} } ) {
 
             next RECIPE if ( not $active_parameter_href->{$recipe} );
 
@@ -127,15 +121,14 @@ sub build_rd_rna_meta_files {
 
             $build_recipe{$parameter_build_name}->(
                 {
-                    active_parameter_href => $active_parameter_href,
-                    file_info_href        => $file_info_href,
-                    job_id_href           => $job_id_href,
-                    log                   => $log,
-                    parameter_build_suffixes_ref =>
-                      \@{ $file_info_href->{$parameter_build_name} },
-                    parameter_href   => $parameter_href,
-                    recipe_name      => $recipe,
-                    sample_info_href => $sample_info_href,
+                    active_parameter_href        => $active_parameter_href,
+                    file_info_href               => $file_info_href,
+                    job_id_href                  => $job_id_href,
+                    log                          => $log,
+                    parameter_build_suffixes_ref => \@{ $file_info_href->{$parameter_build_name} },
+                    parameter_href               => $parameter_href,
+                    recipe_name                  => $recipe,
+                    sample_info_href             => $sample_info_href,
                 }
             );
 

--- a/lib/MIP/Recipes/Build/Rtg_prerequisites.pm
+++ b/lib/MIP/Recipes/Build/Rtg_prerequisites.pm
@@ -7,7 +7,6 @@ use English qw{ -no_match_vars };
 use File::Spec::Functions qw{ catdir catfile };
 use open qw{ :encoding(UTF-8) :std };
 use Params::Check qw{ check allow last_error };
-use strict;
 use utf8;
 use warnings;
 use warnings qw{ FATAL utf8 };
@@ -146,8 +145,7 @@ sub build_rtg_prerequisites {
     use MIP::Language::Shell qw{ check_exist_and_move_file };
     use MIP::Processmanagement::Processes qw{ submit_recipe };
     use MIP::Program::Rtg qw{ rtg_format };
-    use MIP::Recipes::Build::Human_genome_prerequisites
-      qw{ build_human_genome_prerequisites };
+    use MIP::Recipes::Build::Human_genome_prerequisites qw{ build_human_genome_prerequisites };
     use MIP::Script::Setup_script qw{ setup_script };
 
     ## Constants
@@ -174,25 +172,25 @@ sub build_rtg_prerequisites {
     ## Creates recipe directories (info & data & script), recipe script filenames and writes sbatch header
     my ($recipe_file_path) = setup_script(
         {
-            active_parameter_href => $active_parameter_href,
-            core_number           => $active_parameter_href->{max_cores_per_node},
-            filehandle            => $filehandle,
-            directory_id          => $case_id,
-            job_id_href           => $job_id_href,
-            process_time          => $PROCESSING_TIME,
-            recipe_directory      => $recipe_name,
-            recipe_name           => $recipe_name,
+            active_parameter_href           => $active_parameter_href,
+            core_number                     => $active_parameter_href->{max_cores_per_node},
+            filehandle                      => $filehandle,
+            directory_id                    => $case_id,
+            job_id_href                     => $job_id_href,
+            process_time                    => $PROCESSING_TIME,
+            recipe_directory                => $recipe_name,
+            recipe_name                     => $recipe_name,
             source_environment_commands_ref => $recipe_resource{load_env_ref},
         }
     );
 
     build_human_genome_prerequisites(
         {
-            active_parameter_href => $active_parameter_href,
-            filehandle            => $filehandle,
-            file_info_href        => $file_info_href,
-            job_id_href           => $job_id_href,
-            log                   => $log,
+            active_parameter_href        => $active_parameter_href,
+            filehandle                   => $filehandle,
+            file_info_href               => $file_info_href,
+            job_id_href                  => $job_id_href,
+            log                          => $log,
             parameter_build_suffixes_ref =>
               \@{ $file_info_href->{human_genome_reference_file_endings} },
             parameter_href   => $parameter_href,
@@ -212,9 +210,7 @@ sub build_rtg_prerequisites {
         say {$filehandle} q{## Building SDF dir files};
         ## Get parameters
         my $sdf_directory_tmp =
-            $active_parameter_href->{rtg_vcfeval_reference_genome}
-          . $UNDERSCORE
-          . $random_integer;
+          $active_parameter_href->{rtg_vcfeval_reference_genome} . $UNDERSCORE . $random_integer;
         rtg_format(
             {
                 filehandle            => $filehandle,

--- a/lib/MIP/Recipes/Build/Salmon_quant_prerequisites.pm
+++ b/lib/MIP/Recipes/Build/Salmon_quant_prerequisites.pm
@@ -7,7 +7,6 @@ use English qw{ -no_match_vars };
 use File::Spec::Functions qw{ catdir catfile };
 use open qw{ :encoding(UTF-8) :std };
 use Params::Check qw{ check allow last_error };
-use strict;
 use utf8;
 use warnings;
 use warnings qw{ FATAL utf8 };
@@ -198,9 +197,7 @@ sub build_salmon_quant_prerequisites {
     say {$filehandle} q{## Building Salmon dir files};
     ## Get parameters
     my $salmon_quant_directory_tmp =
-        $active_parameter_href->{salmon_quant_reference_genome}
-      . $UNDERSCORE
-      . $random_integer;
+      $active_parameter_href->{salmon_quant_reference_genome} . $UNDERSCORE . $random_integer;
 
     # Create temp dir
     gnu_mkdir(
@@ -237,8 +234,7 @@ sub build_salmon_quant_prerequisites {
   PREREQ:
     foreach my $suffix ( @{$parameter_build_suffixes_ref} ) {
 
-        my $intended_file_path =
-          $active_parameter_href->{salmon_quant_reference_genome} . $suffix;
+        my $intended_file_path = $active_parameter_href->{salmon_quant_reference_genome} . $suffix;
 
         ## Checks if a file exists and moves the file in place if file is lacking or has a size of 0 bytes.
         check_exist_and_move_file(

--- a/lib/MIP/Recipes/Build/Star_fusion_prerequisites.pm
+++ b/lib/MIP/Recipes/Build/Star_fusion_prerequisites.pm
@@ -7,7 +7,6 @@ use English qw{ -no_match_vars };
 use File::Spec::Functions qw{ catdir catfile };
 use open qw{ :encoding(UTF-8) :std };
 use Params::Check qw{ check allow last_error };
-use strict;
 use utf8;
 use warnings;
 use warnings qw{ FATAL utf8 };
@@ -195,9 +194,8 @@ sub build_star_fusion_prerequisites {
     say {$filehandle} q{## Building Star-Fusion dir files};
     ## Get parameters
     my $star_fusion_directory_tmp =
-      catdir( $active_parameter_href->{star_fusion_reference_genome}
-          . $UNDERSCORE
-          . $random_integer );
+      catdir(
+        $active_parameter_href->{star_fusion_reference_genome} . $UNDERSCORE . $random_integer );
 
     # Create temp dir
     gnu_mkdir(
@@ -229,8 +227,7 @@ sub build_star_fusion_prerequisites {
   PREREQ:
     foreach my $suffix ( @{$parameter_build_suffixes_ref} ) {
 
-        my $intended_file_path =
-          $active_parameter_href->{star_fusion_reference_genome} . $suffix;
+        my $intended_file_path = $active_parameter_href->{star_fusion_reference_genome} . $suffix;
 
         ## Checks if a file exists and moves the file in place if file is lacking or has a size of 0 bytes.
         check_exist_and_move_file(

--- a/lib/MIP/Recipes/Build/Star_prerequisites.pm
+++ b/lib/MIP/Recipes/Build/Star_prerequisites.pm
@@ -7,7 +7,6 @@ use English qw{ -no_match_vars };
 use File::Spec::Functions qw{ catdir catfile };
 use open qw{ :encoding(UTF-8) :std };
 use Params::Check qw{ check allow last_error };
-use strict;
 use utf8;
 use warnings;
 use warnings qw{ FATAL utf8 };
@@ -225,8 +224,7 @@ sub build_star_prerequisites {
   PREREQ:
     foreach my $suffix ( @{$parameter_build_suffixes_ref} ) {
 
-        my $intended_file_path =
-          $active_parameter_href->{star_aln_reference_genome} . $suffix;
+        my $intended_file_path = $active_parameter_href->{star_aln_reference_genome} . $suffix;
 
         ## Checks if a file exists and moves the file in place if file is lacking or has a size of 0 bytes.
         check_exist_and_move_file(

--- a/lib/MIP/Recipes/Build/Transcript_annotation_prerequisites.pm
+++ b/lib/MIP/Recipes/Build/Transcript_annotation_prerequisites.pm
@@ -7,7 +7,6 @@ use English qw{ -no_match_vars };
 use File::Spec::Functions qw{ catdir catfile };
 use open qw{ :encoding(UTF-8) :std };
 use Params::Check qw{ allow check last_error };
-use strict;
 use warnings;
 use warnings qw{ FATAL utf8 };
 
@@ -155,10 +154,9 @@ sub build_transcript_annotation_prerequisites {
     );
 
     ## Generate a random integer.
-    my $random_integer       = int rand $MAX_RANDOM_NUMBER;
-    my $annotation_file_path = $active_parameter_href->{transcript_annotation};
-    my $annotation_file_path_random =
-      $annotation_file_path . $UNDERSCORE . $random_integer;
+    my $random_integer              = int rand $MAX_RANDOM_NUMBER;
+    my $annotation_file_path        = $active_parameter_href->{transcript_annotation};
+    my $annotation_file_path_random = $annotation_file_path . $UNDERSCORE . $random_integer;
 
     ## No supplied filehandle i.e. create new sbatch script
     if ( not defined $filehandle ) {
@@ -416,8 +414,7 @@ sub _build_rrna_interval_list {
     picardtools_createsequencedictionary(
         {
             filehandle => $filehandle,
-            java_jar =>
-              catfile( $active_parameter_href->{picardtools_path}, q{picard.jar} ),
+            java_jar   => catfile( $active_parameter_href->{picardtools_path}, q{picard.jar} ),
             java_use_large_pages => $active_parameter_href->{java_use_large_pages},
             memory_allocation    => q{Xmx2g},
             outfile_path         => $temp_dict_file_path,
@@ -432,8 +429,7 @@ sub _build_rrna_interval_list {
         {
             filehandle  => $filehandle,
             infile_path => $temp_rrna_bed_file_path,
-            java_jar =>
-              catfile( $active_parameter_href->{picardtools_path}, q{picard.jar} ),
+            java_jar    => catfile( $active_parameter_href->{picardtools_path}, q{picard.jar} ),
             java_use_large_pages => $active_parameter_href->{java_use_large_pages},
             memory_allocation    => q{Xmx2g},
             outfile_path         => $temp_file_path,

--- a/lib/MIP/Recipes/Check.pm
+++ b/lib/MIP/Recipes/Check.pm
@@ -6,7 +6,6 @@ use charnames qw{ :full :short };
 use English qw{ -no_match_vars };
 use open qw{ :encoding(UTF-8) :std };
 use Params::Check qw{ allow check last_error };
-use strict;
 use utf8;
 use warnings;
 use warnings qw{ FATAL utf8 };
@@ -43,12 +42,12 @@ sub check_recipe_exists_in_hash {
 
     my $tmpl = {
         parameter_name => { defined => 1, required => 1, store => \$parameter_name, },
-        query_ref => {
+        query_ref      => {
             defined  => 1,
             required => 1,
             store    => \$query_ref,
         },
-        truth_href     => {
+        truth_href => {
             default     => {},
             defined     => 1,
             required    => 1,
@@ -71,8 +70,7 @@ sub check_recipe_exists_in_hash {
 
             next RECIPE_NAME if ( exists $truth_href->{$recipe_name} );
 
-            $log->fatal(
-                $parameter_name . qq{ key $SINGLE_QUOTE} . $recipe_name . $error_msg );
+            $log->fatal( $parameter_name . qq{ key $SINGLE_QUOTE} . $recipe_name . $error_msg );
             exit 1;
         }
     }
@@ -83,10 +81,7 @@ sub check_recipe_exists_in_hash {
 
             next RECIPE_NAME if ( exists $truth_href->{$recipe_name} );
 
-            $log->fatal( $parameter_name
-                  . qq{ element $SINGLE_QUOTE}
-                  . $recipe_name
-                  . $error_msg );
+            $log->fatal( $parameter_name . qq{ element $SINGLE_QUOTE} . $recipe_name . $error_msg );
             exit 1;
         }
     }
@@ -94,8 +89,7 @@ sub check_recipe_exists_in_hash {
 
         return if ( exists $truth_href->{$parameter_name} );
 
-        $log->fatal(
-            $parameter_name . qq{ element $SINGLE_QUOTE} . $parameter_name . $error_msg );
+        $log->fatal( $parameter_name . qq{ element $SINGLE_QUOTE} . $parameter_name . $error_msg );
         exit 1;
     }
     return;

--- a/lib/MIP/Recipes/Download/1000g_indels.pm
+++ b/lib/MIP/Recipes/Download/1000g_indels.pm
@@ -8,7 +8,6 @@ use File::Basename qw{ dirname };
 use File::Spec::Functions qw{ catfile };
 use open qw{ :encoding(UTF-8) :std };
 use Params::Check qw{ allow check last_error };
-use strict;
 use utf8;
 use warnings;
 use warnings qw{ FATAL utf8 };
@@ -121,8 +120,7 @@ sub download_1000g_indels {
     use MIP::Get::Parameter qw{ get_recipe_resources };
     use MIP::Recipes::Download::Get_reference qw{ get_reference };
     use MIP::Script::Setup_script qw{ setup_script };
-    use MIP::Processmanagement::Slurm_processes
-      qw{ slurm_submit_job_no_dependency_dead_end };
+    use MIP::Processmanagement::Slurm_processes qw{ slurm_submit_job_no_dependency_dead_end };
 
     ### PREPROCESSING:
 
@@ -130,9 +128,8 @@ sub download_1000g_indels {
     my $log = Log::Log4perl->get_logger( uc q{mip_download} );
 
     ## Unpack parameters
-    my $reference_dir = $active_parameter_href->{reference_dir};
-    my @reference_genome_versions =
-      @{ $active_parameter_href->{reference_genome_versions} };
+    my $reference_dir             = $active_parameter_href->{reference_dir};
+    my @reference_genome_versions = @{ $active_parameter_href->{reference_genome_versions} };
 
     my %recipe_resource = get_recipe_resources(
         {
@@ -151,19 +148,19 @@ sub download_1000g_indels {
     ## Creates recipe directories (info & data & script), recipe script filenames and writes sbatch header
     my ( $recipe_file_path, $recipe_info_path ) = setup_script(
         {
-            active_parameter_href      => $active_parameter_href,
-            core_number                => $recipe_resource{core_number},
-            directory_id               => q{mip_download},
-            filehandle                 => $filehandle,
-            job_id_href                => $job_id_href,
-            memory_allocation          => $recipe_resource{memory},
-            outdata_dir                => $reference_dir,
-            outscript_dir              => $reference_dir,
-            process_time               => $recipe_resource{time},
-            recipe_data_directory_path => $active_parameter_href->{reference_dir},
-            recipe_directory           => $recipe_name . $UNDERSCORE . $reference_version,
-            recipe_name                => $recipe_name,
-            temp_directory             => $temp_directory,
+            active_parameter_href           => $active_parameter_href,
+            core_number                     => $recipe_resource{core_number},
+            directory_id                    => q{mip_download},
+            filehandle                      => $filehandle,
+            job_id_href                     => $job_id_href,
+            memory_allocation               => $recipe_resource{memory},
+            outdata_dir                     => $reference_dir,
+            outscript_dir                   => $reference_dir,
+            process_time                    => $recipe_resource{time},
+            recipe_data_directory_path      => $active_parameter_href->{reference_dir},
+            recipe_directory                => $recipe_name . $UNDERSCORE . $reference_version,
+            recipe_name                     => $recipe_name,
+            temp_directory                  => $temp_directory,
             source_environment_commands_ref => $recipe_resource{load_env_ref},
         }
     );

--- a/lib/MIP/Recipes/Download/1000g_omni.pm
+++ b/lib/MIP/Recipes/Download/1000g_omni.pm
@@ -8,7 +8,6 @@ use File::Basename qw{ dirname };
 use File::Spec::Functions qw{ catfile };
 use open qw{ :encoding(UTF-8) :std };
 use Params::Check qw{ allow check last_error };
-use strict;
 use utf8;
 use warnings;
 use warnings qw{ FATAL utf8 };
@@ -121,8 +120,7 @@ sub download_1000g_omni {
     use MIP::Get::Parameter qw{ get_recipe_resources };
     use MIP::Recipes::Download::Get_reference qw{ get_reference };
     use MIP::Script::Setup_script qw{ setup_script };
-    use MIP::Processmanagement::Slurm_processes
-      qw{ slurm_submit_job_no_dependency_dead_end };
+    use MIP::Processmanagement::Slurm_processes qw{ slurm_submit_job_no_dependency_dead_end };
 
     ### PREPROCESSING:
 
@@ -130,9 +128,8 @@ sub download_1000g_omni {
     my $log = Log::Log4perl->get_logger( uc q{mip_download} );
 
     ## Unpack parameters
-    my $reference_dir = $active_parameter_href->{reference_dir};
-    my @reference_genome_versions =
-      @{ $active_parameter_href->{reference_genome_versions} };
+    my $reference_dir             = $active_parameter_href->{reference_dir};
+    my @reference_genome_versions = @{ $active_parameter_href->{reference_genome_versions} };
 
     my %recipe_resource = get_recipe_resources(
         {
@@ -151,19 +148,19 @@ sub download_1000g_omni {
     ## Creates recipe directories (info & data & script), recipe script filenames and writes sbatch header
     my ( $recipe_file_path, $recipe_info_path ) = setup_script(
         {
-            active_parameter_href      => $active_parameter_href,
-            core_number                => $recipe_resource{core_number},
-            directory_id               => q{mip_download},
-            filehandle                 => $filehandle,
-            job_id_href                => $job_id_href,
-            memory_allocation          => $recipe_resource{memory},
-            outdata_dir                => $reference_dir,
-            outscript_dir              => $reference_dir,
-            process_time               => $recipe_resource{time},
-            recipe_data_directory_path => $active_parameter_href->{reference_dir},
-            recipe_directory           => $recipe_name . $UNDERSCORE . $reference_version,
-            recipe_name                => $recipe_name,
-            temp_directory             => $temp_directory,
+            active_parameter_href           => $active_parameter_href,
+            core_number                     => $recipe_resource{core_number},
+            directory_id                    => q{mip_download},
+            filehandle                      => $filehandle,
+            job_id_href                     => $job_id_href,
+            memory_allocation               => $recipe_resource{memory},
+            outdata_dir                     => $reference_dir,
+            outscript_dir                   => $reference_dir,
+            process_time                    => $recipe_resource{time},
+            recipe_data_directory_path      => $active_parameter_href->{reference_dir},
+            recipe_directory                => $recipe_name . $UNDERSCORE . $reference_version,
+            recipe_name                     => $recipe_name,
+            temp_directory                  => $temp_directory,
             source_environment_commands_ref => $recipe_resource{load_env_ref},
         }
     );

--- a/lib/MIP/Recipes/Download/1000g_sites.pm
+++ b/lib/MIP/Recipes/Download/1000g_sites.pm
@@ -8,7 +8,6 @@ use File::Basename qw{ dirname };
 use File::Spec::Functions qw{ catfile };
 use open qw{ :encoding(UTF-8) :std };
 use Params::Check qw{ allow check last_error };
-use strict;
 use utf8;
 use warnings;
 use warnings qw{ FATAL utf8 };
@@ -121,8 +120,7 @@ sub download_1000g_sites {
     use MIP::Get::Parameter qw{ get_recipe_resources };
     use MIP::Recipes::Download::Get_reference qw{ get_reference };
     use MIP::Script::Setup_script qw{ setup_script };
-    use MIP::Processmanagement::Slurm_processes
-      qw{ slurm_submit_job_no_dependency_dead_end };
+    use MIP::Processmanagement::Slurm_processes qw{ slurm_submit_job_no_dependency_dead_end };
 
     ### PREPROCESSING:
 
@@ -130,9 +128,8 @@ sub download_1000g_sites {
     my $log = Log::Log4perl->get_logger( uc q{mip_download} );
 
     ## Unpack parameters
-    my $reference_dir = $active_parameter_href->{reference_dir};
-    my @reference_genome_versions =
-      @{ $active_parameter_href->{reference_genome_versions} };
+    my $reference_dir             = $active_parameter_href->{reference_dir};
+    my @reference_genome_versions = @{ $active_parameter_href->{reference_genome_versions} };
 
     my %recipe_resource = get_recipe_resources(
         {
@@ -151,19 +148,19 @@ sub download_1000g_sites {
     ## Creates recipe directories (info & data & script), recipe script filenames and writes sbatch header
     my ( $recipe_file_path, $recipe_info_path ) = setup_script(
         {
-            active_parameter_href      => $active_parameter_href,
-            core_number                => $recipe_resource{core_number},
-            directory_id               => q{mip_download},
-            filehandle                 => $filehandle,
-            job_id_href                => $job_id_href,
-            memory_allocation          => $recipe_resource{memory},
-            outdata_dir                => $reference_dir,
-            outscript_dir              => $reference_dir,
-            process_time               => $recipe_resource{time},
-            recipe_data_directory_path => $active_parameter_href->{reference_dir},
-            recipe_directory           => $recipe_name . $UNDERSCORE . $reference_version,
-            recipe_name                => $recipe_name,
-            temp_directory             => $temp_directory,
+            active_parameter_href           => $active_parameter_href,
+            core_number                     => $recipe_resource{core_number},
+            directory_id                    => q{mip_download},
+            filehandle                      => $filehandle,
+            job_id_href                     => $job_id_href,
+            memory_allocation               => $recipe_resource{memory},
+            outdata_dir                     => $reference_dir,
+            outscript_dir                   => $reference_dir,
+            process_time                    => $recipe_resource{time},
+            recipe_data_directory_path      => $active_parameter_href->{reference_dir},
+            recipe_directory                => $recipe_name . $UNDERSCORE . $reference_version,
+            recipe_name                     => $recipe_name,
+            temp_directory                  => $temp_directory,
             source_environment_commands_ref => $recipe_resource{load_env_ref},
         }
     );

--- a/lib/MIP/Recipes/Download/1000g_snps.pm
+++ b/lib/MIP/Recipes/Download/1000g_snps.pm
@@ -8,7 +8,6 @@ use File::Basename qw{ dirname };
 use File::Spec::Functions qw{ catfile };
 use open qw{ :encoding(UTF-8) :std };
 use Params::Check qw{ allow check last_error };
-use strict;
 use utf8;
 use warnings;
 use warnings qw{ FATAL utf8 };
@@ -121,8 +120,7 @@ sub download_1000g_snps {
     use MIP::Get::Parameter qw{ get_recipe_resources };
     use MIP::Recipes::Download::Get_reference qw{ get_reference };
     use MIP::Script::Setup_script qw{ setup_script };
-    use MIP::Processmanagement::Slurm_processes
-      qw{ slurm_submit_job_no_dependency_dead_end };
+    use MIP::Processmanagement::Slurm_processes qw{ slurm_submit_job_no_dependency_dead_end };
 
     ### PREPROCESSING:
 
@@ -130,9 +128,8 @@ sub download_1000g_snps {
     my $log = Log::Log4perl->get_logger( uc q{mip_download} );
 
     ## Unpack parameters
-    my $reference_dir = $active_parameter_href->{reference_dir};
-    my @reference_genome_versions =
-      @{ $active_parameter_href->{reference_genome_versions} };
+    my $reference_dir             = $active_parameter_href->{reference_dir};
+    my @reference_genome_versions = @{ $active_parameter_href->{reference_genome_versions} };
 
     my %recipe_resource = get_recipe_resources(
         {
@@ -151,19 +148,19 @@ sub download_1000g_snps {
     ## Creates recipe directories (info & data & script), recipe script filenames and writes sbatch header
     my ( $recipe_file_path, $recipe_info_path ) = setup_script(
         {
-            active_parameter_href      => $active_parameter_href,
-            core_number                => $recipe_resource{core_number},
-            directory_id               => q{mip_download},
-            filehandle                 => $filehandle,
-            job_id_href                => $job_id_href,
-            memory_allocation          => $recipe_resource{memory},
-            outdata_dir                => $reference_dir,
-            outscript_dir              => $reference_dir,
-            process_time               => $recipe_resource{time},
-            recipe_data_directory_path => $active_parameter_href->{reference_dir},
-            recipe_directory           => $recipe_name . $UNDERSCORE . $reference_version,
-            recipe_name                => $recipe_name,
-            temp_directory             => $temp_directory,
+            active_parameter_href           => $active_parameter_href,
+            core_number                     => $recipe_resource{core_number},
+            directory_id                    => q{mip_download},
+            filehandle                      => $filehandle,
+            job_id_href                     => $job_id_href,
+            memory_allocation               => $recipe_resource{memory},
+            outdata_dir                     => $reference_dir,
+            outscript_dir                   => $reference_dir,
+            process_time                    => $recipe_resource{time},
+            recipe_data_directory_path      => $active_parameter_href->{reference_dir},
+            recipe_directory                => $recipe_name . $UNDERSCORE . $reference_version,
+            recipe_name                     => $recipe_name,
+            temp_directory                  => $temp_directory,
             source_environment_commands_ref => $recipe_resource{load_env_ref}
         }
     );

--- a/lib/MIP/Recipes/Download/Cadd_offline_annotations.pm
+++ b/lib/MIP/Recipes/Download/Cadd_offline_annotations.pm
@@ -8,7 +8,6 @@ use File::Basename qw{ dirname };
 use File::Spec::Functions qw{ catdir catfile };
 use open qw{ :encoding(UTF-8) :std };
 use Params::Check qw{ allow check last_error };
-use strict;
 use utf8;
 use warnings;
 use warnings qw{ FATAL utf8 };
@@ -122,8 +121,7 @@ sub download_cadd_offline_annotations {
     use MIP::Program::Gnu::Coreutils qw{ gnu_mkdir gnu_mv gnu_rm_and_echo };
     use MIP::Recipes::Download::Get_reference qw{ get_reference };
     use MIP::Script::Setup_script qw{ setup_script };
-    use MIP::Processmanagement::Slurm_processes
-      qw{ slurm_submit_job_no_dependency_dead_end };
+    use MIP::Processmanagement::Slurm_processes qw{ slurm_submit_job_no_dependency_dead_end };
 
     ### PREPROCESSING:
 
@@ -150,18 +148,18 @@ sub download_cadd_offline_annotations {
     ## Creates recipe directories (info & data & script), recipe script filenames and writes sbatch header
     my ( $recipe_file_path, $recipe_info_path ) = setup_script(
         {
-            active_parameter_href      => $active_parameter_href,
-            core_number                => $recipe_resource{core_number},
-            directory_id               => q{mip_download},
-            filehandle                 => $filehandle,
-            job_id_href                => $job_id_href,
-            memory_allocation          => $recipe_resource{memory},
-            outdata_dir                => $reference_dir,
-            outscript_dir              => $reference_dir,
-            process_time               => $recipe_resource{time},
-            recipe_data_directory_path => $active_parameter_href->{reference_dir},
-            recipe_directory           => $recipe_name . $UNDERSCORE . $reference_version,
-            recipe_name                => $recipe_name,
+            active_parameter_href           => $active_parameter_href,
+            core_number                     => $recipe_resource{core_number},
+            directory_id                    => q{mip_download},
+            filehandle                      => $filehandle,
+            job_id_href                     => $job_id_href,
+            memory_allocation               => $recipe_resource{memory},
+            outdata_dir                     => $reference_dir,
+            outscript_dir                   => $reference_dir,
+            process_time                    => $recipe_resource{time},
+            recipe_data_directory_path      => $active_parameter_href->{reference_dir},
+            recipe_directory                => $recipe_name . $UNDERSCORE . $reference_version,
+            recipe_name                     => $recipe_name,
             source_environment_commands_ref => $recipe_resource{load_env_ref},
         }
     );

--- a/lib/MIP/Recipes/Download/Cadd_to_vcf_header.pm
+++ b/lib/MIP/Recipes/Download/Cadd_to_vcf_header.pm
@@ -8,7 +8,6 @@ use File::Basename qw{ dirname };
 use File::Spec::Functions qw{ catfile };
 use open qw{ :encoding(UTF-8) :std };
 use Params::Check qw{ allow check last_error };
-use strict;
 use utf8;
 use warnings;
 use warnings qw{ FATAL utf8 };
@@ -121,8 +120,7 @@ sub download_cadd_to_vcf_header {
     use MIP::Get::Parameter qw{ get_recipe_resources };
     use MIP::Recipes::Download::Get_reference qw{ get_reference };
     use MIP::Script::Setup_script qw{ setup_script };
-    use MIP::Processmanagement::Slurm_processes
-      qw{ slurm_submit_job_no_dependency_dead_end };
+    use MIP::Processmanagement::Slurm_processes qw{ slurm_submit_job_no_dependency_dead_end };
 
     ### PREPROCESSING:
 
@@ -149,18 +147,18 @@ sub download_cadd_to_vcf_header {
     ## Creates recipe directories (info & data & script), recipe script filenames and writes sbatch header
     my ( $recipe_file_path, $recipe_info_path ) = setup_script(
         {
-            active_parameter_href      => $active_parameter_href,
-            core_number                => $recipe_resource{core_number},
-            directory_id               => q{mip_download},
-            filehandle                 => $filehandle,
-            job_id_href                => $job_id_href,
-            memory_allocation          => $recipe_resource{memory},
-            outdata_dir                => $reference_dir,
-            outscript_dir              => $reference_dir,
-            process_time               => $recipe_resource{time},
-            recipe_data_directory_path => $active_parameter_href->{reference_dir},
-            recipe_directory           => $recipe_name . $UNDERSCORE . $reference_version,
-            recipe_name                => $recipe_name,
+            active_parameter_href           => $active_parameter_href,
+            core_number                     => $recipe_resource{core_number},
+            directory_id                    => q{mip_download},
+            filehandle                      => $filehandle,
+            job_id_href                     => $job_id_href,
+            memory_allocation               => $recipe_resource{memory},
+            outdata_dir                     => $reference_dir,
+            outscript_dir                   => $reference_dir,
+            process_time                    => $recipe_resource{time},
+            recipe_data_directory_path      => $active_parameter_href->{reference_dir},
+            recipe_directory                => $recipe_name . $UNDERSCORE . $reference_version,
+            recipe_name                     => $recipe_name,
             source_environment_commands_ref => $recipe_resource{load_env_ref},
         }
     );

--- a/lib/MIP/Recipes/Download/Cadd_whole_genome_snvs.pm
+++ b/lib/MIP/Recipes/Download/Cadd_whole_genome_snvs.pm
@@ -8,7 +8,6 @@ use File::Basename qw{ dirname };
 use File::Spec::Functions qw{ catdir catfile };
 use open qw{ :encoding(UTF-8) :std };
 use Params::Check qw{ allow check last_error };
-use strict;
 use utf8;
 use warnings;
 use warnings qw{ FATAL utf8 };
@@ -121,8 +120,7 @@ sub download_cadd_whole_genome_snvs {
     use MIP::Get::Parameter qw{ get_recipe_resources };
     use MIP::Recipes::Download::Get_reference qw{ get_reference };
     use MIP::Script::Setup_script qw{ setup_script };
-    use MIP::Processmanagement::Slurm_processes
-      qw{ slurm_submit_job_no_dependency_dead_end };
+    use MIP::Processmanagement::Slurm_processes qw{ slurm_submit_job_no_dependency_dead_end };
 
     ### PREPROCESSING:
 
@@ -149,18 +147,18 @@ sub download_cadd_whole_genome_snvs {
     ## Creates recipe directories (info & data & script), recipe script filenames and writes sbatch header
     my ( $recipe_file_path, $recipe_info_path ) = setup_script(
         {
-            active_parameter_href      => $active_parameter_href,
-            core_number                => $recipe_resource{core_number},
-            directory_id               => q{mip_download},
-            filehandle                 => $filehandle,
-            job_id_href                => $job_id_href,
-            memory_allocation          => $recipe_resource{memory},
-            outdata_dir                => $reference_dir,
-            outscript_dir              => $reference_dir,
-            process_time               => $recipe_resource{time},
-            recipe_data_directory_path => $active_parameter_href->{reference_dir},
-            recipe_directory           => $recipe_name . $UNDERSCORE . $reference_version,
-            recipe_name                => $recipe_name,
+            active_parameter_href           => $active_parameter_href,
+            core_number                     => $recipe_resource{core_number},
+            directory_id                    => q{mip_download},
+            filehandle                      => $filehandle,
+            job_id_href                     => $job_id_href,
+            memory_allocation               => $recipe_resource{memory},
+            outdata_dir                     => $reference_dir,
+            outscript_dir                   => $reference_dir,
+            process_time                    => $recipe_resource{time},
+            recipe_data_directory_path      => $active_parameter_href->{reference_dir},
+            recipe_directory                => $recipe_name . $UNDERSCORE . $reference_version,
+            recipe_name                     => $recipe_name,
             source_environment_commands_ref => $recipe_resource{load_env_ref},
         }
     );

--- a/lib/MIP/Recipes/Download/Chromograph_cytoband.pm
+++ b/lib/MIP/Recipes/Download/Chromograph_cytoband.pm
@@ -8,7 +8,6 @@ use File::Basename qw{ dirname };
 use File::Spec::Functions qw{ catfile };
 use open qw{ :encoding(UTF-8) :std };
 use Params::Check qw{ allow check last_error };
-use strict;
 use utf8;
 use warnings;
 use warnings qw{ FATAL utf8 };
@@ -120,8 +119,7 @@ sub download_chromograph_cytoband {
     use MIP::Get::Parameter qw{ get_recipe_resources };
     use MIP::Recipes::Download::Get_reference qw{ get_reference };
     use MIP::Script::Setup_script qw{ setup_script };
-    use MIP::Processmanagement::Slurm_processes
-      qw{ slurm_submit_job_no_dependency_dead_end };
+    use MIP::Processmanagement::Slurm_processes qw{ slurm_submit_job_no_dependency_dead_end };
 
     ### PREPROCESSING:
 
@@ -148,18 +146,18 @@ sub download_chromograph_cytoband {
     ## Creates recipe directories (info & data & script), recipe script filenames and writes sbatch header
     my ( $recipe_file_path, $recipe_info_path ) = setup_script(
         {
-            active_parameter_href      => $active_parameter_href,
-            core_number                => $recipe_resource{core_number},
-            directory_id               => q{mip_download},
-            filehandle                 => $filehandle,
-            job_id_href                => $job_id_href,
-            memory_allocation          => $recipe_resource{memory},
-            outdata_dir                => $reference_dir,
-            outscript_dir              => $reference_dir,
-            process_time               => $recipe_resource{time},
-            recipe_data_directory_path => $active_parameter_href->{reference_dir},
-            recipe_directory           => $recipe_name . $UNDERSCORE . $reference_version,
-            recipe_name                => $recipe_name,
+            active_parameter_href           => $active_parameter_href,
+            core_number                     => $recipe_resource{core_number},
+            directory_id                    => q{mip_download},
+            filehandle                      => $filehandle,
+            job_id_href                     => $job_id_href,
+            memory_allocation               => $recipe_resource{memory},
+            outdata_dir                     => $reference_dir,
+            outscript_dir                   => $reference_dir,
+            process_time                    => $recipe_resource{time},
+            recipe_data_directory_path      => $active_parameter_href->{reference_dir},
+            recipe_directory                => $recipe_name . $UNDERSCORE . $reference_version,
+            recipe_name                     => $recipe_name,
             source_environment_commands_ref => $recipe_resource{load_env_ref},
         }
     );

--- a/lib/MIP/Recipes/Download/Clinvar.pm
+++ b/lib/MIP/Recipes/Download/Clinvar.pm
@@ -9,7 +9,6 @@ use File::Path qw{ remove_tree };
 use File::Spec::Functions qw{ catfile };
 use open qw{ :encoding(UTF-8) :std };
 use Params::Check qw{ allow check last_error };
-use strict;
 use utf8;
 use warnings;
 use warnings qw{ FATAL utf8 };
@@ -125,8 +124,7 @@ sub download_clinvar {
     use MIP::Program::Bcftools qw{ bcftools_annotate };
     use MIP::Recipes::Download::Get_reference qw{ get_reference };
     use MIP::Script::Setup_script qw{ setup_script };
-    use MIP::Processmanagement::Slurm_processes
-      qw{ slurm_submit_job_no_dependency_dead_end };
+    use MIP::Processmanagement::Slurm_processes qw{ slurm_submit_job_no_dependency_dead_end };
 
     ### PREPROCESSING:
 
@@ -134,10 +132,9 @@ sub download_clinvar {
     my $log = Log::Log4perl->get_logger( uc q{mip_download} );
 
     ## Unpack parameters
-    my $reference_dir = $active_parameter_href->{reference_dir};
-    my @reference_genome_versions =
-      @{ $active_parameter_href->{reference_genome_versions} };
-    my %recipe_resource = get_recipe_resources(
+    my $reference_dir             = $active_parameter_href->{reference_dir};
+    my @reference_genome_versions = @{ $active_parameter_href->{reference_genome_versions} };
+    my %recipe_resource           = get_recipe_resources(
         {
             active_parameter_href => $active_parameter_href,
             recipe_name           => $recipe_name,
@@ -154,19 +151,19 @@ sub download_clinvar {
     ## Creates recipe directories (info & data & script), recipe script filenames and writes sbatch header
     my ( $recipe_file_path, $recipe_info_path ) = setup_script(
         {
-            active_parameter_href      => $active_parameter_href,
-            core_number                => $recipe_resource{core_number},
-            directory_id               => q{mip_download},
-            filehandle                 => $filehandle,
-            job_id_href                => $job_id_href,
-            memory_allocation          => $recipe_resource{memory},
-            outdata_dir                => $reference_dir,
-            outscript_dir              => $reference_dir,
-            process_time               => $recipe_resource{time},
-            recipe_data_directory_path => $active_parameter_href->{reference_dir},
-            recipe_directory           => $recipe_name . $UNDERSCORE . $reference_version,
-            recipe_name                => $recipe_name,
-            temp_directory             => $temp_directory,
+            active_parameter_href           => $active_parameter_href,
+            core_number                     => $recipe_resource{core_number},
+            directory_id                    => q{mip_download},
+            filehandle                      => $filehandle,
+            job_id_href                     => $job_id_href,
+            memory_allocation               => $recipe_resource{memory},
+            outdata_dir                     => $reference_dir,
+            outscript_dir                   => $reference_dir,
+            process_time                    => $recipe_resource{time},
+            recipe_data_directory_path      => $active_parameter_href->{reference_dir},
+            recipe_directory                => $recipe_name . $UNDERSCORE . $reference_version,
+            recipe_name                     => $recipe_name,
+            temp_directory                  => $temp_directory,
             source_environment_commands_ref => $recipe_resource{load_env_ref},
         }
     );
@@ -188,11 +185,7 @@ sub download_clinvar {
 
     say {$filehandle} q{## Build clinvar variation ID header file};
     my $header_file_path = catfile( $reference_dir,
-            $genome_version
-          . $UNDERSCORE
-          . $reference_version
-          . $UNDERSCORE
-          . q{clnvid_header.txt} );
+        $genome_version . $UNDERSCORE . $reference_version . $UNDERSCORE . q{clnvid_header.txt} );
     ## Build clinvar variation ID header file
     _build_clnvid_head_file(
         {
@@ -213,9 +206,7 @@ sub download_clinvar {
     say {$filehandle} $PIPE . $SPACE . $BACKWARD_SLASH;
 
     my $reformated_outfile = join $UNDERSCORE,
-      (
-        $genome_version, $recipe_name, q{reformated}, q{-} . $reference_version . q{-.vcf}
-      );
+      ( $genome_version, $recipe_name, q{reformated}, q{-} . $reference_version . q{-.vcf} );
     my $reformated_outfile_path = catfile( $reference_dir, $reformated_outfile );
 
     ## Add clinvar variation ID to vcf info file
@@ -305,7 +296,7 @@ sub _build_clnvid_head_file {
 
     ## Print header line for Clinvar variation ID
     print {$filehandle}
-q? print q{##INFO=<ID=CLNVID,Number=1,Type=Integer,Description="ClinVar Variation ID">} '?;
+      q? print q{##INFO=<ID=CLNVID,Number=1,Type=Integer,Description="ClinVar Variation ID">} '?;
 
     ## Write to files
     say {$filehandle} q{ > } . $header_file_path . $NEWLINE;
@@ -345,8 +336,7 @@ sub _add_clnvid_to_vcf_info {
     print {$filehandle} q?if($_=~/^#/) { print $_;} ?;
 
     ## Else add CLVID to INFO
-    print {$filehandle}
-      q?else { chomp; my $line = $_; say STDOUT $_ . q{;CLNVID=} . $F[2] } '?;
+    print {$filehandle} q?else { chomp; my $line = $_; say STDOUT $_ . q{;CLNVID=} . $F[2] } '?;
 
     ## Write to files
     say {$filehandle} q{ > } . $outfile_path . $NEWLINE;

--- a/lib/MIP/Recipes/Download/Ctat_resource_lib.pm
+++ b/lib/MIP/Recipes/Download/Ctat_resource_lib.pm
@@ -8,7 +8,6 @@ use File::Basename qw{ dirname };
 use File::Spec::Functions qw{ catfile };
 use open qw{ :encoding(UTF-8) :std };
 use Params::Check qw{ allow check last_error };
-use strict;
 use utf8;
 use warnings;
 use warnings qw{ FATAL utf8 };
@@ -122,8 +121,7 @@ sub download_ctat_resource_lib {
     use MIP::Program::Gnu::Coreutils qw{ gnu_mv };
     use MIP::Recipes::Download::Get_reference qw{ get_reference };
     use MIP::Script::Setup_script qw{ setup_script };
-    use MIP::Processmanagement::Slurm_processes
-      qw{ slurm_submit_job_no_dependency_dead_end };
+    use MIP::Processmanagement::Slurm_processes qw{ slurm_submit_job_no_dependency_dead_end };
 
     ### PREPROCESSING:
 
@@ -150,18 +148,18 @@ sub download_ctat_resource_lib {
     ## Creates recipe directories (info & data & script), recipe script filenames and writes sbatch header
     my ( $recipe_file_path, $recipe_info_path ) = setup_script(
         {
-            active_parameter_href      => $active_parameter_href,
-            core_number                => $recipe_resource{core_number},
-            directory_id               => q{mip_download},
-            filehandle                 => $filehandle,
-            job_id_href                => $job_id_href,
-            memory_allocation          => $recipe_resource{memory},
-            outdata_dir                => $reference_dir,
-            outscript_dir              => $reference_dir,
-            process_time               => $recipe_resource{time},
-            recipe_data_directory_path => $active_parameter_href->{reference_dir},
-            recipe_directory           => $recipe_name . $UNDERSCORE . $reference_version,
-            recipe_name                => $recipe_name,
+            active_parameter_href           => $active_parameter_href,
+            core_number                     => $recipe_resource{core_number},
+            directory_id                    => q{mip_download},
+            filehandle                      => $filehandle,
+            job_id_href                     => $job_id_href,
+            memory_allocation               => $recipe_resource{memory},
+            outdata_dir                     => $reference_dir,
+            outscript_dir                   => $reference_dir,
+            process_time                    => $recipe_resource{time},
+            recipe_data_directory_path      => $active_parameter_href->{reference_dir},
+            recipe_directory                => $recipe_name . $UNDERSCORE . $reference_version,
+            recipe_name                     => $recipe_name,
             source_environment_commands_ref => $recipe_resource{load_env_ref},
         }
     );
@@ -181,11 +179,9 @@ sub download_ctat_resource_lib {
         }
     );
 
-    my $reformated_outdir_name = join $UNDERSCORE,
-      ( $genome_version, $reference_version );
+    my $reformated_outdir_name = join $UNDERSCORE, ( $genome_version, $reference_version );
     my $reformated_outdir_path =
-      catfile( $reference_dir, $reformated_outdir_name, q{ctat_genome_lib_build_dir},
-        $ASTERISK );
+      catfile( $reference_dir, $reformated_outdir_name, q{ctat_genome_lib_build_dir}, $ASTERISK );
 
     ## Move dir
     gnu_mv(

--- a/lib/MIP/Recipes/Download/Dbnsfp.pm
+++ b/lib/MIP/Recipes/Download/Dbnsfp.pm
@@ -8,7 +8,6 @@ use File::Basename qw{ dirname };
 use File::Spec::Functions qw{ catfile };
 use open qw{ :encoding(UTF-8) :std };
 use Params::Check qw{ allow check last_error };
-use strict;
 use utf8;
 use warnings;
 use warnings qw{ FATAL utf8 };
@@ -18,8 +17,7 @@ use autodie qw{ :all };
 use Readonly;
 
 ## MIPs lib/
-use MIP::Constants
-  qw{ $ASTERISK $BACKWARD_SLASH $COMMA $DASH $NEWLINE $PIPE $SPACE $UNDERSCORE };
+use MIP::Constants qw{ $ASTERISK $BACKWARD_SLASH $COMMA $DASH $NEWLINE $PIPE $SPACE $UNDERSCORE };
 
 BEGIN {
 
@@ -132,8 +130,7 @@ sub download_dbnsfp {
     use MIP::Program::Htslib qw{ htslib_bgzip htslib_tabix };
     use MIP::Recipes::Download::Get_reference qw{ get_reference };
     use MIP::Script::Setup_script qw{ setup_script };
-    use MIP::Processmanagement::Slurm_processes
-      qw{ slurm_submit_job_no_dependency_dead_end };
+    use MIP::Processmanagement::Slurm_processes qw{ slurm_submit_job_no_dependency_dead_end };
 
     ### PREPROCESSING:
 
@@ -160,18 +157,18 @@ sub download_dbnsfp {
     ## Creates recipe directories (info & data & script), recipe script filenames and writes sbatch header
     my ( $recipe_file_path, $recipe_info_path ) = setup_script(
         {
-            active_parameter_href      => $active_parameter_href,
-            core_number                => $recipe_resource{core_number},
-            directory_id               => q{mip_download},
-            filehandle                 => $filehandle,
-            job_id_href                => $job_id_href,
-            memory_allocation          => $recipe_resource{memory},
-            outdata_dir                => $reference_dir,
-            outscript_dir              => $reference_dir,
-            process_time               => $recipe_resource{time},
-            recipe_data_directory_path => $active_parameter_href->{reference_dir},
-            recipe_directory           => $recipe_name . $UNDERSCORE . $reference_version,
-            recipe_name                => $recipe_name,
+            active_parameter_href           => $active_parameter_href,
+            core_number                     => $recipe_resource{core_number},
+            directory_id                    => q{mip_download},
+            filehandle                      => $filehandle,
+            job_id_href                     => $job_id_href,
+            memory_allocation               => $recipe_resource{memory},
+            outdata_dir                     => $reference_dir,
+            outscript_dir                   => $reference_dir,
+            process_time                    => $recipe_resource{time},
+            recipe_data_directory_path      => $active_parameter_href->{reference_dir},
+            recipe_directory                => $recipe_name . $UNDERSCORE . $reference_version,
+            recipe_name                     => $recipe_name,
             source_environment_commands_ref => $recipe_resource{load_env_ref},
             temp_directory                  => $temp_directory,
         }
@@ -195,14 +192,10 @@ sub download_dbnsfp {
     say {$filehandle} q{## Build dbnsfp header file after unzip};
 
     ## Build dbnsfp chr file name after unzip
-    my $dbnsfp_chr_file_name =
-      q{dbNSFP} . $reference_version . $UNDERSCORE . q{variant.chr};
+    my $dbnsfp_chr_file_name = q{dbNSFP} . $reference_version . $UNDERSCORE . q{variant.chr};
     my $dbnsfp_chr_file_path = catfile( $reference_dir, $dbnsfp_chr_file_name );
     my $reformated_outfile   = join $UNDERSCORE,
-      (
-        $genome_version, $recipe_name, q{reformated},
-        $DASH . $reference_version . q{-.txt}
-      );
+      ( $genome_version, $recipe_name, q{reformated}, $DASH . $reference_version . q{-.txt} );
     my $reformated_outfile_path = catfile( $reference_dir, $reformated_outfile );
 
     if ( $genome_version eq q{grch37} ) {

--- a/lib/MIP/Recipes/Download/Dbsnp.pm
+++ b/lib/MIP/Recipes/Download/Dbsnp.pm
@@ -8,7 +8,6 @@ use File::Basename qw{ dirname };
 use File::Spec::Functions qw{ catfile };
 use open qw{ :encoding(UTF-8) :std };
 use Params::Check qw{ allow check last_error };
-use strict;
 use utf8;
 use warnings;
 use warnings qw{ FATAL utf8 };
@@ -121,8 +120,7 @@ sub download_dbsnp {
     use MIP::Get::Parameter qw{ get_recipe_resources };
     use MIP::Recipes::Download::Get_reference qw{ get_reference };
     use MIP::Script::Setup_script qw{ setup_script };
-    use MIP::Processmanagement::Slurm_processes
-      qw{ slurm_submit_job_no_dependency_dead_end };
+    use MIP::Processmanagement::Slurm_processes qw{ slurm_submit_job_no_dependency_dead_end };
 
     ### PREPROCESSING:
 
@@ -130,9 +128,8 @@ sub download_dbsnp {
     my $log = Log::Log4perl->get_logger( uc q{mip_download} );
 
     ## Unpack parameters
-    my $reference_dir = $active_parameter_href->{reference_dir};
-    my @reference_genome_versions =
-      @{ $active_parameter_href->{reference_genome_versions} };
+    my $reference_dir             = $active_parameter_href->{reference_dir};
+    my @reference_genome_versions = @{ $active_parameter_href->{reference_genome_versions} };
 
     my %recipe_resource = get_recipe_resources(
         {
@@ -151,19 +148,19 @@ sub download_dbsnp {
     ## Creates recipe directories (info & data & script), recipe script filenames and writes sbatch header
     my ( $recipe_file_path, $recipe_info_path ) = setup_script(
         {
-            active_parameter_href      => $active_parameter_href,
-            core_number                => $recipe_resource{core_number},
-            directory_id               => q{mip_download},
-            filehandle                 => $filehandle,
-            job_id_href                => $job_id_href,
-            memory_allocation          => $recipe_resource{memory},
-            outdata_dir                => $reference_dir,
-            outscript_dir              => $reference_dir,
-            process_time               => $recipe_resource{time},
-            recipe_data_directory_path => $active_parameter_href->{reference_dir},
-            recipe_directory           => $recipe_name . $UNDERSCORE . $reference_version,
-            recipe_name                => $recipe_name,
-            temp_directory             => $temp_directory,
+            active_parameter_href           => $active_parameter_href,
+            core_number                     => $recipe_resource{core_number},
+            directory_id                    => q{mip_download},
+            filehandle                      => $filehandle,
+            job_id_href                     => $job_id_href,
+            memory_allocation               => $recipe_resource{memory},
+            outdata_dir                     => $reference_dir,
+            outscript_dir                   => $reference_dir,
+            process_time                    => $recipe_resource{time},
+            recipe_data_directory_path      => $active_parameter_href->{reference_dir},
+            recipe_directory                => $recipe_name . $UNDERSCORE . $reference_version,
+            recipe_name                     => $recipe_name,
+            temp_directory                  => $temp_directory,
             source_environment_commands_ref => $recipe_resource{load_env_ref},
         }
     );

--- a/lib/MIP/Recipes/Download/Delly_exclude.pm
+++ b/lib/MIP/Recipes/Download/Delly_exclude.pm
@@ -8,7 +8,6 @@ use File::Basename qw{ dirname };
 use File::Spec::Functions qw{ catfile };
 use open qw{ :encoding(UTF-8) :std };
 use Params::Check qw{ allow check last_error };
-use strict;
 use utf8;
 use warnings;
 use warnings qw{ FATAL utf8 };
@@ -121,8 +120,7 @@ sub download_delly_exclude {
     use MIP::Get::Parameter qw{ get_recipe_resources };
     use MIP::Recipes::Download::Get_reference qw{ get_reference };
     use MIP::Script::Setup_script qw{ setup_script };
-    use MIP::Processmanagement::Slurm_processes
-      qw{ slurm_submit_job_no_dependency_dead_end };
+    use MIP::Processmanagement::Slurm_processes qw{ slurm_submit_job_no_dependency_dead_end };
 
     ### PREPROCESSING:
 
@@ -149,18 +147,18 @@ sub download_delly_exclude {
     ## Creates recipe directories (info & data & script), recipe script filenames and writes sbatch header
     my ( $recipe_file_path, $recipe_info_path ) = setup_script(
         {
-            active_parameter_href      => $active_parameter_href,
-            core_number                => $recipe_resource{core_number},
-            directory_id               => q{mip_download},
-            filehandle                 => $filehandle,
-            job_id_href                => $job_id_href,
-            memory_allocation          => $recipe_resource{memory},
-            outdata_dir                => $reference_dir,
-            outscript_dir              => $reference_dir,
-            process_time               => $recipe_resource{time},
-            recipe_data_directory_path => $active_parameter_href->{reference_dir},
-            recipe_directory           => $recipe_name . $UNDERSCORE . $reference_version,
-            recipe_name                => $recipe_name,
+            active_parameter_href           => $active_parameter_href,
+            core_number                     => $recipe_resource{core_number},
+            directory_id                    => q{mip_download},
+            filehandle                      => $filehandle,
+            job_id_href                     => $job_id_href,
+            memory_allocation               => $recipe_resource{memory},
+            outdata_dir                     => $reference_dir,
+            outscript_dir                   => $reference_dir,
+            process_time                    => $recipe_resource{time},
+            recipe_data_directory_path      => $active_parameter_href->{reference_dir},
+            recipe_directory                => $recipe_name . $UNDERSCORE . $reference_version,
+            recipe_name                     => $recipe_name,
             source_environment_commands_ref => $recipe_resource{load_env_ref},
         }
     );

--- a/lib/MIP/Recipes/Download/Expansionhunter.pm
+++ b/lib/MIP/Recipes/Download/Expansionhunter.pm
@@ -8,7 +8,6 @@ use File::Basename qw{ dirname };
 use File::Spec::Functions qw{ catfile };
 use open qw{ :encoding(UTF-8) :std };
 use Params::Check qw{ allow check last_error };
-use strict;
 use utf8;
 use warnings;
 use warnings qw{ FATAL utf8 };
@@ -121,8 +120,7 @@ sub download_expansionhunter {
     use MIP::Get::Parameter qw{ get_recipe_resources };
     use MIP::Recipes::Download::Get_reference qw{ get_reference };
     use MIP::Script::Setup_script qw{ setup_script };
-    use MIP::Processmanagement::Slurm_processes
-      qw{ slurm_submit_job_no_dependency_dead_end };
+    use MIP::Processmanagement::Slurm_processes qw{ slurm_submit_job_no_dependency_dead_end };
 
     ### PREPROCESSING:
 
@@ -159,9 +157,9 @@ sub download_expansionhunter {
             outscript_dir         => $reference_dir,
             process_time          => $recipe_resource{time},
             ,
-            recipe_data_directory_path => $active_parameter_href->{reference_dir},
-            recipe_directory           => $recipe_name . $UNDERSCORE . $reference_version,
-            recipe_name                => $recipe_name,
+            recipe_data_directory_path      => $active_parameter_href->{reference_dir},
+            recipe_directory                => $recipe_name . $UNDERSCORE . $reference_version,
+            recipe_name                     => $recipe_name,
             source_environment_commands_ref => $recipe_resource{load_env_ref},
         }
     );

--- a/lib/MIP/Recipes/Download/Gatk_mitochondrial_ref.pm
+++ b/lib/MIP/Recipes/Download/Gatk_mitochondrial_ref.pm
@@ -8,7 +8,6 @@ use File::Basename qw{ dirname };
 use File::Spec::Functions qw{ catfile };
 use open qw{ :encoding(UTF-8) :std };
 use Params::Check qw{ allow check last_error };
-use strict;
 use utf8;
 use warnings;
 use warnings qw{ FATAL utf8 };
@@ -121,8 +120,7 @@ sub download_gatk_mitochondrial_ref {
     use MIP::Get::Parameter qw{ get_recipe_resources };
     use MIP::Recipes::Download::Get_reference qw{ get_reference };
     use MIP::Script::Setup_script qw{ setup_script };
-    use MIP::Processmanagement::Slurm_processes
-      qw{ slurm_submit_job_no_dependency_dead_end };
+    use MIP::Processmanagement::Slurm_processes qw{ slurm_submit_job_no_dependency_dead_end };
 
     ### PREPROCESSING:
 
@@ -149,18 +147,18 @@ sub download_gatk_mitochondrial_ref {
     ## Creates recipe directories (info & data & script), recipe script filenames and writes sbatch header
     my ( $recipe_file_path, $recipe_info_path ) = setup_script(
         {
-            active_parameter_href      => $active_parameter_href,
-            core_number                => $recipe_resource{core_number},
-            directory_id               => q{mip_download},
-            filehandle                 => $filehandle,
-            job_id_href                => $job_id_href,
-            memory_allocation          => $recipe_resource{memory},
-            outdata_dir                => $reference_dir,
-            outscript_dir              => $reference_dir,
-            process_time               => $recipe_resource{time},
-            recipe_data_directory_path => $active_parameter_href->{reference_dir},
-            recipe_directory           => $recipe_name . $UNDERSCORE . $reference_version,
-            recipe_name                => $recipe_name,
+            active_parameter_href           => $active_parameter_href,
+            core_number                     => $recipe_resource{core_number},
+            directory_id                    => q{mip_download},
+            filehandle                      => $filehandle,
+            job_id_href                     => $job_id_href,
+            memory_allocation               => $recipe_resource{memory},
+            outdata_dir                     => $reference_dir,
+            outscript_dir                   => $reference_dir,
+            process_time                    => $recipe_resource{time},
+            recipe_data_directory_path      => $active_parameter_href->{reference_dir},
+            recipe_directory                => $recipe_name . $UNDERSCORE . $reference_version,
+            recipe_name                     => $recipe_name,
             source_environment_commands_ref => $recipe_resource{load_env_ref},
         }
     );

--- a/lib/MIP/Recipes/Download/Genbank_haplogroup.pm
+++ b/lib/MIP/Recipes/Download/Genbank_haplogroup.pm
@@ -8,7 +8,6 @@ use File::Basename qw{ dirname };
 use File::Spec::Functions qw{ catfile };
 use open qw{ :encoding(UTF-8) :std };
 use Params::Check qw{ allow check last_error };
-use strict;
 use utf8;
 use warnings;
 use warnings qw{ FATAL utf8 };
@@ -121,8 +120,7 @@ sub download_genbank_haplogroup {
     use MIP::Get::Parameter qw{ get_recipe_resources };
     use MIP::Recipes::Download::Get_reference qw{ get_reference };
     use MIP::Script::Setup_script qw{ setup_script };
-    use MIP::Processmanagement::Slurm_processes
-      qw{ slurm_submit_job_no_dependency_dead_end };
+    use MIP::Processmanagement::Slurm_processes qw{ slurm_submit_job_no_dependency_dead_end };
 
     ### PREPROCESSING:
 
@@ -149,18 +147,18 @@ sub download_genbank_haplogroup {
     ## Creates recipe directories (info & data & script), recipe script filenames and writes sbatch header
     my ( $recipe_file_path, $recipe_info_path ) = setup_script(
         {
-            active_parameter_href      => $active_parameter_href,
-            core_number                => $recipe_resource{core_number},
-            directory_id               => q{mip_download},
-            filehandle                 => $filehandle,
-            job_id_href                => $job_id_href,
-            memory_allocation          => $recipe_resource{memory},
-            outdata_dir                => $reference_dir,
-            outscript_dir              => $reference_dir,
-            process_time               => $recipe_resource{time},
-            recipe_data_directory_path => $active_parameter_href->{reference_dir},
-            recipe_directory           => $recipe_name . $UNDERSCORE . $reference_version,
-            recipe_name                => $recipe_name,
+            active_parameter_href           => $active_parameter_href,
+            core_number                     => $recipe_resource{core_number},
+            directory_id                    => q{mip_download},
+            filehandle                      => $filehandle,
+            job_id_href                     => $job_id_href,
+            memory_allocation               => $recipe_resource{memory},
+            outdata_dir                     => $reference_dir,
+            outscript_dir                   => $reference_dir,
+            process_time                    => $recipe_resource{time},
+            recipe_data_directory_path      => $active_parameter_href->{reference_dir},
+            recipe_directory                => $recipe_name . $UNDERSCORE . $reference_version,
+            recipe_name                     => $recipe_name,
             source_environment_commands_ref => $recipe_resource{load_env_ref},
         }
     );

--- a/lib/MIP/Recipes/Download/Gencode_annotation.pm
+++ b/lib/MIP/Recipes/Download/Gencode_annotation.pm
@@ -8,7 +8,6 @@ use File::Basename qw{ dirname };
 use File::Spec::Functions qw{ catfile };
 use open qw{ :encoding(UTF-8) :std };
 use Params::Check qw{ allow check last_error };
-use strict;
 use utf8;
 use warnings;
 use warnings qw{ FATAL utf8 };
@@ -122,8 +121,7 @@ sub download_gencode_annotation {
     use MIP::Program::Gtf2bed qw{ gtf2bed };
     use MIP::Recipes::Download::Get_reference qw{ get_reference };
     use MIP::Script::Setup_script qw{ setup_script };
-    use MIP::Processmanagement::Slurm_processes
-      qw{ slurm_submit_job_no_dependency_dead_end };
+    use MIP::Processmanagement::Slurm_processes qw{ slurm_submit_job_no_dependency_dead_end };
 
     ### PREPROCESSING:
 
@@ -150,18 +148,18 @@ sub download_gencode_annotation {
     ## Creates recipe directories (info & data & script), recipe script filenames and writes sbatch header
     my ( $recipe_file_path, $recipe_info_path ) = setup_script(
         {
-            active_parameter_href      => $active_parameter_href,
-            core_number                => $recipe_resource{core_number},
-            directory_id               => q{mip_download},
-            filehandle                 => $filehandle,
-            job_id_href                => $job_id_href,
-            memory_allocation          => $recipe_resource{memory},
-            outdata_dir                => $reference_dir,
-            outscript_dir              => $reference_dir,
-            process_time               => $recipe_resource{time},
-            recipe_data_directory_path => $active_parameter_href->{reference_dir},
-            recipe_directory           => $recipe_name . $UNDERSCORE . $reference_version,
-            recipe_name                => $recipe_name,
+            active_parameter_href           => $active_parameter_href,
+            core_number                     => $recipe_resource{core_number},
+            directory_id                    => q{mip_download},
+            filehandle                      => $filehandle,
+            job_id_href                     => $job_id_href,
+            memory_allocation               => $recipe_resource{memory},
+            outdata_dir                     => $reference_dir,
+            outscript_dir                   => $reference_dir,
+            process_time                    => $recipe_resource{time},
+            recipe_data_directory_path      => $active_parameter_href->{reference_dir},
+            recipe_directory                => $recipe_name . $UNDERSCORE . $reference_version,
+            recipe_name                     => $recipe_name,
             source_environment_commands_ref => $recipe_resource{load_env_ref},
         }
     );
@@ -189,10 +187,7 @@ sub download_gencode_annotation {
     if ( $genome_version eq q{grch37} ) {
         ## Build reformated outfile
         my $reformated_outfile = join $UNDERSCORE,
-          (
-            $genome_version, $recipe_name, q{reformated},
-            q{-} . $reference_version . q{-.gtf}
-          );
+          ( $genome_version, $recipe_name, q{reformated}, q{-} . $reference_version . q{-.gtf} );
         my $reformated_outfile_path = catfile( $reference_dir, $reformated_outfile );
 
         _remove_chr_prefix_rename_chrm(

--- a/lib/MIP/Recipes/Download/Giab.pm
+++ b/lib/MIP/Recipes/Download/Giab.pm
@@ -8,7 +8,6 @@ use File::Basename qw{ dirname };
 use File::Spec::Functions qw{ catfile };
 use open qw{ :encoding(UTF-8) :std };
 use Params::Check qw{ allow check last_error };
-use strict;
 use utf8;
 use warnings;
 use warnings qw{ FATAL utf8 };
@@ -121,8 +120,7 @@ sub download_giab {
     use MIP::Get::Parameter qw{ get_recipe_resources };
     use MIP::Recipes::Download::Get_reference qw{ get_reference };
     use MIP::Script::Setup_script qw{ setup_script };
-    use MIP::Processmanagement::Slurm_processes
-      qw{ slurm_submit_job_no_dependency_dead_end };
+    use MIP::Processmanagement::Slurm_processes qw{ slurm_submit_job_no_dependency_dead_end };
 
     ### PREPROCESSING:
 
@@ -149,18 +147,18 @@ sub download_giab {
     ## Creates recipe directories (info & data & script), recipe script filenames and writes sbatch header
     my ( $recipe_file_path, $recipe_info_path ) = setup_script(
         {
-            active_parameter_href      => $active_parameter_href,
-            core_number                => $recipe_resource{core_number},
-            directory_id               => q{mip_download},
-            filehandle                 => $filehandle,
-            job_id_href                => $job_id_href,
-            memory_allocation          => $recipe_resource{memory},
-            outdata_dir                => $reference_dir,
-            outscript_dir              => $reference_dir,
-            process_time               => $recipe_resource{time},
-            recipe_data_directory_path => $active_parameter_href->{reference_dir},
-            recipe_directory           => $recipe_name . $UNDERSCORE . $reference_version,
-            recipe_name                => $recipe_name,
+            active_parameter_href           => $active_parameter_href,
+            core_number                     => $recipe_resource{core_number},
+            directory_id                    => q{mip_download},
+            filehandle                      => $filehandle,
+            job_id_href                     => $job_id_href,
+            memory_allocation               => $recipe_resource{memory},
+            outdata_dir                     => $reference_dir,
+            outscript_dir                   => $reference_dir,
+            process_time                    => $recipe_resource{time},
+            recipe_data_directory_path      => $active_parameter_href->{reference_dir},
+            recipe_directory                => $recipe_name . $UNDERSCORE . $reference_version,
+            recipe_name                     => $recipe_name,
             source_environment_commands_ref => $recipe_resource{load_env_ref},
         }
     );

--- a/lib/MIP/Recipes/Download/Gnomad_pli_per_gene.pm
+++ b/lib/MIP/Recipes/Download/Gnomad_pli_per_gene.pm
@@ -8,7 +8,6 @@ use File::Basename qw{ dirname fileparse };
 use File::Spec::Functions qw{ catfile };
 use open qw{ :encoding(UTF-8) :std };
 use Params::Check qw{ allow check last_error };
-use strict;
 use utf8;
 use warnings;
 use warnings qw{ FATAL utf8 };
@@ -123,8 +122,7 @@ sub download_gnomad_pli_per_gene {
     use MIP::Program::Gnu::Software::Gnu_grep qw{ gnu_grep };
     use MIP::Recipes::Download::Get_reference qw{ get_reference };
     use MIP::Script::Setup_script qw{ setup_script };
-    use MIP::Processmanagement::Slurm_processes
-      qw{ slurm_submit_job_no_dependency_dead_end };
+    use MIP::Processmanagement::Slurm_processes qw{ slurm_submit_job_no_dependency_dead_end };
 
     ## Constants
     Readonly my $HGNC_SYMBOL_COL_NR => 1;
@@ -155,18 +153,18 @@ sub download_gnomad_pli_per_gene {
     ## Creates recipe directories (info & data & script), recipe script filenames and writes sbatch header
     my ( $recipe_file_path, $recipe_info_path ) = setup_script(
         {
-            active_parameter_href      => $active_parameter_href,
-            core_number                => $recipe_resource{core_number},
-            directory_id               => q{mip_download},
-            filehandle                 => $filehandle,
-            job_id_href                => $job_id_href,
-            memory_allocation          => $recipe_resource{memory},
-            outdata_dir                => $reference_dir,
-            outscript_dir              => $reference_dir,
-            process_time               => $recipe_resource{time},
-            recipe_data_directory_path => $active_parameter_href->{reference_dir},
-            recipe_directory           => $recipe_name . $UNDERSCORE . $reference_version,
-            recipe_name                => $recipe_name,
+            active_parameter_href           => $active_parameter_href,
+            core_number                     => $recipe_resource{core_number},
+            directory_id                    => q{mip_download},
+            filehandle                      => $filehandle,
+            job_id_href                     => $job_id_href,
+            memory_allocation               => $recipe_resource{memory},
+            outdata_dir                     => $reference_dir,
+            outscript_dir                   => $reference_dir,
+            process_time                    => $recipe_resource{time},
+            recipe_data_directory_path      => $active_parameter_href->{reference_dir},
+            recipe_directory                => $recipe_name . $UNDERSCORE . $reference_version,
+            recipe_name                     => $recipe_name,
             source_environment_commands_ref => $recipe_resource{load_env_ref},
         }
     );

--- a/lib/MIP/Recipes/Download/Hapmap.pm
+++ b/lib/MIP/Recipes/Download/Hapmap.pm
@@ -8,7 +8,6 @@ use File::Basename qw{ dirname };
 use File::Spec::Functions qw{ catfile };
 use open qw{ :encoding(UTF-8) :std };
 use Params::Check qw{ allow check last_error };
-use strict;
 use utf8;
 use warnings;
 use warnings qw{ FATAL utf8 };
@@ -121,8 +120,7 @@ sub download_hapmap {
     use MIP::Get::Parameter qw{ get_recipe_resources };
     use MIP::Recipes::Download::Get_reference qw{ get_reference };
     use MIP::Script::Setup_script qw{ setup_script };
-    use MIP::Processmanagement::Slurm_processes
-      qw{ slurm_submit_job_no_dependency_dead_end };
+    use MIP::Processmanagement::Slurm_processes qw{ slurm_submit_job_no_dependency_dead_end };
 
     ### PREPROCESSING:
 
@@ -130,9 +128,8 @@ sub download_hapmap {
     my $log = Log::Log4perl->get_logger( uc q{mip_download} );
 
     ## Unpack parameters
-    my $reference_dir = $active_parameter_href->{reference_dir};
-    my @reference_genome_versions =
-      @{ $active_parameter_href->{reference_genome_versions} };
+    my $reference_dir             = $active_parameter_href->{reference_dir};
+    my @reference_genome_versions = @{ $active_parameter_href->{reference_genome_versions} };
 
     my %recipe_resource = get_recipe_resources(
         {
@@ -151,19 +148,19 @@ sub download_hapmap {
     ## Creates recipe directories (info & data & script), recipe script filenames and writes sbatch header
     my ( $recipe_file_path, $recipe_info_path ) = setup_script(
         {
-            active_parameter_href      => $active_parameter_href,
-            core_number                => $recipe_resource{core_number},
-            directory_id               => q{mip_download},
-            filehandle                 => $filehandle,
-            job_id_href                => $job_id_href,
-            memory_allocation          => $recipe_resource{memory},
-            outdata_dir                => $reference_dir,
-            outscript_dir              => $reference_dir,
-            process_time               => $recipe_resource{time},
-            recipe_data_directory_path => $active_parameter_href->{reference_dir},
-            recipe_directory           => $recipe_name . $UNDERSCORE . $reference_version,
-            recipe_name                => $recipe_name,
-            temp_directory             => $temp_directory,
+            active_parameter_href           => $active_parameter_href,
+            core_number                     => $recipe_resource{core_number},
+            directory_id                    => q{mip_download},
+            filehandle                      => $filehandle,
+            job_id_href                     => $job_id_href,
+            memory_allocation               => $recipe_resource{memory},
+            outdata_dir                     => $reference_dir,
+            outscript_dir                   => $reference_dir,
+            process_time                    => $recipe_resource{time},
+            recipe_data_directory_path      => $active_parameter_href->{reference_dir},
+            recipe_directory                => $recipe_name . $UNDERSCORE . $reference_version,
+            recipe_name                     => $recipe_name,
+            temp_directory                  => $temp_directory,
             source_environment_commands_ref => $recipe_resource{load_env_ref},
         }
     );

--- a/lib/MIP/Recipes/Download/Manta_call_regions.pm
+++ b/lib/MIP/Recipes/Download/Manta_call_regions.pm
@@ -8,7 +8,6 @@ use File::Basename qw{ dirname };
 use File::Spec::Functions qw{ catfile };
 use open qw{ :encoding(UTF-8) :std };
 use Params::Check qw{ allow check last_error };
-use strict;
 use utf8;
 use warnings;
 use warnings qw{ FATAL utf8 };
@@ -121,8 +120,7 @@ sub download_manta_call_regions {
     use MIP::Get::Parameter qw{ get_recipe_resources };
     use MIP::Recipes::Download::Get_reference qw{ get_reference };
     use MIP::Script::Setup_script qw{ setup_script };
-    use MIP::Processmanagement::Slurm_processes
-      qw{ slurm_submit_job_no_dependency_dead_end };
+    use MIP::Processmanagement::Slurm_processes qw{ slurm_submit_job_no_dependency_dead_end };
 
     ### PREPROCESSING:
 
@@ -149,18 +147,18 @@ sub download_manta_call_regions {
     ## Creates recipe directories (info & data & script), recipe script filenames and writes sbatch header
     my ( $recipe_file_path, $recipe_info_path ) = setup_script(
         {
-            active_parameter_href      => $active_parameter_href,
-            core_number                => $recipe_resource{core_number},
-            directory_id               => q{mip_download},
-            filehandle                 => $filehandle,
-            job_id_href                => $job_id_href,
-            memory_allocation          => $recipe_resource{memory},
-            outdata_dir                => $reference_dir,
-            outscript_dir              => $reference_dir,
-            process_time               => $recipe_resource{time},
-            recipe_data_directory_path => $active_parameter_href->{reference_dir},
-            recipe_directory           => $recipe_name . $UNDERSCORE . $reference_version,
-            recipe_name                => $recipe_name,
+            active_parameter_href           => $active_parameter_href,
+            core_number                     => $recipe_resource{core_number},
+            directory_id                    => q{mip_download},
+            filehandle                      => $filehandle,
+            job_id_href                     => $job_id_href,
+            memory_allocation               => $recipe_resource{memory},
+            outdata_dir                     => $reference_dir,
+            outscript_dir                   => $reference_dir,
+            process_time                    => $recipe_resource{time},
+            recipe_data_directory_path      => $active_parameter_href->{reference_dir},
+            recipe_directory                => $recipe_name . $UNDERSCORE . $reference_version,
+            recipe_name                     => $recipe_name,
             source_environment_commands_ref => $recipe_resource{load_env_ref},
         }
     );

--- a/lib/MIP/Recipes/Download/Mills_and_1000g_indels.pm
+++ b/lib/MIP/Recipes/Download/Mills_and_1000g_indels.pm
@@ -8,7 +8,6 @@ use File::Basename qw{ dirname };
 use File::Spec::Functions qw{ catfile };
 use open qw{ :encoding(UTF-8) :std };
 use Params::Check qw{ allow check last_error };
-use strict;
 use utf8;
 use warnings;
 use warnings qw{ FATAL utf8 };
@@ -122,8 +121,7 @@ sub download_mills_and_1000g_indels {
     use MIP::Get::Parameter qw{ get_recipe_resources };
     use MIP::Recipes::Download::Get_reference qw{ get_reference };
     use MIP::Script::Setup_script qw{ setup_script };
-    use MIP::Processmanagement::Slurm_processes
-      qw{ slurm_submit_job_no_dependency_dead_end };
+    use MIP::Processmanagement::Slurm_processes qw{ slurm_submit_job_no_dependency_dead_end };
 
     ### PREPROCESSING:
 
@@ -131,9 +129,8 @@ sub download_mills_and_1000g_indels {
     my $log = Log::Log4perl->get_logger( uc q{mip_download} );
 
     ## Unpack parameters
-    my $reference_dir = $active_parameter_href->{reference_dir};
-    my @reference_genome_versions =
-      @{ $active_parameter_href->{reference_genome_versions} };
+    my $reference_dir             = $active_parameter_href->{reference_dir};
+    my @reference_genome_versions = @{ $active_parameter_href->{reference_genome_versions} };
 
     my %recipe_resource = get_recipe_resources(
         {
@@ -152,19 +149,19 @@ sub download_mills_and_1000g_indels {
     ## Creates recipe directories (info & data & script), recipe script filenames and writes sbatch header
     my ( $recipe_file_path, $recipe_info_path ) = setup_script(
         {
-            active_parameter_href      => $active_parameter_href,
-            core_number                => $recipe_resource{core_number},
-            directory_id               => q{mip_download},
-            filehandle                 => $filehandle,
-            job_id_href                => $job_id_href,
-            memory_allocation          => $recipe_resource{memory},
-            outdata_dir                => $reference_dir,
-            outscript_dir              => $reference_dir,
-            process_time               => $recipe_resource{time},
-            recipe_data_directory_path => $active_parameter_href->{reference_dir},
-            recipe_directory           => $recipe_name . $UNDERSCORE . $reference_version,
-            recipe_name                => $recipe_name,
-            temp_directory             => $temp_directory,
+            active_parameter_href           => $active_parameter_href,
+            core_number                     => $recipe_resource{core_number},
+            directory_id                    => q{mip_download},
+            filehandle                      => $filehandle,
+            job_id_href                     => $job_id_href,
+            memory_allocation               => $recipe_resource{memory},
+            outdata_dir                     => $reference_dir,
+            outscript_dir                   => $reference_dir,
+            process_time                    => $recipe_resource{time},
+            recipe_data_directory_path      => $active_parameter_href->{reference_dir},
+            recipe_directory                => $recipe_name . $UNDERSCORE . $reference_version,
+            recipe_name                     => $recipe_name,
+            temp_directory                  => $temp_directory,
             source_environment_commands_ref => $recipe_resource{load_env_ref},
         }
     );

--- a/lib/MIP/Recipes/Download/Rank_model.pm
+++ b/lib/MIP/Recipes/Download/Rank_model.pm
@@ -8,7 +8,6 @@ use File::Basename qw{ dirname };
 use File::Spec::Functions qw{ catfile };
 use open qw{ :encoding(UTF-8) :std };
 use Params::Check qw{ allow check last_error };
-use strict;
 use utf8;
 use warnings;
 use warnings qw{ FATAL utf8 };
@@ -121,8 +120,7 @@ sub download_rank_model {
     use MIP::Get::Parameter qw{ get_recipe_resources };
     use MIP::Recipes::Download::Get_reference qw{ get_reference };
     use MIP::Script::Setup_script qw{ setup_script };
-    use MIP::Processmanagement::Slurm_processes
-      qw{ slurm_submit_job_no_dependency_dead_end };
+    use MIP::Processmanagement::Slurm_processes qw{ slurm_submit_job_no_dependency_dead_end };
 
     ### PREPROCESSING:
 
@@ -149,18 +147,18 @@ sub download_rank_model {
     ## Creates recipe directories (info & data & script), recipe script filenames and writes sbatch header
     my ( $recipe_file_path, $recipe_info_path ) = setup_script(
         {
-            active_parameter_href      => $active_parameter_href,
-            core_number                => $recipe_resource{core_number},
-            directory_id               => q{mip_download},
-            filehandle                 => $filehandle,
-            job_id_href                => $job_id_href,
-            memory_allocation          => $recipe_resource{memory},
-            outdata_dir                => $reference_dir,
-            outscript_dir              => $reference_dir,
-            process_time               => $recipe_resource{time},
-            recipe_data_directory_path => $active_parameter_href->{reference_dir},
-            recipe_directory           => $recipe_name . $UNDERSCORE . $reference_version,
-            recipe_name                => $recipe_name,
+            active_parameter_href           => $active_parameter_href,
+            core_number                     => $recipe_resource{core_number},
+            directory_id                    => q{mip_download},
+            filehandle                      => $filehandle,
+            job_id_href                     => $job_id_href,
+            memory_allocation               => $recipe_resource{memory},
+            outdata_dir                     => $reference_dir,
+            outscript_dir                   => $reference_dir,
+            process_time                    => $recipe_resource{time},
+            recipe_data_directory_path      => $active_parameter_href->{reference_dir},
+            recipe_directory                => $recipe_name . $UNDERSCORE . $reference_version,
+            recipe_name                     => $recipe_name,
             source_environment_commands_ref => $recipe_resource{load_env_ref},
         }
     );

--- a/lib/MIP/Recipes/Download/Reduced_penetrance.pm
+++ b/lib/MIP/Recipes/Download/Reduced_penetrance.pm
@@ -8,7 +8,6 @@ use File::Basename qw{ dirname };
 use File::Spec::Functions qw{ catfile };
 use open qw{ :encoding(UTF-8) :std };
 use Params::Check qw{ allow check last_error };
-use strict;
 use utf8;
 use warnings;
 use warnings qw{ FATAL utf8 };
@@ -121,8 +120,7 @@ sub download_reduced_penetrance {
     use MIP::Get::Parameter qw{ get_recipe_resources };
     use MIP::Recipes::Download::Get_reference qw{ get_reference };
     use MIP::Script::Setup_script qw{ setup_script };
-    use MIP::Processmanagement::Slurm_processes
-      qw{ slurm_submit_job_no_dependency_dead_end };
+    use MIP::Processmanagement::Slurm_processes qw{ slurm_submit_job_no_dependency_dead_end };
 
     ### PREPROCESSING:
 
@@ -149,18 +147,18 @@ sub download_reduced_penetrance {
     ## Creates recipe directories (info & data & script), recipe script filenames and writes sbatch header
     my ( $recipe_file_path, $recipe_info_path ) = setup_script(
         {
-            active_parameter_href      => $active_parameter_href,
-            core_number                => $recipe_resource{core_number},
-            directory_id               => q{mip_download},
-            filehandle                 => $filehandle,
-            job_id_href                => $job_id_href,
-            memory_allocation          => $recipe_resource{memory},
-            outdata_dir                => $reference_dir,
-            outscript_dir              => $reference_dir,
-            process_time               => $recipe_resource{time},
-            recipe_data_directory_path => $active_parameter_href->{reference_dir},
-            recipe_directory           => $recipe_name . $UNDERSCORE . $reference_version,
-            recipe_name                => $recipe_name,
+            active_parameter_href           => $active_parameter_href,
+            core_number                     => $recipe_resource{core_number},
+            directory_id                    => q{mip_download},
+            filehandle                      => $filehandle,
+            job_id_href                     => $job_id_href,
+            memory_allocation               => $recipe_resource{memory},
+            outdata_dir                     => $reference_dir,
+            outscript_dir                   => $reference_dir,
+            process_time                    => $recipe_resource{time},
+            recipe_data_directory_path      => $active_parameter_href->{reference_dir},
+            recipe_directory                => $recipe_name . $UNDERSCORE . $reference_version,
+            recipe_name                     => $recipe_name,
             source_environment_commands_ref => $recipe_resource{load_env_ref},
         }
     );

--- a/lib/MIP/Recipes/Download/Scout_exons.pm
+++ b/lib/MIP/Recipes/Download/Scout_exons.pm
@@ -8,7 +8,6 @@ use File::Basename qw{ dirname };
 use File::Spec::Functions qw{ catfile };
 use open qw{ :encoding(UTF-8) :std };
 use Params::Check qw{ allow check last_error };
-use strict;
 use utf8;
 use warnings;
 use warnings qw{ FATAL utf8 };
@@ -121,8 +120,7 @@ sub download_scout_exons {
     use MIP::Get::Parameter qw{ get_recipe_resources };
     use MIP::Recipes::Download::Get_reference qw{ get_reference };
     use MIP::Script::Setup_script qw{ setup_script };
-    use MIP::Processmanagement::Slurm_processes
-      qw{ slurm_submit_job_no_dependency_dead_end };
+    use MIP::Processmanagement::Slurm_processes qw{ slurm_submit_job_no_dependency_dead_end };
 
     ### PREPROCESSING:
 
@@ -149,18 +147,18 @@ sub download_scout_exons {
     ## Creates recipe directories (info & data & script), recipe script filenames and writes sbatch header
     my ( $recipe_file_path, $recipe_info_path ) = setup_script(
         {
-            active_parameter_href      => $active_parameter_href,
-            core_number                => $recipe_resource{core_number},
-            directory_id               => q{mip_download},
-            filehandle                 => $filehandle,
-            job_id_href                => $job_id_href,
-            memory_allocation          => $recipe_resource{memory},
-            outdata_dir                => $reference_dir,
-            outscript_dir              => $reference_dir,
-            process_time               => $recipe_resource{time},
-            recipe_data_directory_path => $active_parameter_href->{reference_dir},
-            recipe_directory           => $recipe_name . $UNDERSCORE . $reference_version,
-            recipe_name                => $recipe_name,
+            active_parameter_href           => $active_parameter_href,
+            core_number                     => $recipe_resource{core_number},
+            directory_id                    => q{mip_download},
+            filehandle                      => $filehandle,
+            job_id_href                     => $job_id_href,
+            memory_allocation               => $recipe_resource{memory},
+            outdata_dir                     => $reference_dir,
+            outscript_dir                   => $reference_dir,
+            process_time                    => $recipe_resource{time},
+            recipe_data_directory_path      => $active_parameter_href->{reference_dir},
+            recipe_directory                => $recipe_name . $UNDERSCORE . $reference_version,
+            recipe_name                     => $recipe_name,
             source_environment_commands_ref => $recipe_resource{load_env_ref},
         }
     );

--- a/lib/MIP/Recipes/Download/Sv_vcfanno_config.pm
+++ b/lib/MIP/Recipes/Download/Sv_vcfanno_config.pm
@@ -8,7 +8,6 @@ use File::Basename qw{ dirname };
 use File::Spec::Functions qw{ catfile };
 use open qw{ :encoding(UTF-8) :std };
 use Params::Check qw{ allow check last_error };
-use strict;
 use utf8;
 use warnings;
 use warnings qw{ FATAL utf8 };
@@ -122,8 +121,7 @@ sub download_sv_vcfanno_config {
     use MIP::Program::Gnu::Coreutils qw{ gnu_mv};
     use MIP::Recipes::Download::Get_reference qw{ get_reference };
     use MIP::Script::Setup_script qw{ setup_script };
-    use MIP::Processmanagement::Slurm_processes
-      qw{ slurm_submit_job_no_dependency_dead_end };
+    use MIP::Processmanagement::Slurm_processes qw{ slurm_submit_job_no_dependency_dead_end };
 
     ### PREPROCESSING:
 
@@ -150,18 +148,18 @@ sub download_sv_vcfanno_config {
     ## Creates recipe directories (info & data & script), recipe script filenames and writes sbatch header
     my ( $recipe_file_path, $recipe_info_path ) = setup_script(
         {
-            active_parameter_href      => $active_parameter_href,
-            core_number                => $recipe_resource{core_number},
-            directory_id               => q{mip_download},
-            filehandle                 => $filehandle,
-            job_id_href                => $job_id_href,
-            memory_allocation          => $recipe_resource{memory},
-            outdata_dir                => $reference_dir,
-            outscript_dir              => $reference_dir,
-            process_time               => $recipe_resource{time},
-            recipe_data_directory_path => $active_parameter_href->{reference_dir},
-            recipe_directory           => $recipe_name . $UNDERSCORE . $reference_version,
-            recipe_name                => $recipe_name,
+            active_parameter_href           => $active_parameter_href,
+            core_number                     => $recipe_resource{core_number},
+            directory_id                    => q{mip_download},
+            filehandle                      => $filehandle,
+            job_id_href                     => $job_id_href,
+            memory_allocation               => $recipe_resource{memory},
+            outdata_dir                     => $reference_dir,
+            outscript_dir                   => $reference_dir,
+            process_time                    => $recipe_resource{time},
+            recipe_data_directory_path      => $active_parameter_href->{reference_dir},
+            recipe_directory                => $recipe_name . $UNDERSCORE . $reference_version,
+            recipe_name                     => $recipe_name,
             source_environment_commands_ref => $recipe_resource{load_env_ref},
         }
     );

--- a/lib/MIP/Recipes/Download/Svrank_model.pm
+++ b/lib/MIP/Recipes/Download/Svrank_model.pm
@@ -8,7 +8,6 @@ use File::Basename qw{ dirname };
 use File::Spec::Functions qw{ catfile };
 use open qw{ :encoding(UTF-8) :std };
 use Params::Check qw{ allow check last_error };
-use strict;
 use utf8;
 use warnings;
 use warnings qw{ FATAL utf8 };
@@ -121,8 +120,7 @@ sub download_svrank_model {
     use MIP::Get::Parameter qw{ get_recipe_resources };
     use MIP::Recipes::Download::Get_reference qw{ get_reference };
     use MIP::Script::Setup_script qw{ setup_script };
-    use MIP::Processmanagement::Slurm_processes
-      qw{ slurm_submit_job_no_dependency_dead_end };
+    use MIP::Processmanagement::Slurm_processes qw{ slurm_submit_job_no_dependency_dead_end };
 
     ### PREPROCESSING:
 
@@ -149,18 +147,18 @@ sub download_svrank_model {
     ## Creates recipe directories (info & data & script), recipe script filenames and writes sbatch header
     my ( $recipe_file_path, $recipe_info_path ) = setup_script(
         {
-            active_parameter_href      => $active_parameter_href,
-            core_number                => $recipe_resource{core_number},
-            directory_id               => q{mip_download},
-            filehandle                 => $filehandle,
-            job_id_href                => $job_id_href,
-            memory_allocation          => $recipe_resource{memory},
-            outdata_dir                => $reference_dir,
-            outscript_dir              => $reference_dir,
-            process_time               => $recipe_resource{time},
-            recipe_data_directory_path => $active_parameter_href->{reference_dir},
-            recipe_directory           => $recipe_name . $UNDERSCORE . $reference_version,
-            recipe_name                => $recipe_name,
+            active_parameter_href           => $active_parameter_href,
+            core_number                     => $recipe_resource{core_number},
+            directory_id                    => q{mip_download},
+            filehandle                      => $filehandle,
+            job_id_href                     => $job_id_href,
+            memory_allocation               => $recipe_resource{memory},
+            outdata_dir                     => $reference_dir,
+            outscript_dir                   => $reference_dir,
+            process_time                    => $recipe_resource{time},
+            recipe_data_directory_path      => $active_parameter_href->{reference_dir},
+            recipe_directory                => $recipe_name . $UNDERSCORE . $reference_version,
+            recipe_name                     => $recipe_name,
             source_environment_commands_ref => $recipe_resource{load_env_ref},
         }
     );

--- a/lib/MIP/Recipes/Download/Vcf2cytosure_blacklist_regions.pm
+++ b/lib/MIP/Recipes/Download/Vcf2cytosure_blacklist_regions.pm
@@ -8,7 +8,6 @@ use File::Basename qw{ dirname };
 use File::Spec::Functions qw{ catfile };
 use open qw{ :encoding(UTF-8) :std };
 use Params::Check qw{ allow check last_error };
-use strict;
 use utf8;
 use warnings;
 use warnings qw{ FATAL utf8 };
@@ -120,8 +119,7 @@ sub download_vcf2cytosure_blacklist_regions {
     use MIP::Get::Parameter qw{ get_recipe_resources };
     use MIP::Recipes::Download::Get_reference qw{ get_reference };
     use MIP::Script::Setup_script qw{ setup_script };
-    use MIP::Processmanagement::Slurm_processes
-      qw{ slurm_submit_job_no_dependency_dead_end };
+    use MIP::Processmanagement::Slurm_processes qw{ slurm_submit_job_no_dependency_dead_end };
 
     ### PREPROCESSING:
 
@@ -148,18 +146,18 @@ sub download_vcf2cytosure_blacklist_regions {
     ## Creates recipe directories (info & data & script), recipe script filenames and writes sbatch header
     my ( $recipe_file_path, $recipe_info_path ) = setup_script(
         {
-            active_parameter_href      => $active_parameter_href,
-            core_number                => $recipe_resource{core_number},
-            directory_id               => q{mip_download},
-            filehandle                 => $filehandle,
-            job_id_href                => $job_id_href,
-            memory_allocation          => $recipe_resource{memory},
-            outdata_dir                => $reference_dir,
-            outscript_dir              => $reference_dir,
-            process_time               => $recipe_resource{time},
-            recipe_data_directory_path => $active_parameter_href->{reference_dir},
-            recipe_directory           => $recipe_name . $UNDERSCORE . $reference_version,
-            recipe_name                => $recipe_name,
+            active_parameter_href           => $active_parameter_href,
+            core_number                     => $recipe_resource{core_number},
+            directory_id                    => q{mip_download},
+            filehandle                      => $filehandle,
+            job_id_href                     => $job_id_href,
+            memory_allocation               => $recipe_resource{memory},
+            outdata_dir                     => $reference_dir,
+            outscript_dir                   => $reference_dir,
+            process_time                    => $recipe_resource{time},
+            recipe_data_directory_path      => $active_parameter_href->{reference_dir},
+            recipe_directory                => $recipe_name . $UNDERSCORE . $reference_version,
+            recipe_name                     => $recipe_name,
             source_environment_commands_ref => $recipe_resource{load_env_ref},
         }
     );

--- a/lib/MIP/Recipes/Download/Vcfanno_config.pm
+++ b/lib/MIP/Recipes/Download/Vcfanno_config.pm
@@ -8,7 +8,6 @@ use File::Basename qw{ dirname };
 use File::Spec::Functions qw{ catfile };
 use open qw{ :encoding(UTF-8) :std };
 use Params::Check qw{ allow check last_error };
-use strict;
 use utf8;
 use warnings;
 use warnings qw{ FATAL utf8 };
@@ -18,8 +17,7 @@ use autodie qw{ :all };
 use Readonly;
 
 ## MIPs lib/
-use MIP::Constants
-  qw{ $DOT $DOUBLE_QUOTE $EMPTY_STR $LOG_NAME $NEWLINE $SPACE $UNDERSCORE };
+use MIP::Constants qw{ $DOT $DOUBLE_QUOTE $EMPTY_STR $LOG_NAME $NEWLINE $SPACE $UNDERSCORE };
 
 BEGIN {
 
@@ -123,8 +121,7 @@ sub download_vcfanno_config {
     use MIP::Program::Gnu::Coreutils qw{ gnu_mv};
     use MIP::Recipes::Download::Get_reference qw{ get_reference };
     use MIP::Script::Setup_script qw{ setup_script };
-    use MIP::Processmanagement::Slurm_processes
-      qw{ slurm_submit_job_no_dependency_dead_end };
+    use MIP::Processmanagement::Slurm_processes qw{ slurm_submit_job_no_dependency_dead_end };
 
     ### PREPROCESSING:
 
@@ -151,18 +148,18 @@ sub download_vcfanno_config {
     ## Creates recipe directories (info & data & script), recipe script filenames and writes sbatch header
     my ( $recipe_file_path, $recipe_info_path ) = setup_script(
         {
-            active_parameter_href      => $active_parameter_href,
-            core_number                => $recipe_resource{core_number},
-            directory_id               => q{mip_download},
-            filehandle                 => $filehandle,
-            job_id_href                => $job_id_href,
-            memory_allocation          => $recipe_resource{memory},
-            outdata_dir                => $reference_dir,
-            outscript_dir              => $reference_dir,
-            process_time               => $recipe_resource{time},
-            recipe_data_directory_path => $active_parameter_href->{reference_dir},
-            recipe_directory           => $recipe_name . $UNDERSCORE . $reference_version,
-            recipe_name                => $recipe_name,
+            active_parameter_href           => $active_parameter_href,
+            core_number                     => $recipe_resource{core_number},
+            directory_id                    => q{mip_download},
+            filehandle                      => $filehandle,
+            job_id_href                     => $job_id_href,
+            memory_allocation               => $recipe_resource{memory},
+            outdata_dir                     => $reference_dir,
+            outscript_dir                   => $reference_dir,
+            process_time                    => $recipe_resource{time},
+            recipe_data_directory_path      => $active_parameter_href->{reference_dir},
+            recipe_directory                => $recipe_name . $UNDERSCORE . $reference_version,
+            recipe_name                     => $recipe_name,
             source_environment_commands_ref => $recipe_resource{load_env_ref},
         }
     );

--- a/lib/MIP/Recipes/Download/Vcfanno_functions.pm
+++ b/lib/MIP/Recipes/Download/Vcfanno_functions.pm
@@ -8,7 +8,6 @@ use File::Basename qw{ dirname };
 use File::Spec::Functions qw{ catfile };
 use open qw{ :encoding(UTF-8) :std };
 use Params::Check qw{ allow check last_error };
-use strict;
 use utf8;
 use warnings;
 use warnings qw{ FATAL utf8 };
@@ -18,8 +17,7 @@ use autodie qw{ :all };
 use Readonly;
 
 ## MIPs lib/
-use MIP::Constants
-  qw{ $DOT $DOUBLE_QUOTE $EMPTY_STR $LOG_NAME $NEWLINE $SPACE $UNDERSCORE };
+use MIP::Constants qw{ $DOT $DOUBLE_QUOTE $EMPTY_STR $LOG_NAME $NEWLINE $SPACE $UNDERSCORE };
 
 BEGIN {
 
@@ -123,8 +121,7 @@ sub download_vcfanno_functions {
     use MIP::Program::Gnu::Coreutils qw{ gnu_mv};
     use MIP::Recipes::Download::Get_reference qw{ get_reference };
     use MIP::Script::Setup_script qw{ setup_script };
-    use MIP::Processmanagement::Slurm_processes
-      qw{ slurm_submit_job_no_dependency_dead_end };
+    use MIP::Processmanagement::Slurm_processes qw{ slurm_submit_job_no_dependency_dead_end };
 
     ### PREPROCESSING:
 
@@ -151,18 +148,18 @@ sub download_vcfanno_functions {
     ## Creates recipe directories (info & data & script), recipe script filenames and writes sbatch header
     my ( $recipe_file_path, $recipe_info_path ) = setup_script(
         {
-            active_parameter_href      => $active_parameter_href,
-            core_number                => $recipe_resource{core_number},
-            directory_id               => q{mip_download},
-            filehandle                 => $filehandle,
-            job_id_href                => $job_id_href,
-            memory_allocation          => $recipe_resource{memory},
-            outdata_dir                => $reference_dir,
-            outscript_dir              => $reference_dir,
-            process_time               => $recipe_resource{time},
-            recipe_data_directory_path => $active_parameter_href->{reference_dir},
-            recipe_directory           => $recipe_name . $UNDERSCORE . $reference_version,
-            recipe_name                => $recipe_name,
+            active_parameter_href           => $active_parameter_href,
+            core_number                     => $recipe_resource{core_number},
+            directory_id                    => q{mip_download},
+            filehandle                      => $filehandle,
+            job_id_href                     => $job_id_href,
+            memory_allocation               => $recipe_resource{memory},
+            outdata_dir                     => $reference_dir,
+            outscript_dir                   => $reference_dir,
+            process_time                    => $recipe_resource{time},
+            recipe_data_directory_path      => $active_parameter_href->{reference_dir},
+            recipe_directory                => $recipe_name . $UNDERSCORE . $reference_version,
+            recipe_name                     => $recipe_name,
             source_environment_commands_ref => $recipe_resource{load_env_ref},
         }
     );

--- a/lib/MIP/Recipes/Install/Mip_scripts.pm
+++ b/lib/MIP/Recipes/Install/Mip_scripts.pm
@@ -10,7 +10,6 @@ use List::Util qw{ none };
 use open qw{ :encoding(UTF-8) :std };
 use Params::Check qw{ allow check last_error };
 use Path::Tiny qw{ path };
-use strict;
 use utf8;
 use warnings qw{ FATAL utf8 };
 use warnings;
@@ -75,8 +74,7 @@ sub install_mip_scripts {
 
     my %mip_sub_script = (
         utility_scripts => [qw{ calculate_af.pl max_af.pl }],
-        t =>
-          [qw{ mip_install.test mip_analyse_rd_dna.test mip_core.t mip_analysis.test }],
+        t         => [qw{ mip_install.test mip_analyse_rd_dna.test mip_core.t mip_analysis.test }],
         templates => [
             qw{ 643594-miptest_pedigree.yaml
               gene_panels.bed
@@ -123,7 +121,7 @@ sub install_mip_scripts {
         my @cp_cmds = gnu_cp(
             {
                 force        => 1,
-                infile_path  => catdir( $mip_dir_path, $directory ),
+                infile_path  => catdir( $mip_dir_path,      $directory ),
                 outfile_path => catdir( $conda_prefix_path, q{bin} ),
                 recursive    => 1,
             }
@@ -147,7 +145,7 @@ sub install_mip_scripts {
   SCRIPT:
     foreach my $script (@mip_scripts) {
 
-        my $src_path = catfile( $mip_dir_path,      $script );
+        my $src_path = catfile( $mip_dir_path, $script );
         my $dst_path = catfile( $conda_prefix_path, q{bin}, $script );
         path($src_path)->copy($dst_path);
         path($dst_path)->chmod(q{a+x});

--- a/lib/MIP/Recipes/Install/Vep.pm
+++ b/lib/MIP/Recipes/Install/Vep.pm
@@ -11,7 +11,6 @@ use File::Spec::Functions qw{ catdir catfile devnull };
 use List::MoreUtils qw{ any };
 use open qw{ :encoding(UTF-8) :std };
 use Params::Check qw{ check allow last_error };
-use strict;
 use utf8;
 use warnings qw{ FATAL utf8 };
 use warnings;
@@ -88,8 +87,7 @@ sub install_vep {
 
     if ( not $cache_dir_path and not $reference_dir_path ) {
         $log->fatal(
-q{Please supply a reference directory or a cache directory when installing VEP}
-        );
+            q{Please supply a reference directory or a cache directory when installing VEP});
         $log->fatal(
 q{By default VEP cache and plugins will be downloaded to <reference_dir>/ensembl-tools-release-<version>/cache}
         );
@@ -102,10 +100,10 @@ q{By default VEP cache and plugins will be downloaded to <reference_dir>/ensembl
     ## Setup cache_dir_path
     $cache_dir_path = _setup_cache_dir(
         {
-            cache_dir_path        => $cache_dir_path,
-            container_path        => $container_path,
-            reference_dir_path    => $reference_dir_path,
-            verbose               => $verbose,
+            cache_dir_path     => $cache_dir_path,
+            container_path     => $container_path,
+            reference_dir_path => $reference_dir_path,
+            verbose            => $verbose,
         }
     );
 
@@ -128,10 +126,10 @@ q{By default VEP cache and plugins will be downloaded to <reference_dir>/ensembl
     my @container_cmds = [
         run_container(
             {
-                bind_paths_ref        => [$cache_dir_path],
-                container_path        => $container_path,
-                container_manager     => $CONTAINER_MANAGER,
-                container_cmds_ref    => \@vep_install_cmds,
+                bind_paths_ref     => [$cache_dir_path],
+                container_path     => $container_path,
+                container_manager  => $CONTAINER_MANAGER,
+                container_cmds_ref => \@vep_install_cmds,
             }
         )
     ];
@@ -163,8 +161,8 @@ q{By default VEP cache and plugins will be downloaded to <reference_dir>/ensembl
               [
                 run_container(
                     {
-                        bind_paths_ref        => [$cache_dir_path],
-                        container_path        => $container_path,
+                        bind_paths_ref     => [$cache_dir_path],
+                        container_path     => $container_path,
                         container_manager  => $active_parameter_href->{container_manager},
                         container_cmds_ref => \@vep_install_cmds,
                     }
@@ -243,9 +241,8 @@ sub _install_maxentscan_plugin {
         {
             outfile_path => catfile( dirname( devnull() ), q{stdout} ),
             quiet        => 1,
-            url =>
-              q{http://hollywood.mit.edu/burgelab/maxent/download/fordownload.tar.gz},
-            verbose => 0,
+            url          => q{http://hollywood.mit.edu/burgelab/maxent/download/fordownload.tar.gz},
+            verbose      => 0,
         }
     );
     push @cmds, $PIPE;
@@ -287,8 +284,8 @@ sub _install_loftool_plugin {
     my @cmds = wget(
         {
             outfile_path => catfile( $plugin_dir_path, q{LoFtool_scores.txt} ),
-            url =>
-q{https://raw.githubusercontent.com/Ensembl/VEP_plugins/master/LoFtool_scores.txt},
+            url          =>
+              q{https://raw.githubusercontent.com/Ensembl/VEP_plugins/master/LoFtool_scores.txt},
         }
     );
 
@@ -320,8 +317,8 @@ sub _install_exacpli_plugin {
     my @cmds = wget(
         {
             outfile_path => catfile( $plugin_dir_path, q{ExACpLI_values.txt} ),
-            url =>
-q{https://raw.githubusercontent.com/Ensembl/VEP_plugins/master/ExACpLI_values.txt},
+            url          =>
+              q{https://raw.githubusercontent.com/Ensembl/VEP_plugins/master/ExACpLI_values.txt},
         }
     );
 
@@ -384,9 +381,9 @@ sub _setup_cache_dir {
 
         my @vep_launch_cmds = run_container(
             {
-                container_cmds_ref    => [q{vep}],
-                container_path        => $container_path,
-                container_manager     => $CONTAINER_MANAGER,
+                container_cmds_ref => [q{vep}],
+                container_path     => $container_path,
+                container_manager  => $CONTAINER_MANAGER,
             }
         );
 
@@ -403,8 +400,7 @@ sub _setup_cache_dir {
             $vep_version = q{unknown};
         }
         $cache_dir_path =
-          catdir( $reference_dir_path, q{ensembl-tools-release-} . $vep_version,
-            q{cache} );
+          catdir( $reference_dir_path, q{ensembl-tools-release-} . $vep_version, q{cache} );
 
         $log->warn( q{Setting VEP cache dir to: } . $cache_dir_path );
     }

--- a/lib/MIP/Recipes/Parse.pm
+++ b/lib/MIP/Recipes/Parse.pm
@@ -6,7 +6,6 @@ use charnames qw{ :full :short };
 use English qw{ -no_match_vars };
 use open qw{ :encoding(UTF-8) :std };
 use Params::Check qw{ allow check last_error };
-use strict;
 use utf8;
 use warnings;
 use warnings qw{ FATAL utf8 };

--- a/lib/MIP/Recipes/Pipeline/Analyse_dragen_rd_dna.pm
+++ b/lib/MIP/Recipes/Pipeline/Analyse_dragen_rd_dna.pm
@@ -7,7 +7,6 @@ use English qw{ -no_match_vars };
 use File::Spec::Functions qw{ catdir catfile };
 use open qw{ :encoding(UTF-8) :std };
 use Params::Check qw{ check allow last_error };
-use strict;
 use utf8;
 use warnings;
 use warnings qw{ FATAL utf8 };
@@ -23,8 +22,6 @@ BEGIN {
 
     require Exporter;
     use base qw{ Exporter };
-
-
 
     # Functions and variables which can be optionally exported
     our @EXPORT_OK = qw{ parse_dragen_rd_dna pipeline_analyse_dragen_rd_dna };
@@ -126,7 +123,7 @@ sub parse_dragen_rd_dna {
 
     ## Set analysis constants
     set_container_constants( { active_parameter_href => $active_parameter_href, } );
-    
+
     parse_containers(
         {
             active_parameter_href => $active_parameter_href,
@@ -369,8 +366,7 @@ sub pipeline_analyse_dragen_rd_dna {
     use MIP::Recipes::Analysis::Cadd qw{ analysis_cadd };
     use MIP::Recipes::Analysis::Dragen_dna
       qw{ analysis_dragen_dna_align_vc analysis_dragen_dna_joint_calling };
-    use MIP::Recipes::Analysis::Endvariantannotationblock
-      qw{ analysis_endvariantannotationblock };
+    use MIP::Recipes::Analysis::Endvariantannotationblock qw{ analysis_endvariantannotationblock };
     use MIP::Recipes::Analysis::Frequency_filter qw{ analysis_frequency_filter };
     use MIP::Recipes::Analysis::Mip_vcfparser
       qw{ analysis_mip_vcfparser analysis_mip_vcfparser_sv_wes analysis_mip_vcfparser_sv_wgs };
@@ -386,11 +382,9 @@ sub pipeline_analyse_dragen_rd_dna {
     use MIP::Recipes::Analysis::Variant_annotation qw{ analysis_variant_annotation };
     use MIP::Recipes::Analysis::Vcf_rerun_reformat
       qw{ analysis_vcf_rerun_reformat_sv analysis_vcf_rerun_reformat };
-    use MIP::Recipes::Analysis::Vep
-      qw{ analysis_vep_wgs analysis_vep_sv_wes analysis_vep_sv_wgs };
+    use MIP::Recipes::Analysis::Vep qw{ analysis_vep_wgs analysis_vep_sv_wes analysis_vep_sv_wgs };
     use MIP::Recipes::Analysis::Vt qw{ analysis_vt };
-    use MIP::Recipes::Build::Human_genome_prerequisites
-      qw{ build_human_genome_prerequisites };
+    use MIP::Recipes::Build::Human_genome_prerequisites qw{ build_human_genome_prerequisites };
     use MIP::Recipes::Build::Dragen_rd_dna qw{build_dragen_rd_dna_meta_files};
 
     ### Pipeline specific checks
@@ -439,21 +433,21 @@ sub pipeline_analyse_dragen_rd_dna {
         endvariantannotationblock        => \&analysis_endvariantannotationblock,
         frequency_filter                 => \&analysis_frequency_filter,
         prepareforvariantannotationblock => \&analysis_prepareforvariantannotationblock,
-        rankvariant    => undef,                         # Depends on sample features
-        rhocall_ar     => \&analysis_rhocall_annotate,
-        sacct          => \&analysis_sacct,
-        sv_annotate    => \&analysis_sv_annotate,
-        sv_rankvariant => undef,                         # Depends on sample features
-        sv_reformat    => \&analysis_reformat_sv,
-        sv_vcf_rerun_reformat => \&analysis_vcf_rerun_reformat_sv,
-        sv_varianteffectpredictor => undef,                # Depends on analysis type,
-        sv_vcfparser              => undef,                # Depends on analysis type
+        rankvariant               => undef,                             # Depends on sample features
+        rhocall_ar                => \&analysis_rhocall_annotate,
+        sacct                     => \&analysis_sacct,
+        sv_annotate               => \&analysis_sv_annotate,
+        sv_rankvariant            => undef,                             # Depends on sample features
+        sv_reformat               => \&analysis_reformat_sv,
+        sv_vcf_rerun_reformat     => \&analysis_vcf_rerun_reformat_sv,
+        sv_varianteffectpredictor => undef,                             # Depends on analysis type,
+        sv_vcfparser              => undef,                             # Depends on analysis type
         varianteffectpredictor    => \&analysis_vep_wgs,
-        variant_annotation => \&analysis_variant_annotation,
-        vcfparser_ar       => \&analysis_mip_vcfparser,
-        vcf_rerun_reformat => \&analysis_vcf_rerun_reformat,
-        version_collect_ar => \&analysis_mip_vercollect,
-        vt_ar              => \&analysis_vt,
+        variant_annotation        => \&analysis_variant_annotation,
+        vcfparser_ar              => \&analysis_mip_vcfparser,
+        vcf_rerun_reformat        => \&analysis_vcf_rerun_reformat,
+        version_collect_ar        => \&analysis_mip_vercollect,
+        vt_ar                     => \&analysis_vt,
     );
 
     ## Special case for rankvariants recipe

--- a/lib/MIP/Recipes/Pipeline/Download.pm
+++ b/lib/MIP/Recipes/Pipeline/Download.pm
@@ -7,7 +7,6 @@ use English qw{ -no_match_vars };
 use File::Spec::Functions qw{ catfile };
 use open qw{ :encoding(UTF-8) :std };
 use Params::Check qw{ check allow last_error };
-use strict;
 use utf8;
 use warnings;
 use warnings qw{ FATAL utf8 };
@@ -81,11 +80,9 @@ sub pipeline_download {
     use MIP::Recipes::Download::1000g_omni qw{ download_1000g_omni };
     use MIP::Recipes::Download::1000g_sites qw{ download_1000g_sites };
     use MIP::Recipes::Download::1000g_snps qw{ download_1000g_snps };
-    use MIP::Recipes::Download::Cadd_offline_annotations
-      qw{ download_cadd_offline_annotations };
+    use MIP::Recipes::Download::Cadd_offline_annotations qw{ download_cadd_offline_annotations };
     use MIP::Recipes::Download::Cadd_to_vcf_header qw{ download_cadd_to_vcf_header };
-    use MIP::Recipes::Download::Cadd_whole_genome_snvs
-      qw{ download_cadd_whole_genome_snvs };
+    use MIP::Recipes::Download::Cadd_whole_genome_snvs qw{ download_cadd_whole_genome_snvs };
     use MIP::Recipes::Download::Chromograph_cytoband qw{ download_chromograph_cytoband };
     use MIP::Recipes::Download::Clinvar qw{ download_clinvar };
     use MIP::Recipes::Download::Ctat_resource_lib qw{ download_ctat_resource_lib };
@@ -93,8 +90,7 @@ sub pipeline_download {
     use MIP::Recipes::Download::Dbsnp qw{ download_dbsnp };
     use MIP::Recipes::Download::Delly_exclude qw{ download_delly_exclude };
     use MIP::Recipes::Download::Expansionhunter qw{ download_expansionhunter };
-    use MIP::Recipes::Download::Gatk_mitochondrial_ref
-      qw{ download_gatk_mitochondrial_ref };
+    use MIP::Recipes::Download::Gatk_mitochondrial_ref qw{ download_gatk_mitochondrial_ref };
     use MIP::Recipes::Download::Genbank_haplogroup qw{ download_genbank_haplogroup };
     use MIP::Recipes::Download::Gencode_annotation qw{ download_gencode_annotation };
     use MIP::Recipes::Download::Genomic_superdups qw{ download_genomic_superdups };
@@ -105,8 +101,7 @@ sub pipeline_download {
     use MIP::Recipes::Download::Hapmap qw{ download_hapmap };
     use MIP::Recipes::Download::Human_reference qw{ download_human_reference };
     use MIP::Recipes::Download::Manta_call_regions qw{ download_manta_call_regions };
-    use MIP::Recipes::Download::Mills_and_1000g_indels
-      qw{ download_mills_and_1000g_indels };
+    use MIP::Recipes::Download::Mills_and_1000g_indels qw{ download_mills_and_1000g_indels };
     use MIP::Recipes::Download::Pfam qw{ download_pfam };
     use MIP::Recipes::Download::Rank_model qw{ download_rank_model };
     use MIP::Recipes::Download::Reduced_penetrance qw{ download_reduced_penetrance };
@@ -167,9 +162,7 @@ sub pipeline_download {
     my %job_id;
 
   REFERENCE:
-    while ( my ( $reference_id, $versions_ref ) =
-        each %{ $active_parameter_href->{reference} } )
-    {
+    while ( my ( $reference_id, $versions_ref ) = each %{ $active_parameter_href->{reference} } ) {
 
         next REFERENCE if ( not exists $download_recipe{$reference_id} );
 
@@ -177,8 +170,7 @@ sub pipeline_download {
         foreach my $reference_version ( @{$versions_ref} ) {
 
           GENOME_VERSION:
-            foreach my $genome_version (
-                @{ $active_parameter_href->{reference_genome_versions} } )
+            foreach my $genome_version ( @{ $active_parameter_href->{reference_genome_versions} } )
             {
 
                 my $reference_href =
@@ -208,10 +200,7 @@ sub pipeline_download {
 
                 $log->info( q{Cannot find reference file:} . $outfile_path );
                 $log->info(
-                        q{Will try to download: }
-                      . $reference_id
-                      . q{ version: }
-                      . $reference_version,
+                    q{Will try to download: } . $reference_id . q{ version: } . $reference_version,
                 );
 
                 $download_recipe{$reference_id}->(

--- a/lib/MIP/Recipes/Pipeline/Install.pm
+++ b/lib/MIP/Recipes/Pipeline/Install.pm
@@ -9,7 +9,6 @@ use File::Spec::Functions qw{ catfile };
 use List::Util qw{ any };
 use open qw{ :encoding(UTF-8) :std };
 use Params::Check qw{ check allow last_error };
-use strict;
 use utf8;
 use warnings;
 use warnings qw{ FATAL utf8 };
@@ -81,8 +80,7 @@ sub pipeline_install {
     ## Retrieve logger object now that log_file has been set
     my $log = Log::Log4perl->get_logger($LOG_NAME);
 
-    $log->info( q{Installing MIP into environment: }
-          . $active_parameter_href->{environment_name} );
+    $log->info( q{Installing MIP into environment: } . $active_parameter_href->{environment_name} );
 
     set_container_constants( { active_parameter_href => $active_parameter_href, } );
 

--- a/lib/MIP/Sample_info.pm
+++ b/lib/MIP/Sample_info.pm
@@ -8,7 +8,6 @@ use File::Basename qw{ dirname };
 use File::Spec::Functions qw{ catfile };
 use open qw{ :encoding(UTF-8) :std };
 use Params::Check qw{ allow check last_error };
-use strict;
 use Time::Piece;
 use utf8;
 use warnings;
@@ -249,18 +248,13 @@ sub get_read_group {
           {read_direction_file}{ $infile_prefix . q{_1} } };
 
     my $platform_unit =
-        $fastq_file{flowcell}
-      . $DOT
-      . $fastq_file{lane}
-      . $DOT
-      . $fastq_file{sample_barcode};
+      $fastq_file{flowcell} . $DOT . $fastq_file{lane} . $DOT . $fastq_file{sample_barcode};
 
     ## RG hash
     my %rg = (
         id   => $infile_prefix,
         lane => $fastq_file{lane},
-        lb   => $sample_id
-        ,    ## Add molecular library (Dummy value since the actual LB isn't available)
+        lb => $sample_id, ## Add molecular library (Dummy value since the actual LB isn't available)
         pl => $platform,
         pu => $platform_unit,
         sm => $sample_id,
@@ -444,17 +438,12 @@ sub get_sample_info_sample_recipe_attributes {
     ## Get and return attribute value
     if ( defined $attribute && $attribute ) {
 
-        return $sample_info_href->{sample}{$sample_id}{recipe}{$recipe_name}
-          {$infile}{$attribute};
+        return $sample_info_href->{sample}{$sample_id}{recipe}{$recipe_name}{$infile}{$attribute};
     }
-    if (
-        ref $sample_info_href->{sample}{$sample_id}{recipe}{$recipe_name}{$infile} eq
-        q{HASH} )
-    {
+    if ( ref $sample_info_href->{sample}{$sample_id}{recipe}{$recipe_name}{$infile} eq q{HASH} ) {
 
 ## Get recipe attribute for infile hash
-        return %{ $sample_info_href->{sample}{$sample_id}{recipe}{$recipe_name}{$infile}
-        };
+        return %{ $sample_info_href->{sample}{$sample_id}{recipe}{$recipe_name}{$infile} };
     }
 
     ## No infile level
@@ -626,8 +615,7 @@ sub set_gene_panel {
     my $sample_info_href;
 
     my $tmpl = {
-        aggregate_gene_panel_file =>
-          { store => \$aggregate_gene_panel_file, strict_type => 1, },
+        aggregate_gene_panel_file => { store => \$aggregate_gene_panel_file, strict_type => 1, },
         aggregate_gene_panels_key => {
             defined     => 1,
             required    => 1,
@@ -674,8 +662,7 @@ sub set_gene_panel {
     );
 
     my $ret = $return{stdouts_ref}[0]
-      or $log->logdie(
-        qq{Unable to parse gene panel information from $aggregate_gene_panel_file});
+      or $log->logdie(qq{Unable to parse gene panel information from $aggregate_gene_panel_file});
 
   LINE:
 
@@ -812,8 +799,7 @@ sub set_infile_info {
                 sample_id       => $sample_id,
             }
         );
-        my $sequence_run_type =
-          $attribute{is_interleaved} ? q{interleaved} : q{single-end};
+        my $sequence_run_type = $attribute{is_interleaved} ? q{interleaved} : q{single-end};
         set_sample_file_attribute(
             {
                 attribute       => q{sequence_run_type},
@@ -1212,8 +1198,8 @@ sub set_recipe_outfile_in_sample_info {
 
             if ( defined $parameter_value ) {
 
-                $sample_info_href->{sample}{$sample_id}{recipe}{$recipe_name}
-                  {$parameter_key} = $parameter_value;
+                $sample_info_href->{sample}{$sample_id}{recipe}{$recipe_name}{$parameter_key} =
+                  $parameter_value;
             }
         }
     }
@@ -1404,8 +1390,8 @@ sub set_recipe_metafile_in_sample_info {
 
             if ( defined $parameter_value ) {
 
-                $sample_info_href->{recipe}{$recipe_name}{$metafile_tag}{$parameter_key}
-                  = $parameter_value;
+                $sample_info_href->{recipe}{$recipe_name}{$metafile_tag}{$parameter_key} =
+                  $parameter_value;
             }
         }
     }

--- a/lib/MIP/Script/Utils.pm
+++ b/lib/MIP/Script/Utils.pm
@@ -9,7 +9,6 @@ use File::Basename qw{ basename };
 use File::Spec::Functions qw{ catdir };
 use open qw{ :encoding(UTF-8) :std };
 use Params::Check qw{ check allow last_error };
-use strict;
 use utf8;
 use warnings qw{ FATAL utf8 };
 use warnings;

--- a/lib/MIP/Set/Analysis.pm
+++ b/lib/MIP/Set/Analysis.pm
@@ -6,7 +6,6 @@ use charnames qw{ :full :short };
 use English qw{ -no_match_vars };
 use open qw{ :encoding(UTF-8) :std };
 use Params::Check qw{ allow check last_error };
-use strict;
 use utf8;
 use warnings;
 use warnings qw{ FATAL utf8 };
@@ -124,8 +123,7 @@ sub set_recipe_gatk_variantrecalibration {
 
     check( $tmpl, $arg_href, 1 ) or croak q{Could not parse arguments!};
 
-    use MIP::Recipes::Analysis::Gatk_cnnscorevariants
-      qw{ analysis_gatk_cnnscorevariants };
+    use MIP::Recipes::Analysis::Gatk_cnnscorevariants qw{ analysis_gatk_cnnscorevariants };
 
     ## Use already set gatk_variantrecalibration recipe
     return if ( @{$sample_ids_ref} != 1 );
@@ -133,8 +131,7 @@ sub set_recipe_gatk_variantrecalibration {
     return if ( not $use_cnnscorevariants );
 
     $log->warn(
-q{Switched from VariantRecalibration to CNNScoreVariants for single sample analysis}
-    );
+        q{Switched from VariantRecalibration to CNNScoreVariants for single sample analysis});
 
     ## Use new CNN recipe for single samples
     $analysis_recipe_href->{gatk_variantrecalibration} = \&analysis_gatk_cnnscorevariants;

--- a/lib/MIP/Set/File.pm
+++ b/lib/MIP/Set/File.pm
@@ -7,7 +7,6 @@ use File::Basename qw{ basename dirname fileparse };
 use File::Spec::Functions qw{ catdir catfile splitpath };
 use Params::Check qw{ check allow last_error };
 use open qw{ :encoding(UTF-8) :std };
-use strict;
 use utf8;
 use warnings;
 use warnings qw{ FATAL utf8 };
@@ -107,8 +106,7 @@ sub set_io_files {
   FILE_PATH:
     foreach my $file_path ( @{$file_paths_ref} ) {
 
-        my ( $file_name_prefix, $dirs, $suffix ) =
-          fileparse( $file_path, qr/([.][^.]*)*/sxm );
+        my ( $file_name_prefix, $dirs, $suffix ) = fileparse( $file_path, qr/([.][^.]*)*/sxm );
 
         push @{ $io_recipe_href->{$stream}{file_names} },         basename($file_path);
         push @{ $io_recipe_href->{$stream}{file_name_prefixes} }, $file_name_prefix;
@@ -162,8 +160,7 @@ sub set_io_files {
 
         ## Switch to temp dir for path
         my @file_paths_temp =
-          map { catfile( $temp_directory, $_ ) }
-          @{ $io_recipe_href->{$stream}{file_names} };
+          map { catfile( $temp_directory, $_ ) } @{ $io_recipe_href->{$stream}{file_names} };
 
         set_io_files(
             {
@@ -378,8 +375,7 @@ sub _set_io_files_hash {
     while ( my ( $array_key, $hash_key ) = each %file_map ) {
 
       SUFFIX:
-        while ( my ( $file_index, $suffix ) =
-            each @{ $io_recipe_href->{$stream}{file_suffixes} } )
+        while ( my ( $file_index, $suffix ) = each @{ $io_recipe_href->{$stream}{file_suffixes} } )
         {
 
             my $file = $io_recipe_href->{$stream}{$array_key}[$file_index];

--- a/lib/MIP/Set/Parameter.pm
+++ b/lib/MIP/Set/Parameter.pm
@@ -7,7 +7,6 @@ use English qw{ -no_match_vars };
 use File::Spec::Functions qw{ catdir catfile };
 use open qw{ :encoding(UTF-8) :std };
 use Params::Check qw{ check allow last_error };
-use strict;
 use utf8;
 use warnings;
 use warnings qw{ FATAL utf8 };
@@ -98,7 +97,7 @@ sub set_programs_for_installation {
         and ( scalar @{ $active_parameter_href->{select_programs} } > 0 ) )
     {
         $log->fatal(
-q{"--skip_programs" and "--select_programs" are mutually exclusive command line options}
+            q{"--skip_programs" and "--select_programs" are mutually exclusive command line options}
         );
         exit 1;
     }
@@ -115,8 +114,7 @@ q{"--skip_programs" and "--select_programs" are mutually exclusive command line 
     }
 
     ## Remove programs that are to be skipped
-    delete @{ $active_parameter_href->{container} }
-      { @{ $active_parameter_href->{skip_programs} } };
+    delete @{ $active_parameter_href->{container} }{ @{ $active_parameter_href->{skip_programs} } };
 
     ## Special case for mip_scripts
     @{ $active_parameter_href->{select_programs} } = array_minus(

--- a/lib/MIP/Star.pm
+++ b/lib/MIP/Star.pm
@@ -7,7 +7,6 @@ use English qw{ -no_match_vars };
 use File::Spec::Functions qw{ catfile };
 use open qw{ :encoding(UTF-8) :std };
 use Params::Check qw{ allow check last_error };
-use strict;
 use utf8;
 use warnings;
 use warnings qw{ FATAL utf8 };
@@ -88,8 +87,8 @@ sub check_interleaved_files_for_star {
             ## STAR does not support interleaved fastq files
             if ($is_interleaved) {
                 $log->fatal(q{MIP rd_rna does not support interleaved fastq files});
-                $log->fatal( q{Please deinterleave: }
-                      . catfile( $attribute{mip_infiles_dir}, $file_name ) );
+                $log->fatal(
+                    q{Please deinterleave: } . catfile( $attribute{mip_infiles_dir}, $file_name ) );
                 exit 1;
             }
         }

--- a/lib/MIP/Store.pm
+++ b/lib/MIP/Store.pm
@@ -6,7 +6,6 @@ use charnames qw{ :full :short };
 use English qw{ -no_match_vars };
 use open qw{ :encoding(UTF-8) :std };
 use Params::Check qw{ allow check last_error };
-use strict;
 use utf8;
 use warnings;
 use warnings qw{ FATAL utf8 };
@@ -156,8 +155,8 @@ sub set_analysis_files_to_store {
 
     use MIP::Sample_info qw{ set_file_path_to_store };
 
-    my %analysis_store_file = define_analysis_files_to_store(
-        { active_parameter_href => $active_parameter_href, } );
+    my %analysis_store_file =
+      define_analysis_files_to_store( { active_parameter_href => $active_parameter_href, } );
 
   FILE:
     foreach my $file ( keys %analysis_store_file ) {

--- a/lib/MIP/System_call.pm
+++ b/lib/MIP/System_call.pm
@@ -6,7 +6,6 @@ use charnames qw{ :full :short };
 use English qw{ -no_match_vars };
 use open qw{ :encoding(UTF-8) :std };
 use Params::Check qw{ allow check last_error };
-use strict;
 use utf8;
 use warnings;
 use warnings qw{ FATAL utf8 };

--- a/lib/MIP/Test/Commands.pm
+++ b/lib/MIP/Test/Commands.pm
@@ -9,7 +9,6 @@ use File::Spec::Functions qw  { catdir };
 use FindBin qw{ $Bin };
 use open qw{ :encoding(UTF-8) :std };
 use Params::Check qw{ allow check last_error };
-use strict;
 use Test::More;
 use utf8;
 use warnings qw{ FATAL utf8 };
@@ -97,10 +96,7 @@ sub build_call {
       POSSIBLE_INPUT_NAMES:
         foreach my $input_name (@possible_input_names) {
 
-            if (
-                ref $required_argument_href->{$required_argument}{$input_name} eq
-                q{HASH} )
-            {
+            if ( ref $required_argument_href->{$required_argument}{$input_name} eq q{HASH} ) {
 
                 # Add required_argument
                 push @keys, $required_argument;
@@ -416,14 +412,12 @@ sub test_function {
                 ## Array
                 if ($input_values_ref) {
 
-                    @commands =
-                      $module_function_cref->( { $argument => $input_values_ref, } );
+                    @commands = $module_function_cref->( { $argument => $input_values_ref, } );
                 }
                 elsif ($input_value_href) {
                     ## Hash
 
-                    @commands =
-                      $module_function_cref->( { $argument => $input_value_href, } );
+                    @commands = $module_function_cref->( { $argument => $input_value_href, } );
                 }
                 else {
 
@@ -444,8 +438,8 @@ sub test_function {
             ## Test function_base_command
             _test_base_command(
                 {
-                    base_commands_ref    => [ @commands[ 0 .. $base_commands_index ] ],
-                    do_test_base_command => $do_test_base_command,
+                    base_commands_ref          => [ @commands[ 0 .. $base_commands_index ] ],
+                    do_test_base_command       => $do_test_base_command,
                     expected_base_commands_ref => $function_base_commands_ref,
                     is_self_testing            => $is_self_testing,
                 }
@@ -456,19 +450,14 @@ sub test_function {
 
             if ( exists $is_argument{$expected_return} ) {
 
-                is( $is_argument{$expected_return},
-                    $expected_return, q{Argument: } . $argument );
+                is( $is_argument{$expected_return}, $expected_return, q{Argument: } . $argument );
             }
             else {
               TODO: {
                     local $TODO = q{Self testing should fail in test_function.t}, 1,
                       if ($is_self_testing);
 
-                    is(
-                        join( $SPACE, @commands ),
-                        $expected_return,
-                        q{Argument: } . $argument
-                    );
+                    is( join( $SPACE, @commands ), $expected_return, q{Argument: } . $argument );
                     say {*STDERR} q{#}
                       . $SPACE x $ERROR_MSG_INDENT
                       . q{Command line does not contain expected argument.};
@@ -532,8 +521,7 @@ sub _test_base_command {
     return if ( not $do_test_base_command );
 
     ## Compare base argument string to the expected one
-    if ( ( join $SPACE, @{$base_commands_ref} ) ne
-        ( join $SPACE, @{$expected_base_commands_ref} ) )
+    if ( ( join $SPACE, @{$base_commands_ref} ) ne ( join $SPACE, @{$expected_base_commands_ref} ) )
     {
 
       TODO: {

--- a/lib/MIP/Test/Writefile.pm
+++ b/lib/MIP/Test/Writefile.pm
@@ -6,7 +6,6 @@ use charnames qw{ :full :short };
 use English qw{ -no_match_vars };
 use open qw{ :encoding(UTF-8) :std };
 use Params::Check qw{ allow check last_error };
-use strict;
 use Test::More;
 use utf8;
 use warnings;
@@ -59,9 +58,8 @@ sub test_write_to_file {
             store       => \$base_commands_ref,
             strict_type => 1,
         },
-        module_function_cref =>
-          { defined => 1, required => 1, store => \$module_function_cref, },
-        separator => {
+        module_function_cref => { defined => 1, required => 1, store => \$module_function_cref, },
+        separator            => {
             default     => $SPACE,
             store       => \$separator,
             strict_type => 1,

--- a/lib/MIP/Toml.pm
+++ b/lib/MIP/Toml.pm
@@ -6,7 +6,6 @@ use charnames qw{ :full :short };
 use English qw{ -no_match_vars };
 use open qw{ :encoding(UTF-8) :std };
 use Params::Check qw{ allow check last_error };
-use strict;
 use utf8;
 use warnings;
 use warnings qw{ FATAL utf8 };

--- a/lib/MIP/Unix/Standard_streams.pm
+++ b/lib/MIP/Unix/Standard_streams.pm
@@ -6,7 +6,6 @@ use charnames qw{ :full :short };
 use English qw{ -no_match_vars };
 use open qw{ :encoding(UTF-8) :std };
 use Params::Check qw{ allow check last_error };
-use strict;
 use utf8;
 use warnings;
 use warnings qw{ FATAL utf8 };
@@ -49,14 +48,12 @@ sub unix_standard_streams {
     my $stdoutfile_path_append;
 
     my $tmpl = {
-        filehandle      => { store => \$filehandle, },
-        stderrfile_path => { store => \$stderrfile_path, strict_type => 1, },
-        stderrfile_path_append =>
-          { store => \$stderrfile_path_append, strict_type => 1, },
-        stdinfile_path  => { store => \$stdinfile_path,  strict_type => 1, },
-        stdoutfile_path => { store => \$stdoutfile_path, strict_type => 1, },
-        stdoutfile_path_append =>
-          { store => \$stdoutfile_path_append, strict_type => 1, },
+        filehandle             => { store => \$filehandle, },
+        stderrfile_path        => { store => \$stderrfile_path,        strict_type => 1, },
+        stderrfile_path_append => { store => \$stderrfile_path_append, strict_type => 1, },
+        stdinfile_path         => { store => \$stdinfile_path,         strict_type => 1, },
+        stdoutfile_path        => { store => \$stdoutfile_path,        strict_type => 1, },
+        stdoutfile_path_append => { store => \$stdoutfile_path_append, strict_type => 1, },
     };
 
     check( $tmpl, $arg_href, 1 ) or croak q{Could not parse arguments!};

--- a/lib/MIP/Unix/Write_to_file.pm
+++ b/lib/MIP/Unix/Write_to_file.pm
@@ -6,7 +6,6 @@ use charnames qw{ :full :short };
 use English qw{ -no_match_vars };
 use open qw{ :encoding(UTF-8) :std };
 use Params::Check qw{ allow check last_error };
-use strict;
 use utf8;
 use warnings;
 use warnings qw{ FATAL utf8 };

--- a/lib/MIP/Update/Parameters.pm
+++ b/lib/MIP/Update/Parameters.pm
@@ -6,7 +6,6 @@ use charnames qw{ :full :short };
 use English qw{ -no_match_vars };
 use open qw{ :encoding(UTF-8) :std };
 use Params::Check qw{ check allow last_error };
-use strict;
 use utf8;
 use warnings;
 use warnings qw{ FATAL utf8 };
@@ -19,8 +18,7 @@ BEGIN {
     use base qw{ Exporter };
 
     # Functions and variables which can be optionally exported
-    our @EXPORT_OK =
-      qw{ update_dynamic_config_parameters update_with_dynamic_config_parameters };
+    our @EXPORT_OK = qw{ update_dynamic_config_parameters update_with_dynamic_config_parameters };
 }
 
 sub update_dynamic_config_parameters {
@@ -57,8 +55,7 @@ sub update_dynamic_config_parameters {
         each %{$dynamic_parameter_href} )
     {
 
-        ${$active_parameter_ref} =~
-          s/$dynamic_parameter_name!/$dynamic_parameter_value/xsmgi;
+        ${$active_parameter_ref} =~ s/$dynamic_parameter_name!/$dynamic_parameter_value/xsmgi;
     }
     return;
 }

--- a/lib/MIP/Validate/Case.pm
+++ b/lib/MIP/Validate/Case.pm
@@ -7,7 +7,6 @@ use English qw{ -no_match_vars };
 use File::Spec::Functions qw{ catfile };
 use open qw{ :encoding(UTF-8) :std };
 use Params::Check qw{ allow check last_error };
-use strict;
 use utf8;
 use warnings;
 use warnings qw{ FATAL utf8 };
@@ -71,8 +70,7 @@ sub check_infiles {
     if ( not @{$infiles_ref} ) {
 
         $log->fatal(
-qq{Could not find any fastq files in supplied infiles directory: $infile_directory}
-        );
+            qq{Could not find any fastq files in supplied infiles directory: $infile_directory});
         exit 1;
     }
 
@@ -196,11 +194,8 @@ sub check_sample_ids {
         ## Family_id cannot be the same as sample_id
         if ( $case_id eq $sample_id ) {
 
-            $log->fatal( q{Case_id: '}
-                  . $case_id
-                  . q{' equals sample_id: '}
-                  . $sample_id
-                  . $SINGLE_QUOTE );
+            $log->fatal(
+                q{Case_id: '} . $case_id . q{' equals sample_id: '} . $sample_id . $SINGLE_QUOTE );
             $log->fatal(q{Please make sure that the case_id and sample_id(s) are unique});
             exit 1;
         }
@@ -215,7 +210,7 @@ sub check_sample_ids {
 
             $log->fatal( q{Sample_id: '} . $sample_id . q{' contains '_'} );
             $log->fatal(
-q{Please rename sample_id according to MIP's filename convention, removing the '_'.}
+                q{Please rename sample_id according to MIP's filename convention, removing the '_'.}
             );
             exit 1;
         }

--- a/lib/MIP/Vcf.pm
+++ b/lib/MIP/Vcf.pm
@@ -6,7 +6,6 @@ use charnames qw{ :full :short };
 use English qw{ -no_match_vars };
 use open qw{ :encoding(UTF-8) :std };
 use Params::Check qw{ allow check last_error };
-use strict;
 use utf8;
 use warnings;
 use warnings qw{ FATAL utf8 };
@@ -58,11 +57,7 @@ sub get_sample_ids_from_vcf {
     ## Export MIP_BIND to bind reference path to htslib sif in proxy bin
     my @commands = gnu_export(
         {
-                bash_variable => q{MIP_BIND}
-              . $EQUALS
-              . $vcf_file_path
-              . $COLON
-              . $vcf_file_path,
+            bash_variable => q{MIP_BIND} . $EQUALS . $vcf_file_path . $COLON . $vcf_file_path,
         }
     );
     push @commands, $SEMICOLON;

--- a/lib/MIP/Vcfanno.pm
+++ b/lib/MIP/Vcfanno.pm
@@ -6,7 +6,6 @@ use charnames qw{ :full :short };
 use English qw{ -no_match_vars };
 use open qw{ :encoding(UTF-8) :std };
 use Params::Check qw{ allow check last_error };
-use strict;
 use utf8;
 use warnings;
 use warnings qw{ FATAL utf8 };
@@ -149,8 +148,8 @@ sub check_vcfanno_toml {
         other => [qw{ columns file names ops }],
     );
 
-    my $err_msg = q{ is not defined or empty vcfanno toml features. Please check file: }
-      . $vcfanno_file_toml;
+    my $err_msg =
+      q{ is not defined or empty vcfanno toml features. Please check file: } . $vcfanno_file_toml;
     my @missing_annotations;
 
   ANNOTATION:

--- a/lib/MIP/Vep.pm
+++ b/lib/MIP/Vep.pm
@@ -7,7 +7,6 @@ use English qw{ -no_match_vars };
 use File::Spec::Functions qw{ catdir catfile };
 use open qw{ :encoding(UTF-8) :std };
 use Params::Check qw{ allow check last_error };
-use strict;
 use utf8;
 use warnings;
 use warnings qw{ FATAL utf8 };
@@ -71,8 +70,7 @@ sub check_vep_api_cache_versions {
     ## Check that a version number was picked up
     if ( not $vep_version ) {
         $log->warn(
-q{Could not retrieve VEP version. Skipping checking that VEP api and cache matches.}
-        );
+            q{Could not retrieve VEP version. Skipping checking that VEP api and cache matches.});
         return;
     }
 
@@ -281,8 +279,7 @@ sub _get_vep_cache_species_dir_path {
     foreach my $species_cache (@vep_species_cache) {
 
         ## Get species specific cache dir
-        $vep_cache_species_dir_path =
-          abs_path( catdir( $vep_directory_cache, $species_cache ) );
+        $vep_cache_species_dir_path = abs_path( catdir( $vep_directory_cache, $species_cache ) );
         last if ( -e $vep_cache_species_dir_path );
     }
     return $vep_cache_species_dir_path;
@@ -366,10 +363,8 @@ sub _check_vep_custom_annotation_options {
               . q{ has a not allowed option value '}
               . $option . q{ => }
               . $custom_ann_option_href->{$option} );
-        $log->fatal(
-            q{Allowed options are: } . join $SPACE,
-            @{ $check_vep_annotations{$option}{allow} }
-        );
+        $log->fatal( q{Allowed options are: } . join $SPACE,
+            @{ $check_vep_annotations{$option}{allow} } );
         exit 1;
     }
     return 1;

--- a/lib/MIP/Yaml.pm
+++ b/lib/MIP/Yaml.pm
@@ -5,7 +5,6 @@ use charnames qw{ :full :short };
 use English qw{ -no_match_vars };
 use open qw{ :encoding(UTF-8) :std };
 use Params::Check qw{ check allow last_error };
-use strict;
 use utf8;
 use warnings;
 use warnings qw{ FATAL utf8 };

--- a/t/mip_install.test
+++ b/t/mip_install.test
@@ -4,7 +4,6 @@ use Carp;
 use open qw{ :encoding(UTF-8) :std };
 use charnames qw{ :full :short };
 use English qw{ -no_match_vars };
-use strict;
 use warnings;
 use warnings qw{ FATAL utf8 };
 use utf8;

--- a/utility_scripts/calculate_af.pl
+++ b/utility_scripts/calculate_af.pl
@@ -1,6 +1,5 @@
 #!/usr/bin/env perl
 
-use strict;
 use warnings;
 use Modern::Perl qw{ 2018 };
 use warnings qw( FATAL utf8 );
@@ -47,10 +46,9 @@ elsif ( ( defined($ARGV) ) && ( $ARGV[0] !~ /^-/ ) )
 
 GetOptions(
     'cak|af_key_suffixes:s' => \@af_key_suffixes,
-    'h|help' => sub { print STDOUT $USAGE, "\n"; exit; },    #Display help text
-    'v|version' =>
-      sub { print STDOUT "\ncalculate_af.pl " . $calculate_af_version, "\n\n"; exit; }
-    ,                                                        #Display version number
+    'h|help'    => sub { print STDOUT $USAGE, "\n"; exit; },    #Display help text
+    'v|version' => sub { print STDOUT "\ncalculate_af.pl " . $calculate_af_version, "\n\n"; exit; }
+    ,                                                           #Display version number
 );
 
 #####
@@ -85,8 +83,7 @@ sub read_infile {
     my $af_key_suffixes_ref;
 
     my $tmpl = {
-        af_key_suffixes_ref =>
-          { default => [], strict_type => 1, store => \$af_key_suffixes_ref },
+        af_key_suffixes_ref  => { default => [], strict_type => 1, store => \$af_key_suffixes_ref },
         calculate_af_version => {
             required    => 1,
             defined     => 1,
@@ -126,16 +123,15 @@ sub read_infile {
                         if ( any { $_ eq $af_key_suffix } @$af_key_suffixes_ref )
                         {                               #If element is part of array
 
-                            $af_header{$af_prefix}{$af_key_suffix} =
-                              $key;                     #For writing header
-                            $af_key{$af_prefix}{$af_key_suffix} = undef;
+                            $af_header{$af_prefix}{$af_key_suffix}       = $key; #For writing header
+                            $af_key{$af_prefix}{$af_key_suffix}          = undef;
                             $af_key{ $af_prefix . "_" . $af_key_suffix } = undef;
                         }
                     }
                     else {
 
-                        $af_header{$af_prefix}{$af_key_suffix} = $key; #For writing header
-                        $af_key{$af_prefix}{$af_key_suffix}    = undef;
+                        $af_header{$af_prefix}{$af_key_suffix}       = $key;     #For writing header
+                        $af_key{$af_prefix}{$af_key_suffix}          = undef;
                         $af_key{ $af_prefix . "_" . $af_key_suffix } = undef;
                     }
                 }
@@ -151,9 +147,7 @@ sub read_infile {
 
                     if ( !exists( $af_header{AN}{$af_key_suffix} ) ) {
 
-                        say STDERR "Could not find af_key_suffix: "
-                          . $af_key_suffix
-                          . " in header";
+                        say STDERR "Could not find af_key_suffix: " . $af_key_suffix . " in header";
                         exit 1;
                     }
 
@@ -167,8 +161,7 @@ sub read_infile {
             }
             else {
 
-                foreach my $key ( keys %{ $af_header{AN} } )
-                {    #Either "AN" or "AC" keys will do
+                foreach my $key ( keys %{ $af_header{AN} } ) {    #Either "AN" or "AC" keys will do
 
                     ## Write vcf Header
                     say '##INFO=<ID=AF_'
@@ -346,8 +339,7 @@ sub calculate_af {
 
             $af_key_href->{AF}{$af_key_suffix} =
               $af_key_href->{AC}{$af_key_suffix} / $af_key_href->{AN}{$af_key_suffix};
-            push( @$afs_ref,
-                "AF_" . $af_key_suffix . "=" . $af_key_href->{AF}{$af_key_suffix} );
+            push( @$afs_ref, "AF_" . $af_key_suffix . "=" . $af_key_href->{AF}{$af_key_suffix} );
         }
     }
 }

--- a/utility_scripts/max_af.pl
+++ b/utility_scripts/max_af.pl
@@ -1,6 +1,5 @@
 #!/usr/bin/env perl
 
-use strict;
 use warnings;
 use Modern::Perl qw{ 2018 };
 use warnings qw( FATAL utf8 );


### PR DESCRIPTION
…ly applied by perl

### This PR adds | fixes:

- See above
- All other changes are due to perltidy

### How to test:

- Automatic and continuous test suite

### Expected outcome:
- [ ] Installation, unit and integration test suite pass

### Review:
- [ ] Code review
- [ ] Tests pass

This [version](https://semver.org/) is a:
- [ ] **MAJOR** - when you make incompatible API changes. If applicable record manual test results in PR header
- [ ] **MINOR** - when you add functionality in a backwards compatible manner. If applicable record manual test results in PR header
- [x] **PATCH** - when you make backwards compatible bug fixes or documentation/instructions
