### PR TITLE
Automatically publish the image of a new release to Docker Hub

### DIFF
--- a/.github/workflows/docker_build_n_push.yml
+++ b/.github/workflows/docker_build_n_push.yml
@@ -1,0 +1,22 @@
+name: Publish to Docker Hub
+
+on:
+ release:
+  types:
+   - created
+
+jobs:
+  docker-image-CI:
+   name: Docker Image CI
+   runs-on: ubuntu-latest
+   steps:
+    - name: Check out git repository
+      uses: actions/checkout@v2
+
+    - name: Publish to Registry
+      uses: elgohr/Publish-Docker-Github-Action@master
+      with:
+        name: clinicalgenomics/mip
+        username: ${{ secrets.DOCKER_USERNAME }}
+        password: ${{ secrets.DOCKER_PASSWORD }}
+        tags: "latest,${{ github.event.release.tag_name }}"


### PR DESCRIPTION
### This PR adds | fixes:
As soon as a new release is created, 2 images are pushed to Docker Hub:
- An image containing version tag (example v2.0.3)
- An image containing "latest" tag

### How to test:
- Check how it's working on my repos (for instance this: https://github.com/Clinical-Genomics/patientMatcher/actions/workflows/docker_build_n_publish.yml)

### Expected outcome:
- [ ] Installation, unit and integration test suite pass

### Review:
- [ ] Code review
- [ ] Tests pass

This [version](https://semver.org/) is a:
- [ ] **MAJOR** - when you make incompatible API changes. If applicable record manual test results in PR header
- [x] **MINOR** - when you add functionality in a backwards compatible manner. If applicable record manual test results in PR header
- [ ] **PATCH** - when you make backwards compatible bug fixes or documentation/instructions
