### PR TITLE
feat(bwa-mem2): 2.0 --> 2.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 **Tools**
 bcftools: 1.10.2-hd2cd319_0 -> 1.11-h7c999a4_0
+bwa-mem2 2.0 -> 2.2
 chanjo: 4.2.0 -> 4.6
 deepvariant: 1.0.0  
 glnexus: v1.2.7

--- a/containers/bwa-mem2/Dockerfile
+++ b/containers/bwa-mem2/Dockerfile
@@ -1,19 +1,31 @@
 ################## BASE IMAGE ######################
 
-FROM clinicalgenomics/mip_base:2.1
+FROM ubuntu:bionic
 
 ################## METADATA ######################
 
-LABEL base_image="clinicalgenomics/mip_base:2.1"
-LABEL version="1"
+LABEL base_image="ubuntu:bionic"
+LABEL version="2"
 LABEL software="bwa-mem2"
-LABEL software.version="2.0"
+LABEL software.version="2.2"
 LABEL extra.binaries="bwa-mem2"
 LABEL maintainer="Clinical-Genomics/MIP"
 
-RUN conda install bwa-mem2=2.0=he513fc3_0
+## Install curl
+RUN apt-get update && \
+    apt-get install -y --no-install-recommends \
+    ca-certificates \
+    curl \
+    libbz2-dev \
+    libreadline-dev && \
+    apt-get clean && \
+    apt-get purge && \
+    rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
 
-## Clean up after conda
-RUN /opt/conda/bin/conda clean -tipsy
+WORKDIR /app
 
-WORKDIR /data/
+## Install bwa-mem2
+RUN curl -L https://github.com/bwa-mem2/bwa-mem2/releases/download/v2.2/bwa-mem2-2.2_x64-linux.tar.bz2 \
+  | tar jxf -
+
+ENV PATH=/app/bwa-mem2-2.2_x64-linux:${PATH}

--- a/definitions/rd_dna_panel_parameters.yaml
+++ b/definitions/rd_dna_panel_parameters.yaml
@@ -273,7 +273,7 @@ bwa_mem:
   associated_recipe:
     - mip
   data_type: SCALAR
-  default: 1
+  default: 0
   file_tag: _sorted
   outfile_suffix: ".bam"
   program_executables:
@@ -294,7 +294,7 @@ bwa_mem2:
   associated_recipe:
     - mip
   data_type: SCALAR
-  default: 0
+  default: 1
   file_tag: _sorted
   outfile_suffix: ".bam"
   program_executables:

--- a/definitions/rd_dna_parameters.yaml
+++ b/definitions/rd_dna_parameters.yaml
@@ -390,7 +390,7 @@ bwa_mem:
   associated_recipe:
     - mip
   data_type: SCALAR
-  default: 1
+  default: 0
   file_tag: _sorted
   outfile_suffix: ".bam"
   program_executables:
@@ -412,7 +412,7 @@ bwa_mem2:
   associated_recipe:
     - mip
   data_type: SCALAR
-  default: 0
+  default: 1
   file_tag: _sorted
   outfile_suffix: ".bam"
   program_executables:

--- a/lib/MIP/Cli/Mip/Analyse/Rd_dna.pm
+++ b/lib/MIP/Cli/Mip/Analyse/Rd_dna.pm
@@ -92,7 +92,7 @@ sub run {
         # BWA human genome reference file endings
         bwa_build_reference => [qw{ .bwt .ann .amb .pac .sa }],
 
-        bwa_mem2_build_reference => [qw{ .0123 .ann .amb .bwt.2bit.64 .bwt.8bit.32 .pac }],
+        bwa_mem2_build_reference => [qw{ .0123 .ann .amb .bwt.2bit.64 .pac }],
 
         exome_target_bed => [qw{ .interval_list .pad100.interval_list }],
 

--- a/lib/MIP/Cli/Mip/Analyse/Rd_dna_panel.pm
+++ b/lib/MIP/Cli/Mip/Analyse/Rd_dna_panel.pm
@@ -95,7 +95,7 @@ sub run {
         # BWA human genome reference file endings
         bwa_build_reference => [qw{ .bwt .ann .amb .pac .sa }],
 
-        bwa_mem2_build_reference => [qw{ .0123 .ann .amb .bwt.2bit.64 .bwt.8bit.32 .pac }],
+        bwa_mem2_build_reference => [qw{ .0123 .ann .amb .bwt.2bit.64 .pac }],
 
         exome_target_bed => [qw{ .interval_list .pad100.interval_list }],
 

--- a/t/data/test_data/miptest_install_config.yaml
+++ b/t/data/test_data/miptest_install_config.yaml
@@ -33,7 +33,7 @@ container:
   bwa-mem2:
     executable:
       bwa-mem2:
-    uri: docker.io/clinicalgenomics/bwa-mem2:2.0
+    uri: docker.io/clinicalgenomics/bwa-mem2:2.2
   bedtools:
     executable:
       bedtools:

--- a/templates/mip_install_config.yaml
+++ b/templates/mip_install_config.yaml
@@ -25,7 +25,7 @@ container:
   bwa-mem2:
     executable:
       bwa-mem2:
-    uri: docker.io/clinicalgenomics/bwa-mem2:2.0
+    uri: docker.io/clinicalgenomics/bwa-mem2:2.2
   bedtools:
     executable:
       bedtools:


### PR DESCRIPTION
### This PR adds | fixes:

- Updates bwa-mem2 to version 2.2. 

The issue with certain fastq files persists. 
E.g. when running fastq pair 5_171015_HKG2VCCXX-21-undetermined_ADM1274A1_XXXXXX_{1,2}.fastq.gz. Bwa-mem2 truncates the quality string of read `ST-E00269:46:HKG2VCCXX:5:2201:14113:4034`, causing samtools to fail. Mapping with the original bwa does not lead to this truncation. The read and quality string has the same length in the fastq file. It works if that read is removed from the fastq file. I'll see if I can formulate this in an issue on the mem2 repo

We are still using mem2 when doing the gender estimation so it might still be useful o update.

### How to test:

- Automatic and continuous test suite

### Expected outcome:
- [ ] Installation, unit and integration test suite pass

### Review:
- [ ] Code review
- [ ] Tests pass

This [version](https://semver.org/) is a:
- [ ] **MAJOR** - when you make incompatible API changes. If applicable record manual test results in PR header
- [ ] **MINOR** - when you add functionality in a backwards compatible manner. If applicable record manual test results in PR header
- [ ] **PATCH** - when you make backwards compatible bug fixes or documentation/instructions
