### PR TITLE
feat(rna_resources): increase star, star-fusion, arriba resources

### DIFF
--- a/definitions/rd_rna_parameters.yaml
+++ b/definitions/rd_rna_parameters.yaml
@@ -129,7 +129,7 @@ recipe_time:
   data_type: HASH
   default:
     analysisrunstatus: 1
-    arriba_ar: 3
+    arriba_ar: 4
     bcftools_merge: 1
     blobfish: 1
     bootstrapann: 2
@@ -156,8 +156,8 @@ recipe_time:
     rseqc: 3
     sacct: 1
     salmon_quant: 5
-    star_aln: 6
-    star_fusion: 8
+    star_aln: 8
+    star_fusion: 10
     stringtie_ar: 2
     svdb_merge_fusion: 1
     trim_galore_ar: 6
@@ -170,7 +170,6 @@ recipe_memory:
   data_type: HASH
   default:
     analysisrunstatus: 1
-    arriba_ar: 3
     dna_vcf_reformat: 2
     gatk_asereadcounter: 25
     gatk_variantfiltration: 8
@@ -182,7 +181,6 @@ recipe_memory:
     rseqc: 30
     salmon_quant: 2
     star_aln: 3
-    star_fusion: 3
     stringtie_ar: 2
     trim_galore_ar: 5
     varianteffectpredictor: 12

--- a/definitions/rd_rna_parameters.yaml
+++ b/definitions/rd_rna_parameters.yaml
@@ -219,7 +219,7 @@ recipe_core_number:
     sacct: 1
     salmon_quant: 20
     star_aln: 36
-    star_fusion: 24
+    star_fusion: 36
     stringtie_ar: 36
     svdb_merge_fusion: 1
     megafusion_ar: 1

--- a/definitions/rd_rna_parameters.yaml
+++ b/definitions/rd_rna_parameters.yaml
@@ -170,6 +170,7 @@ recipe_memory:
   data_type: HASH
   default:
     analysisrunstatus: 1
+    build_sj_tracks: 8
     dna_vcf_reformat: 2
     gatk_asereadcounter: 25
     gatk_variantfiltration: 8
@@ -178,7 +179,7 @@ recipe_memory:
     picardtools_collectrnaseqmetrics: 5
     picardtools_mergesamfiles: 5
     preseq_ar: 8
-    rseqc: 30
+    rseqc: 35
     salmon_quant: 2
     star_aln: 3
     stringtie_ar: 2


### PR DESCRIPTION
### This PR adds | fixes:

Ran into a sample with a lot of reads causing memory failures and timeouts

- Increases memory and time for the arriba, star and star-fusion recipes

### How to test:

- Automatic and continuous test suite

### Expected outcome:
- [ ] Installation, unit and integration test suite pass

### Review:
- [ ] Code review
- [ ] Tests pass

This [version](https://semver.org/) is a:
- [ ] **MAJOR** - when you make incompatible API changes. If applicable record manual test results in PR header
- [ ] **MINOR** - when you add functionality in a backwards compatible manner. If applicable record manual test results in PR header
- [ ] **PATCH** - when you make backwards compatible bug fixes or documentation/instructions
