### PR TITLE
feat(refactor): Move sub set_recipe_on_analysis_type

### DIFF
--- a/lib/MIP/Analysis.pm
+++ b/lib/MIP/Analysis.pm
@@ -42,6 +42,7 @@ BEGIN {
       set_recipe_bwa_mem
       set_recipe_deepvariant
       set_recipe_gatk_variantrecalibration
+      set_recipe_on_analysis_type
       update_prioritize_flag
       update_recipe_mode_for_fastq_compatibility
       update_recipe_mode_for_pedigree
@@ -928,6 +929,79 @@ sub set_recipe_gatk_variantrecalibration {
     ## Use new CNN recipe for single samples
     $analysis_recipe_href->{gatk_variantrecalibration} = \&analysis_gatk_cnnscorevariants;
 
+    return;
+}
+
+sub set_recipe_on_analysis_type {
+
+## Function : Set which recipe to use depending on consensus analysis type
+## Returns  :
+## Arguments: $analysis_recipe_href    => Analysis recipe hash {REF}
+##          : $consensus_analysis_type => Consensus analysis type
+
+    my ($arg_href) = @_;
+
+    ## Flatten argument(s)
+    my $analysis_recipe_href;
+    my $consensus_analysis_type;
+
+    my $tmpl = {
+        analysis_recipe_href => {
+            default     => {},
+            defined     => 1,
+            required    => 1,
+            store       => \$analysis_recipe_href,
+            strict_type => 1,
+        },
+        consensus_analysis_type => {
+            defined     => 1,
+            required    => 1,
+            store       => \$consensus_analysis_type,
+            strict_type => 1,
+        },
+    };
+
+    check( $tmpl, $arg_href, 1 ) or croak q{Could not parse arguments!};
+
+    use MIP::Recipes::Analysis::Gatk_variantrecalibration
+      qw{ analysis_gatk_variantrecalibration_wes analysis_gatk_variantrecalibration_wgs };
+    use MIP::Recipes::Analysis::Mip_vcfparser
+      qw{ analysis_mip_vcfparser_sv_wes analysis_mip_vcfparser_sv_wgs };
+    use MIP::Recipes::Analysis::Telomerecat qw{ analysis_telomerecat };
+    use MIP::Recipes::Analysis::Vep qw{ analysis_vep_sv_wes analysis_vep_sv_wgs };
+
+    my %analysis_type_recipe = (
+        vrn => {
+            sv_varianteffectpredictor => \&analysis_vep_sv_wgs,
+            sv_vcfparser              => \&analysis_mip_vcfparser_sv_wgs,
+        },
+        wes => {
+            gatk_variantrecalibration => \&analysis_gatk_variantrecalibration_wes,
+            sv_varianteffectpredictor => \&analysis_vep_sv_wes,
+            sv_vcfparser              => \&analysis_mip_vcfparser_sv_wes,
+        },
+        wgs => {
+            gatk_variantrecalibration => \&analysis_gatk_variantrecalibration_wgs,
+            sv_varianteffectpredictor => \&analysis_vep_sv_wgs,
+            sv_vcfparser              => \&analysis_mip_vcfparser_sv_wgs,
+        },
+    );
+
+    ## If not a defined consensus analysis type in analysis_type_recipe e.g. "mixed"
+    $consensus_analysis_type =
+      ( not exists $analysis_type_recipe{$consensus_analysis_type} )
+      ? q{wgs}
+      : $consensus_analysis_type;
+
+  ANALYSIS_RECIPE:
+    foreach my $recipe_name ( keys %{$analysis_recipe_href} ) {
+
+        next ANALYSIS_RECIPE
+          if ( not exists $analysis_type_recipe{$consensus_analysis_type}{$recipe_name} );
+
+        $analysis_recipe_href->{$recipe_name} =
+          $analysis_type_recipe{$consensus_analysis_type}{$recipe_name};
+    }
     return;
 }
 

--- a/lib/MIP/Analysis.pm
+++ b/lib/MIP/Analysis.pm
@@ -967,7 +967,6 @@ sub set_recipe_on_analysis_type {
       qw{ analysis_gatk_variantrecalibration_wes analysis_gatk_variantrecalibration_wgs };
     use MIP::Recipes::Analysis::Mip_vcfparser
       qw{ analysis_mip_vcfparser_sv_wes analysis_mip_vcfparser_sv_wgs };
-    use MIP::Recipes::Analysis::Telomerecat qw{ analysis_telomerecat };
     use MIP::Recipes::Analysis::Vep qw{ analysis_vep_sv_wes analysis_vep_sv_wgs };
 
     my %analysis_type_recipe = (

--- a/lib/MIP/Recipes/Pipeline/Analyse_dragen_rd_dna.pm
+++ b/lib/MIP/Recipes/Pipeline/Analyse_dragen_rd_dna.pm
@@ -357,9 +357,9 @@ sub pipeline_analyse_dragen_rd_dna {
 
     check( $tmpl, $arg_href, 1 ) or croak q{Could not parse arguments!};
 
-    use MIP::Analysis qw{ set_rankvariants_ar };
+    use MIP::Analysis qw{ set_rankvariants_ar set_recipe_on_analysis_type };
+    use MIP::Parameter qw{ get_cache };
     use MIP::Parse::Reference qw{ parse_references };
-    use MIP::Set::Analysis qw{ set_recipe_on_analysis_type };
 
     ## Recipes
     use MIP::Log::MIP_log4perl qw{ log_display_recipe_for_user };
@@ -460,11 +460,17 @@ sub pipeline_analyse_dragen_rd_dna {
         }
     );
 
+    my $consensus_analysis_type = get_cache(
+        {
+            parameter_href => $parameter_href,
+            parameter_name => q{consensus_analysis_type},
+        }
+    );
     ## Update which recipe to use depending on consensus analysis type
     set_recipe_on_analysis_type(
         {
             analysis_recipe_href    => \%analysis_recipe,
-            consensus_analysis_type => $parameter_href->{cache}{consensus_analysis_type},
+            consensus_analysis_type => $consensus_analysis_type,
         }
     );
 

--- a/lib/MIP/Recipes/Pipeline/Analyse_rd_dna.pm
+++ b/lib/MIP/Recipes/Pipeline/Analyse_rd_dna.pm
@@ -436,10 +436,10 @@ sub pipeline_analyse_rd_dna {
     check( $tmpl, $arg_href, 1 ) or croak q{Could not parse arguments!};
 
     use MIP::Analysis
-      qw{ set_rankvariants_ar set_recipe_bwa_mem set_recipe_deepvariant set_recipe_gatk_variantrecalibration };
+      qw{ set_rankvariants_ar set_recipe_bwa_mem set_recipe_deepvariant set_recipe_gatk_variantrecalibration set_recipe_on_analysis_type };
     use MIP::Log::MIP_log4perl qw{ log_display_recipe_for_user };
+    use MIP::Parameter qw{ get_cache };
     use MIP::Parse::Reference qw{ parse_references };
-    use MIP::Set::Analysis qw{ set_recipe_on_analysis_type };
 
     ## Recipes
     use MIP::Recipes::Analysis::Analysisrunstatus qw{ analysis_analysisrunstatus };
@@ -623,11 +623,17 @@ sub pipeline_analyse_rd_dna {
         }
     );
 
+    my $consensus_analysis_type = get_cache(
+        {
+            parameter_href => $parameter_href,
+            parameter_name => q{consensus_analysis_type},
+        }
+    );
     ## Update which recipe to use depending on consensus analysis type
     set_recipe_on_analysis_type(
         {
             analysis_recipe_href    => \%analysis_recipe,
-            consensus_analysis_type => $parameter_href->{cache}{consensus_analysis_type},
+            consensus_analysis_type => $consensus_analysis_type,
         }
     );
 

--- a/lib/MIP/Recipes/Pipeline/Analyse_rd_dna_vcf_rerun.pm
+++ b/lib/MIP/Recipes/Pipeline/Analyse_rd_dna_vcf_rerun.pm
@@ -328,9 +328,9 @@ sub pipeline_analyse_rd_dna_vcf_rerun {
 
     check( $tmpl, $arg_href, 1 ) or croak q{Could not parse arguments!};
 
-    use MIP::Analysis qw{ set_rankvariants_ar };
+    use MIP::Analysis qw{ set_rankvariants_ar set_recipe_on_analysis_type };
+    use MIP::Parameter qw{ get_cache };
     use MIP::Parse::Reference qw{ parse_references };
-    use MIP::Set::Analysis qw{ set_recipe_on_analysis_type };
 
     ## Recipes
     use MIP::Log::MIP_log4perl qw{ log_display_recipe_for_user };
@@ -427,11 +427,17 @@ sub pipeline_analyse_rd_dna_vcf_rerun {
         }
     );
 
+    my $consensus_analysis_type = get_cache(
+        {
+            parameter_href => $parameter_href,
+            parameter_name => q{consensus_analysis_type},
+        }
+    );
     ## Update which recipe to use depending on consensus analysis type
     set_recipe_on_analysis_type(
         {
             analysis_recipe_href    => \%analysis_recipe,
-            consensus_analysis_type => $parameter_href->{cache}{consensus_analysis_type},
+            consensus_analysis_type => $consensus_analysis_type,
         }
     );
 

--- a/lib/MIP/Set/Analysis.pm
+++ b/lib/MIP/Set/Analysis.pm
@@ -23,83 +23,8 @@ BEGIN {
 
     # Functions and variables which can be optionally exported
     our @EXPORT_OK = qw{
-      set_recipe_on_analysis_type
       set_recipe_star_aln
     };
-}
-
-sub set_recipe_on_analysis_type {
-
-## Function : Set which recipe to use depending on consensus analysis type
-## Returns  :
-## Arguments: $analysis_recipe_href    => Analysis recipe hash {REF}
-##          : $consensus_analysis_type => Consensus analysis type
-
-    my ($arg_href) = @_;
-
-    ## Flatten argument(s)
-    my $analysis_recipe_href;
-    my $consensus_analysis_type;
-
-    my $tmpl = {
-        analysis_recipe_href => {
-            default     => {},
-            defined     => 1,
-            required    => 1,
-            store       => \$analysis_recipe_href,
-            strict_type => 1,
-        },
-        consensus_analysis_type => {
-            defined     => 1,
-            required    => 1,
-            store       => \$consensus_analysis_type,
-            strict_type => 1,
-        },
-    };
-
-    check( $tmpl, $arg_href, 1 ) or croak q{Could not parse arguments!};
-
-    use MIP::Recipes::Analysis::Gatk_variantrecalibration
-      qw{ analysis_gatk_variantrecalibration_wes analysis_gatk_variantrecalibration_wgs };
-    use MIP::Recipes::Analysis::Mip_vcfparser
-      qw{ analysis_mip_vcfparser_sv_wes analysis_mip_vcfparser_sv_wgs };
-    use MIP::Recipes::Analysis::Telomerecat qw{ analysis_telomerecat };
-    use MIP::Recipes::Analysis::Vep qw{ analysis_vep_sv_wes analysis_vep_sv_wgs };
-
-    my %analysis_type_recipe = (
-        vrn => {
-            sv_varianteffectpredictor => \&analysis_vep_sv_wgs,
-            sv_vcfparser              => \&analysis_mip_vcfparser_sv_wgs,
-        },
-        wes => {
-            gatk_variantrecalibration => \&analysis_gatk_variantrecalibration_wes,
-            sv_varianteffectpredictor => \&analysis_vep_sv_wes,
-            sv_vcfparser              => \&analysis_mip_vcfparser_sv_wes,
-        },
-        wgs => {
-            gatk_variantrecalibration => \&analysis_gatk_variantrecalibration_wgs,
-            sv_varianteffectpredictor => \&analysis_vep_sv_wgs,
-            sv_vcfparser              => \&analysis_mip_vcfparser_sv_wgs,
-        },
-    );
-
-    ## If not a defined consensus analysis type e.g. "mixed"
-    if ( not exists $analysis_type_recipe{$consensus_analysis_type} ) {
-
-        ## Use wgs as fallback
-        $consensus_analysis_type = q{wgs};
-    }
-
-  ANALYSIS_RECIPE:
-    foreach my $recipe_name ( keys %{$analysis_recipe_href} ) {
-
-        next ANALYSIS_RECIPE
-          if ( not exists $analysis_type_recipe{$consensus_analysis_type}{$recipe_name} );
-
-        $analysis_recipe_href->{$recipe_name} =
-          $analysis_type_recipe{$consensus_analysis_type}{$recipe_name};
-    }
-    return;
 }
 
 sub set_recipe_star_aln {


### PR DESCRIPTION
- Extend test
- Use get_cache sub instead of traversing parameter hash directly

### This PR adds | fixes:

- See above 

### How to test:

- Automatic and continuous test suite

### Expected outcome:
- [ ] Installation, unit and integration test suite pass

### Review:
- [ ] Code review
- [ ] Tests pass

This [version](https://semver.org/) is a:
- [ ] **MAJOR** - when you make incompatible API changes. If applicable record manual test results in PR header
- [ ] **MINOR** - when you add functionality in a backwards compatible manner. If applicable record manual test results in PR header
- [x] **PATCH** - when you make backwards compatible bug fixes or documentation/instructions
