### PR TITLE
set default gpu number for deepvariant to 0

### DIFF
--- a/definitions/rd_dna_parameters.yaml
+++ b/definitions/rd_dna_parameters.yaml
@@ -215,7 +215,7 @@ recipe_gpu_number:
     - mip
   data_type: HASH
   default:
-    deepvariant: 1
+    deepvariant: 0
     deeptrio: 1
   type: mip
 set_recipe_gpu_number:


### PR DESCRIPTION
### This PR adds | fixes:

- Set deepvariant to use CPUs and not GPUs by default

### How to test:

- Automatic and continuous test suite

### Expected outcome:
- [ ] Installation, unit and integration test suite pass

### Review:
- [ ] Code review
- [ ] Tests pass

This [version](https://semver.org/) is a:
- [ ] **MAJOR** - when you make incompatible API changes. If applicable record manual test results in PR header
- [ ] **MINOR** - when you add functionality in a backwards compatible manner. If applicable record manual test results in PR header
- [x] **PATCH** - when you make backwards compatible bug fixes or documentation/instructions
