### PR TITLE
feat(rna): resource bumps and fixes

### DIFF
--- a/definitions/rd_rna_parameters.yaml
+++ b/definitions/rd_rna_parameters.yaml
@@ -157,7 +157,7 @@ recipe_time:
     megafusion_ar: 1
     multiqc_ar: 1
     merge_fusion_reports: 1
-    picardtools_collectrnaseqmetrics: 2
+    picardtools_collectrnaseqmetrics: 4
     picardtools_mergesamfiles: 2
     preseq_ar: 2
     qccollect_ar: 1
@@ -165,7 +165,7 @@ recipe_time:
     sacct: 1
     salmon_quant: 5
     star_aln: 8
-    star_fusion: 10
+    star_fusion: 16
     stringtie_ar: 2
     svdb_merge_fusion: 1
     trim_galore_ar: 6
@@ -181,11 +181,12 @@ recipe_memory:
     analysisrunstatus: 1
     build_sj_tracks: 8
     dna_vcf_reformat: 2
+    fusion_report: 15
     gatk_asereadcounter: 25
     gatk_variantfiltration: 8
     genebody_coverage: 16
     multiqc_ar: 10
-    picardtools_collectrnaseqmetrics: 5
+    picardtools_collectrnaseqmetrics: 10
     picardtools_mergesamfiles: 5
     preseq_ar: 8
     rseqc: 35

--- a/lib/MIP/Recipes/Analysis/Arriba.pm
+++ b/lib/MIP/Recipes/Analysis/Arriba.pm
@@ -153,6 +153,8 @@ sub analysis_arriba {
     use MIP::Script::Setup_script qw{ setup_script };
     use MIP::Unix::Write_to_file qw{ unix_write_to_file };
 
+    Readonly my $SCALING_FACTOR => 0.75;
+
     ### PREPROCESSING:
 
     ## Retrieve logger object
@@ -364,6 +366,8 @@ sub analysis_arriba {
     ## Sort BAM before visualization
     my $sorted_bam_file = $outfile_path_prefix . $DOT . q{bam};
     my $thread_memory   = int( $recipe{memory} / $recipe{core_number} );
+    ## Allow for process overhead
+    $thread_memory = int( $thread_memory * $SCALING_FACTOR );
     samtools_sort(
         {
             filehandle            => $filehandle,

--- a/lib/MIP/Recipes/Analysis/Fusion_report.pm
+++ b/lib/MIP/Recipes/Analysis/Fusion_report.pm
@@ -283,7 +283,7 @@ sub analysis_fusion_report {
             {
                 alignment_file_path      => $bam_file_path,
                 annotation_file_path     => $active_parameter_href->{transcript_annotation},
-                cytoband_file_path       => $active_parameter_href->{arriba_cytoband_path},
+                cytoband_file_path       => $active_parameter_href->{fusion_cytoband_path},
                 filehandle               => $filehandle,
                 fusion_file_path         => $fusion_file_path,
                 outfile_path             => $outfile{$tag}{file_path},

--- a/templates/mip_download_rd_rna_config_-1.0-.yaml
+++ b/templates/mip_download_rd_rna_config_-1.0-.yaml
@@ -48,7 +48,7 @@ reference_feature:
         outfile_decompress: gzip
         url_prefix: ftp://ftp.ebi.ac.uk/pub/databases/gencode/Gencode_human/release_34/
       v37:
-        file: gencode.v37.annotation.gtf.gz
+        file: gencode.v37.primary_assembly.annotation.gtf.gz
         outfile: grch38_gencode_annotation_-v37-.gtf.gz
         outfile_decompress: gzip
         url_prefix: ftp://ftp.ebi.ac.uk/pub/databases/gencode/Gencode_human/release_37/

--- a/templates/mip_install_config.yaml
+++ b/templates/mip_install_config.yaml
@@ -117,7 +117,7 @@ container:
   mip:
     executable:
       mip:
-    uri: docker.io/clinicalgenomics/mip:9.1.3
+    uri: docker.io/clinicalgenomics/mip
   multiqc:
     executable:
       multiqc:


### PR DESCRIPTION
### This PR adds | fixes:

- Use the gencode annotation covering the primary assembly instead of only the chromosomes
- Scaled down the memory used for samtools sort
- RNA resource bumps

### How to test:

- Automatic and continuous test suite

### Expected outcome:
- [ ] Installation, unit and integration test suite pass

### Review:
- [ ] Code review
- [ ] Tests pass

This [version](https://semver.org/) is a:
- [ ] **MAJOR** - when you make incompatible API changes. If applicable record manual test results in PR header
- [ ] **MINOR** - when you add functionality in a backwards compatible manner. If applicable record manual test results in PR header
- [ ] **PATCH** - when you make backwards compatible bug fixes or documentation/instructions
