### PR TITLE
Feature/generate readable commands

### DIFF
--- a/lib/MIP/Program/Singularity.pm
+++ b/lib/MIP/Program/Singularity.pm
@@ -15,7 +15,7 @@ use autodie qw{ :all };
 use Readonly;
 
 ## MIPs lib/
-use MIP::Constants qw{ $COMMA $SPACE };
+use MIP::Constants qw{ $BACKWARD_SLASH $COMMA $NEWLINE $SPACE };
 use MIP::Unix::Standard_streams qw{ unix_standard_streams };
 use MIP::Unix::Write_to_file qw{ unix_write_to_file };
 
@@ -111,6 +111,9 @@ sub singularity_exec {
     if ( @{$container_cmds_ref} ) {
         push @commands, @{$container_cmds_ref};
     }
+
+    ## Split singularity
+    push @commands, $SPACE . $BACKWARD_SLASH . $NEWLINE;
 
     push @commands,
       unix_standard_streams(

--- a/lib/MIP/Program/Singularity.pm
+++ b/lib/MIP/Program/Singularity.pm
@@ -113,7 +113,7 @@ sub singularity_exec {
     }
 
     ## Split singularity
-    push @commands, $SPACE . $BACKWARD_SLASH . $NEWLINE;
+    push @commands, $BACKWARD_SLASH . $NEWLINE;
 
     push @commands,
       unix_standard_streams(

--- a/t/set_executable_container_cmd.t
+++ b/t/set_executable_container_cmd.t
@@ -19,7 +19,7 @@ use Modern::Perl qw{ 2018 };
 
 ## MIPs lib/
 use lib catdir( dirname($Bin), q{lib} );
-use MIP::Constants qw{ $COMMA $SPACE };
+use MIP::Constants qw{ $BACKWARD_SLASH $COMMA $NEWLINE $SPACE };
 use MIP::Test::Fixtures qw{ test_mip_hashes };
 
 BEGIN {
@@ -61,8 +61,7 @@ my %parameter = test_mip_hashes(
 );
 
 ## Given an installation config
-my $install_config_path =
-  catfile( $Bin, qw{ data test_data install_active_parameters.yaml } );
+my $install_config_path = catfile( $Bin, qw{ data test_data install_active_parameters.yaml } );
 $active_parameter{container} =
   { get_install_containers( { install_config_file => $install_config_path, } ) };
 
@@ -80,7 +79,10 @@ my %container_cmd = set_executable_container_cmd(
 );
 
 my $expected_arriba_cmd =
-q{singularity exec --bind reference_dir!/a_dir:opt/conda/share/a_dir docker://docker.io/uhrigs/arriba:1.2.0 /arriba_v1.2.0/arriba};
+q{singularity exec --bind reference_dir!/a_dir:opt/conda/share/a_dir docker://docker.io/uhrigs/arriba:1.2.0 }
+  . $BACKWARD_SLASH
+  . $NEWLINE
+  . q{ /arriba_v1.2.0/arriba};
 
 ## Then return command for how to execute arriba using singularity
 is( $container_cmd{arriba}, $expected_arriba_cmd, q{Set singularity cmd for executable} );
@@ -102,8 +104,7 @@ my $expected_arriba_docker_cmd =
 q{docker run --volume reference_dir!/a_dir:opt/conda/share/a_dir --rm --entrypoint "" docker://docker.io/uhrigs/arriba:1.2.0 /arriba_v1.2.0/arriba};
 
 ## Then return command for how to execute arriba using docker
-is( $container_cmd{arriba}, $expected_arriba_docker_cmd,
-    q{Set docker cmd for executable} );
+is( $container_cmd{arriba}, $expected_arriba_docker_cmd, q{Set docker cmd for executable} );
 
 ## Given "no_executable_in_image" as executable value
 my $no_executable_in_image = q{bwakit};


### PR DESCRIPTION
### This PR adds | fixes:

- Splits the command strings in the sbatch scripts in such a way that the base command starts in a new line


For example, it will reformat this.. 
```
singularity exec --bind /home/ramprasad.neethiraj/analysis/rare_disease_test:/home/ramprasad.neethiraj/analysis/rare_disease_test,/home/proj/stage/housekeeper-bundles:/home/proj/stage/housekeeper-bundles,/home/proj/production/demultiplexed-runs:/home/proj/production/demultiplexed-runs,/home/proj/development/rare-disease/references_9.0:/home/proj/development/rare-disease/references_9.0,/home/proj/stage/rare-disease:/home/proj/stage/rare-disease,/home/proj/production/rare-disease/cases/justhusky:/home/proj/production/rare-disease/cases/justhusky,/home/ramprasad.neethiraj/analysis/rare_disease_test/temp_dir/"$SLURM_JOB_ID":/run/user/$(id -u) docker://docker.io/clinicalgenomics/bwa:0.7.17  bwa mem -K 100000000 -t 36 -R "@RG\tID:earlycasualcaiman_171015_HHT5NDSXX_XXXXXX_lane1\tLB:earlycasualcaiman\tPL:ILLUMINA\tPU:HHT5NDSXX.1.XXXXXX\tSM:earlycasualcaiman" /home/proj/development/rare-disease/references_9.0/grch37_homo_sapiens_-d5-.fasta /home/ramprasad.neethiraj/analysis/rare_disease_test/justhusky/wgs/earlycasualcaiman/fastq/1_171015_HHT5NDSXX_earlycasualcaiman_XXXXXX_1.fastq.gz /home/ramprasad.neethiraj/analysis/rare_disease_test/justhusky/wgs/earlycasualcaiman/fastq/1_171015_HHT5NDSXX_earlycasualcaiman_XXXXXX_2.fastq.gz | singularity exec --bind /home/ramprasad.neethiraj/analysis/rare_disease_test/analysis_deepvar1:/home/ramprasad.neethiraj/analysis/rare_disease_test/analysis_deepvar1,/home/proj/development/rare-disease/references_9.0:/home/proj/development/rare-disease/references_9.0,/home/ramprasad.neethiraj/analysis/rare_disease_test/temp_dir/$SLURM_JOB_ID:/home/ramprasad.neethiraj/analysis/rare_disease_test/temp_dir/$SLURM_JOB_ID,/home/ramprasad.neethiraj/analysis/rare_disease_test/temp_dir/"$SLURM_JOB_ID":/run/user/$(id -u) docker://docker.io/clinicalgenomics/htslib:1.11  samtools view --output-fmt BAM --threads 36 -h -S -u - | singularity exec --bind /home/ramprasad.neethiraj/analysis/rare_disease_test/analysis_deepvar1:/home/ramprasad.neethiraj/analysis/rare_disease_test/analysis_deepvar1,/home/proj/development/rare-disease/references_9.0:/home/proj/development/rare-disease/references_9.0,/home/ramprasad.neethiraj/analysis/rare_disease_test/temp_dir/$SLURM_JOB_ID:/home/ramprasad.neethiraj/analysis/rare_disease_test/temp_dir/$SLURM_JOB_ID,/home/ramprasad.neethiraj/analysis/rare_disease_test/temp_dir/"$SLURM_JOB_ID":/run/user/$(id -u) docker://docker.io/clinicalgenomics/htslib:1.11  samtools sort --output-fmt BAM --threads 36 -m 2G -T /home/ramprasad.neethiraj/analysis/rare_disease_test/temp_dir/$SLURM_JOB_ID/samtools_sort_temp -o /home/ramprasad.neethiraj/analysis/rare_disease_test/analysis_deepvar1/earlycasualcaiman/bwa_mem/earlycasualcaiman_171015_HHT5NDSXX_XXXXXX_lane1_sorted.bam /dev/stdin
```
 
   to look like this

```
singularity exec --bind /home/ramprasad.neethiraj/analysis/rare_disease_test:/home/ramprasad.neethiraj/analysis/rare_disease_test,/home/proj/stage/housekeeper-bundles:/home/proj/stage/housekeeper-bundles,/home/proj/production/demultiplexed-runs:/home/proj/production/demultiplexed-runs,/home/proj/development/rare-disease/references_9.0:/home/proj/development/rare-disease/references_9.0,/home/proj/stage/rare-disease:/home/proj/stage/rare-disease,/home/proj/production/rare-disease/cases/justhusky:/home/proj/production/rare-disease/cases/justhusky,/home/ramprasad.neethiraj/analysis/rare_disease_test/temp_dir/"$SLURM_JOB_ID":/run/user/$(id -u) docker://docker.io/clinicalgenomics/bwa:0.7.17  \
 bwa mem -K 100000000 -t 36 -R "@RG\tID:earlycasualcaiman_171015_HHT5NDSXX_XXXXXX_lane1\tLB:earlycasualcaiman\tPL:ILLUMINA\tPU:HHT5NDSXX.1.XXXXXX\tSM:earlycasualcaiman" /home/proj/development/rare-disease/references_9.0/grch37_homo_sapiens_-d5-.fasta /home/ramprasad.neethiraj/analysis/rare_disease_test/justhusky/wgs/earlycasualcaiman/fastq/1_171015_HHT5NDSXX_earlycasualcaiman_XXXXXX_1.fastq.gz /home/ramprasad.neethiraj/analysis/rare_disease_test/justhusky/wgs/earlycasualcaiman/fastq/1_171015_HHT5NDSXX_earlycasualcaiman_XXXXXX_2.fastq.gz | singularity exec --bind /home/ramprasad.neethiraj/analysis/rare_disease_test/analysis_deepvar1:/home/ramprasad.neethiraj/analysis/rare_disease_test/analysis_deepvar1,/home/proj/development/rare-disease/references_9.0:/home/proj/development/rare-disease/references_9.0,/home/ramprasad.neethiraj/analysis/rare_disease_test/temp_dir/$SLURM_JOB_ID:/home/ramprasad.neethiraj/analysis/rare_disease_test/temp_dir/$SLURM_JOB_ID,/home/ramprasad.neethiraj/analysis/rare_disease_test/temp_dir/"$SLURM_JOB_ID":/run/user/$(id -u) docker://docker.io/clinicalgenomics/htslib:1.11  \
 samtools view --output-fmt BAM --threads 36 -h -S -u - | singularity exec --bind /home/ramprasad.neethiraj/analysis/rare_disease_test/analysis_deepvar1:/home/ramprasad.neethiraj/analysis/rare_disease_test/analysis_deepvar1,/home/proj/development/rare-disease/references_9.0:/home/proj/development/rare-disease/references_9.0,/home/ramprasad.neethiraj/analysis/rare_disease_test/temp_dir/$SLURM_JOB_ID:/home/ramprasad.neethiraj/analysis/rare_disease_test/temp_dir/$SLURM_JOB_ID,/home/ramprasad.neethiraj/analysis/rare_disease_test/temp_dir/"$SLURM_JOB_ID":/run/user/$(id -u) docker://docker.io/clinicalgenomics/htslib:1.11  \
 samtools sort --output-fmt BAM --threads 36 -m 2G -T /home/ramprasad.neethiraj/analysis/rare_disease_test/temp_dir/$SLURM_JOB_ID/samtools_sort_temp -o /home/ramprasad.neethiraj/analysis/rare_disease_test/analysis_deepvar1/earlycasualcaiman/bwa_mem/earlycasualcaiman_171015_HHT5NDSXX_XXXXXX_lane1_sorted.bam /dev/stdin
```

### How to test:

- Automatic and continuous test suite

### Expected outcome:
- [ ] Installation, unit and integration test suite pass

### Review:
- [ ] Code review
- [ ] Tests pass

This [version](https://semver.org/) is a:
- [ ] **MAJOR** - when you make incompatible API changes. If applicable record manual test results in PR header
- [x] **MINOR** - when you add functionality in a backwards compatible manner. If applicable record manual test results in PR header
- [ ] **PATCH** - when you make backwards compatible bug fixes or documentation/instructions
