### PR TITLE
feat(salmon): rename outfile

### DIFF
--- a/definitions/rd_rna_parameters.yaml
+++ b/definitions/rd_rna_parameters.yaml
@@ -290,7 +290,7 @@ salmon_quant:
     - mip
   data_type: SCALAR
   default: 1
-  file_tag: quant
+  file_tag: _quant
   outfile_suffix: ".sf"
   program_executables:
     - pigz

--- a/lib/MIP/Recipes/Analysis/Salmon_quant.pm
+++ b/lib/MIP/Recipes/Analysis/Salmon_quant.pm
@@ -17,7 +17,7 @@ use List::MoreUtils qw{ uniq };
 use Readonly;
 
 ## MIPs lib/
-use MIP::Constants qw{ $LOG_NAME $NEWLINE $SPACE };
+use MIP::Constants qw{ $EMPTY_STR $LOG_NAME $NEWLINE $SPACE $UNDERSCORE };
 
 BEGIN {
 
@@ -127,8 +127,9 @@ sub analysis_salmon_quant {
 
     check( $tmpl, $arg_href, 1 ) or croak q{Could not parse arguments!};
 
-    use MIP::File_info qw{ get_sample_file_attribute };
-    use MIP::File_info qw{ get_io_files parse_io_outfiles };
+    use MIP::File_info
+      qw{ get_io_files get_sample_file_attribute get_sample_fastq_file_lanes parse_io_outfiles };
+    use MIP::Program::Gnu::Coreutils qw{ gnu_cp };
     use MIP::Program::Pigz qw{ pigz };
     use MIP::Program::Salmon qw{ salmon_quant };
     use MIP::Processmanagement::Processes qw{ submit_recipe };
@@ -166,18 +167,23 @@ sub analysis_salmon_quant {
         }
     );
 
-    ## Set outfile
-    my $recipe_dir = catdir( $active_parameter_href->{outdata_dir}, $sample_id, $recipe_name );
-    my $file_path  = catfile( $recipe_dir, $recipe{file_tag} . $recipe{outfile_suffix} );
-
+    ## Join infile lanes
+    my $lanes_id = join $EMPTY_STR,
+      get_sample_fastq_file_lanes(
+        {
+            file_info_href => $file_info_href,
+            sample_id      => $sample_id,
+        }
+      );
     %io = (
         %io,
         parse_io_outfiles(
             {
-                chain_id       => $recipe{job_id_chain},
-                id             => $sample_id,
-                file_info_href => $file_info_href,
-                file_paths_ref => [$file_path],
+                chain_id               => $recipe{job_id_chain},
+                id                     => $sample_id,
+                file_info_href         => $file_info_href,
+                file_name_prefixes_ref =>
+                  [ $sample_id . $UNDERSCORE . q{lanes} . $UNDERSCORE . $lanes_id ],
                 outdata_dir    => $active_parameter_href->{outdata_dir},
                 parameter_href => $parameter_href,
                 recipe_name    => $recipe_name,
@@ -246,7 +252,7 @@ sub analysis_salmon_quant {
         my @read_1_fastq_paths =
           @infile_paths[ grep { !( $_ % 2 ) } 0 .. $#infile_paths ];
 
-        # Odd array indexes get a 1 remainder and are evalauted as true
+        # Odd array indexes get a 1 remainder and are evaluated as true
         my @read_2_fastq_paths = @infile_paths[ grep { $_ % 2 } 0 .. $#infile_paths ];
 
         salmon_quant(
@@ -279,6 +285,17 @@ sub analysis_salmon_quant {
         );
         say {$filehandle} $NEWLINE;
     }
+
+    say {$filehandle} q{## Rename salmon quant file};
+    gnu_cp(
+        {
+            filehandle   => $filehandle,
+            force        => 1,
+            infile_path  => q{quant.sf},
+            outfile_path => $outfile_path,
+        }
+    );
+    say {$filehandle} $NEWLINE;
 
     ## Close filehandleS
     close $filehandle or $log->logcroak(q{Could not close filehandle});

--- a/lib/MIP/Recipes/Analysis/Salmon_quant.pm
+++ b/lib/MIP/Recipes/Analysis/Salmon_quant.pm
@@ -291,7 +291,7 @@ sub analysis_salmon_quant {
         {
             filehandle   => $filehandle,
             force        => 1,
-            infile_path  => q{quant.sf},
+            infile_path  => catfile( $outdir_path, q{quant.sf} ),
             outfile_path => $outfile_path,
         }
     );

--- a/t/analysis_salmon_quant.t
+++ b/t/analysis_salmon_quant.t
@@ -47,7 +47,7 @@ diag(   q{Test analysis_salmon_quant from Salmon_quant.pm}
       . $SPACE
       . $EXECUTABLE_NAME );
 
-my $log = test_log( { log_name => q{MIP}, no_screen => 1, } );
+test_log( { log_name => q{MIP}, no_screen => 1, } );
 
 ## Given analysis parameters
 my $recipe_name    = q{salmon_quant};
@@ -71,6 +71,7 @@ my %file_info = test_mip_hashes(
         recipe_name   => $recipe_name,
     }
 );
+$file_info{$sample_id}{lanes} = [1];
 
 my %job_id;
 my %parameter = test_mip_hashes(
@@ -79,16 +80,16 @@ my %parameter = test_mip_hashes(
         recipe_name   => $recipe_name,
     }
 );
-$parameter{$recipe_name}{file_tag}       = q{salmon};
+$parameter{$recipe_name}{file_tag} = q{salmon};
 
 test_add_io_for_recipe(
     {
-        file_info_href    => \%file_info,
-        id                => $sample_id,
+        file_info_href => \%file_info,
+        id             => $sample_id,
         outfile_suffix => q{.quant},
-        parameter_href    => \%parameter,
-        recipe_name       => $recipe_name,
-        step              => q{fastq},
+        parameter_href => \%parameter,
+        recipe_name    => $recipe_name,
+        step           => q{fastq},
     }
 );
 


### PR DESCRIPTION
### This PR adds | fixes:

- renames generic salmon outfile name (quant.sf) to sample specific same

### How to test:

- Automatic and continuous test suite

### Expected outcome:
- [ ] Installation, unit and integration test suite pass

### Review:
- [ ] Code review
- [ ] Tests pass

This [version](https://semver.org/) is a:
- [ ] **MAJOR** - when you make incompatible API changes. If applicable record manual test results in PR header
- [ ] **MINOR** - when you add functionality in a backwards compatible manner. If applicable record manual test results in PR header
- [ ] **PATCH** - when you make backwards compatible bug fixes or documentation/instructions
