### PR TITLE
Update infile path in rtg_vcfeval

### DIFF
--- a/lib/MIP/Recipes/Analysis/Rtg_vcfeval.pm
+++ b/lib/MIP/Recipes/Analysis/Rtg_vcfeval.pm
@@ -321,10 +321,9 @@ sub analysis_rtg_vcfeval {
 
         rtg_vcfeval(
             {
-                baselinefile_path    => $nist_file_path_prefix . $DOT . q{vcf.gz},
-                bed_regionsfile_path => $nist_bed_file_path,
-                callfile_path        =>
-                  catfile( $rtg_outdirectory_path, $outfile_name_prefix . $DOT . q{vcf.gz} ),
+                baselinefile_path      => $nist_file_path_prefix . $DOT . q{vcf.gz},
+                bed_regionsfile_path   => $nist_bed_file_path,
+                callfile_path          => $infile_path,
                 eval_region_file_path  => $nist_bed_file_path,
                 filehandle             => $filehandle,
                 memory                 => $rtg_memory,


### PR DESCRIPTION
### This PR adds | fixes:

- Feeds the correct infile path for rtg_vcfeval

### How to test:

- Automatic and continuous test suite

### Expected outcome:
- [x] Installation, unit and integration test suite pass

### Review:
- [x] Code review
- [ ] Tests pass

This [version](https://semver.org/) is a:
- [ ] **MAJOR** - when you make incompatible API changes. If applicable record manual test results in PR header
- [ ] **MINOR** - when you add functionality in a backwards compatible manner. If applicable record manual test results in PR header
- [x] **PATCH** - when you make backwards compatible bug fixes or documentation/instructions
