### PR TITLE
feat(gatk): rm genotypegvcf DB at the end

### DIFF
--- a/lib/MIP/Recipes/Analysis/Gatk_genotypegvcfs.pm
+++ b/lib/MIP/Recipes/Analysis/Gatk_genotypegvcfs.pm
@@ -319,6 +319,18 @@ sub analysis_gatk_genotypegvcfs {
         );
         say {$filehandle} $NEWLINE;
 
+        ## Clean up
+        say {$filehandle} q{## Remove GenomicsDB};
+        gnu_rm(
+            {
+                filehandle  => $filehandle,
+                force       => 1,
+                infile_path => $genomicsdb_file_path,
+                recursive   => 1,
+            }
+        );
+        say {$filehandle} $NEWLINE;
+
         close $filehandle;
 
         if ( $recipe{mode} == 1 ) {


### PR DESCRIPTION
### This PR adds | fixes:

- Cleanup the genotypegvcf directory by removing the databases after use

### How to test:

- Automatic and continuous test suite

### Expected outcome:
- [ ] Installation, unit and integration test suite pass

### Review:
- [ ] Code review
- [ ] Tests pass

This [version](https://semver.org/) is a:
- [ ] **MAJOR** - when you make incompatible API changes. If applicable record manual test results in PR header
- [ ] **MINOR** - when you add functionality in a backwards compatible manner. If applicable record manual test results in PR header
- [ ] **PATCH** - when you make backwards compatible bug fixes or documentation/instructions
