### PR TITLE
feat(deeptrio): turned off as default

### DIFF
--- a/definitions/rd_dna_parameters.yaml
+++ b/definitions/rd_dna_parameters.yaml
@@ -526,7 +526,7 @@ deeptrio:
   associated_recipe:
     - mip
   data_type: SCALAR
-  default: 1
+  default: 0
   file_tag: _deeptrio
   outfile_suffix: ".g.vcf.gz"
   program_executables:

--- a/lib/MIP/Recipes/Pipeline/Analyse_rd_dna.pm
+++ b/lib/MIP/Recipes/Pipeline/Analyse_rd_dna.pm
@@ -643,6 +643,7 @@ sub pipeline_analyse_rd_dna {
     set_recipe_deepvariant(
         {
             analysis_recipe_href => \%analysis_recipe,
+            deeptrio_mode        => $active_parameter_href->{deeptrio},
             sample_info_href     => $sample_info_href,
         }
     );

--- a/lib/MIP/Set/Analysis.pm
+++ b/lib/MIP/Set/Analysis.pm
@@ -35,12 +35,14 @@ sub set_recipe_deepvariant {
 ## Function : Set deeptrio or deepvariant recipe depending on the presence of parent-child duo or trio
 ## Returns  :
 ## Arguments: $analysis_recipe_href => Analysis recipe hash {REF}
+##          : $deeptrio_mode        => Deeptrio mode
 ##          : $sample_info_href     => Sample info hash {HASH}
 
     my ($arg_href) = @_;
 
     ## Flatten argument(s)
     my $analysis_recipe_href;
+    my $deeptrio_mode;
     my $sample_info_href;
 
     my $tmpl = {
@@ -49,6 +51,11 @@ sub set_recipe_deepvariant {
             defined     => 1,
             required    => 1,
             store       => \$analysis_recipe_href,
+            strict_type => 1,
+        },
+        deeptrio_mode => {
+            required    => 1,
+            store       => \$deeptrio_mode,
             strict_type => 1,
         },
         sample_info_href => {
@@ -67,6 +74,9 @@ sub set_recipe_deepvariant {
 
     $analysis_recipe_href->{deepvariant} = \&analysis_deepvariant;
     $analysis_recipe_href->{deeptrio}    = undef;
+
+    ## Return if deeptrio is turned off
+    return if ( not $deeptrio_mode );
 
   CONSTELLATION_STATE:
     foreach my $constellation_state (qw{ has_duo has_trio }) {

--- a/t/set_recipe_deepvariant.t
+++ b/t/set_recipe_deepvariant.t
@@ -60,6 +60,7 @@ $sample_info{has_trio} = 0;
 set_recipe_deepvariant(
     {
         analysis_recipe_href => \%analysis_recipe,
+        deeptrio_mode        => 1,
         sample_info_href     => \%sample_info,
     }
 );
@@ -68,8 +69,8 @@ my %expected_analysis_recipe = (
     deeptrio    => \&analysis_deeptrio,
 );
 
-## Then set deepvariant recipe
-is_deeply( \%analysis_recipe, \%expected_analysis_recipe, q{Set deepvariant recipe for a duo} );
+## Then set deeptrio recipe
+is_deeply( \%analysis_recipe, \%expected_analysis_recipe, q{Set deeptrio recipe for a duo} );
 
 ## When constellation state is a trio
 $sample_info{has_duo}  = 0;
@@ -77,14 +78,30 @@ $sample_info{has_trio} = 1;
 set_recipe_deepvariant(
     {
         analysis_recipe_href => \%analysis_recipe,
+        deeptrio_mode        => 1,
         sample_info_href     => \%sample_info,
     }
 );
 $expected_analysis_recipe{deeptrio}    = \&analysis_deeptrio;
 $expected_analysis_recipe{deepvariant} = undef;
 
+## Then set deeptrio recipe
+is_deeply( \%analysis_recipe, \%expected_analysis_recipe, q{Set deeptrio recipe for a trio} );
+
+## When deeptrio is turned off
+set_recipe_deepvariant(
+    {
+        analysis_recipe_href => \%analysis_recipe,
+        deeptrio_mode        => 0,
+        sample_info_href     => \%sample_info,
+    }
+);
+$expected_analysis_recipe{deeptrio}    = undef;
+$expected_analysis_recipe{deepvariant} = \&analysis_deepvariant;
+
 ## Then set deepvariant recipe
-is_deeply( \%analysis_recipe, \%expected_analysis_recipe, q{Set deepvariant recipe for a trio} );
+is_deeply( \%analysis_recipe, \%expected_analysis_recipe,
+    q{Set deepvariant recipe when deeptrio is turned off} );
 
 ## When constellation state is neither a duo or trio
 $sample_info{has_duo}  = 0;
@@ -92,13 +109,14 @@ $sample_info{has_trio} = 0;
 set_recipe_deepvariant(
     {
         analysis_recipe_href => \%analysis_recipe,
+        deeptrio_mode        => 1,
         sample_info_href     => \%sample_info,
     }
 );
 $expected_analysis_recipe{deeptrio}    = undef;
 $expected_analysis_recipe{deepvariant} = \&analysis_deepvariant;
 
-## Then set bwa mem recipe
+## Then set deepvariant recipe
 is_deeply( \%analysis_recipe, \%expected_analysis_recipe,
     q{Set deepvariant recipe when the case is neither a duo or a trio} );
 


### PR DESCRIPTION
### This PR adds | fixes:
 - Use deepvariant for duos and trios for now. 
 
I don't know if you were working on this already Ram but I was running some samples for the rna project and decided to turn off deeptrio for now. Let me know if you already have something else planned

### How to test:

- Automatic and continuous test suite

### Expected outcome:
- [ ] Installation, unit and integration test suite pass

### Review:
- [ ] Code review
- [ ] Tests pass

This [version](https://semver.org/) is a:
- [ ] **MAJOR** - when you make incompatible API changes. If applicable record manual test results in PR header
- [ ] **MINOR** - when you add functionality in a backwards compatible manner. If applicable record manual test results in PR header
- [ ] **PATCH** - when you make backwards compatible bug fixes or documentation/instructions
