### PR TITLE
update starfusion

### DIFF
--- a/lib/MIP/Recipes/Analysis/Star_fusion.pm
+++ b/lib/MIP/Recipes/Analysis/Star_fusion.pm
@@ -260,7 +260,7 @@ sub analysis_star_fusion {
 
     say {$filehandle} q{## Remove intermediary files};
   FILE_TAG:
-    foreach my $file_tag (qw{ _STARgenome _STARpass1 }) {
+    foreach my $file_tag (qw{ _STARgenome _STARpass1 _starF_checkpoints }) {
 
         gnu_rm(
             {

--- a/t/data/test_data/install_active_parameters.yaml
+++ b/t/data/test_data/install_active_parameters.yaml
@@ -179,7 +179,7 @@ container:
       prep_genome_lib.pl: /usr/local/src/STAR-Fusion/ctat-genome-lib-builder/prep_genome_lib.pl
       remove_long_intron_readthru_transcripts.pl: /usr/local/src/STAR-Fusion/ctat-genome-lib-builder/util/remove_long_intron_readthru_transcripts.pl
       restrict_genome_to_chr_entries.pl: /usr/local/src/STAR-Fusion/ctat-genome-lib-builder/util/restrict_genome_to_chr_entries.pl
-    uri: docker.io/trinityctat/starfusion:1.9.0
+    uri: docker.io/trinityctat/starfusion:1.10.0
   stranger:
     executable:
       stranger: ~

--- a/t/data/test_data/miptest_install_config.yaml
+++ b/t/data/test_data/miptest_install_config.yaml
@@ -190,7 +190,7 @@ container:
       remove_long_intron_readthru_transcripts.pl: /usr/local/src/STAR-Fusion/ctat-genome-lib-builder/util/remove_long_intron_readthru_transcripts.pl
       restrict_genome_to_chr_entries.pl: /usr/local/src/STAR-Fusion/ctat-genome-lib-builder/util/restrict_genome_to_chr_entries.pl
       STAR-Fusion: /usr/local/src/STAR-Fusion/STAR-Fusion
-    uri: docker.io/trinityctat/starfusion:1.9.0
+    uri: docker.io/trinityctat/starfusion:1.10.0
   stranger:
     executable:
       stranger:

--- a/templates/mip_install_config.yaml
+++ b/templates/mip_install_config.yaml
@@ -193,7 +193,7 @@ container:
       remove_long_intron_readthru_transcripts.pl: /usr/local/src/STAR-Fusion/ctat-genome-lib-builder/util/remove_long_intron_readthru_transcripts.pl
       restrict_genome_to_chr_entries.pl: /usr/local/src/STAR-Fusion/ctat-genome-lib-builder/util/restrict_genome_to_chr_entries.pl
       STAR-Fusion: /usr/local/src/STAR-Fusion/STAR-Fusion
-    uri: docker.io/trinityctat/starfusion:1.9.0
+    uri: docker.io/trinityctat/starfusion:1.10.0
   stranger:
     executable:
       stranger:


### PR DESCRIPTION
### This PR adds | fixes:

- Update starfusion from 1.9.0 to 1.10.0

### How to test:

- Automatic and continuous test suite

### Expected outcome:
- [x] Installation, unit and integration test suite pass

### Review:
- [x] Code review
- [x] Tests pass

This [version](https://semver.org/) is a:
- [ ] **MAJOR** - when you make incompatible API changes. If applicable record manual test results in PR header
- [x] **MINOR** - when you add functionality in a backwards compatible manner. If applicable record manual test results in PR header
- [ ] **PATCH** - when you make backwards compatible bug fixes or documentation/instructions
