### PR TITLE
Feature/rseqc build

### DIFF
--- a/containers/rseqc/Dockerfile
+++ b/containers/rseqc/Dockerfile
@@ -5,13 +5,13 @@ FROM clinicalgenomics/mip_base:2.1
 ################## METADATA ######################
 
 LABEL base_image="clinicalgenomics/mip_base:2.1"
-LABEL version="2"
+LABEL version="3"
 LABEL software="rseqc"
-LABEL software.version="3.0.1"
+LABEL software.version="4.0.0"
 LABEL extra.binaries="rseqc"
 LABEL maintainer="Clinical-Genomics/MIP"
 
-RUN conda install rseqc=3.0.1 ucsc-wigtobigwig
+RUN conda install rseqc=4.0.0 ucsc-wigtobigwig
 RUN conda clean -ya
 
 WORKDIR /data/

--- a/t/data/test_data/miptest_install_config.yaml
+++ b/t/data/test_data/miptest_install_config.yaml
@@ -158,11 +158,11 @@ container:
       junction_saturation.py:
       read_distribution.py:
       read_duplication.py:
-    uri: clinicalgenomics/rseqc:4.0.0
+    uri: docker.io/clinicalgenomics/rseqc:4.0.0
   rtg-tools:
     executable:
       rtg:
-    uri: realtimegenomics/rtg-tools:3.12
+    uri: docker.io/realtimegenomics/rtg-tools:3.12
   salmon:
     executable:
       salmon:

--- a/t/data/test_data/miptest_install_config.yaml
+++ b/t/data/test_data/miptest_install_config.yaml
@@ -158,7 +158,7 @@ container:
       junction_saturation.py:
       read_distribution.py:
       read_duplication.py:
-    uri: quay.io/biocontainers/rseqc:4.0.0--py38h4a8c8d9_1
+    uri: clinicalgenomics/rseqc:4.0.0
   rtg-tools:
     executable:
       rtg:

--- a/templates/mip_install_config.yaml
+++ b/templates/mip_install_config.yaml
@@ -161,7 +161,7 @@ container:
       junction_saturation.py:
       read_distribution.py:
       read_duplication.py:
-    uri: quay.io/biocontainers/rseqc:4.0.0--py38h4a8c8d9_1
+    uri: clinicalgenomics/rseqc:4.0.0
   rtg-tools:
     executable:
       rtg:

--- a/templates/mip_install_config.yaml
+++ b/templates/mip_install_config.yaml
@@ -117,7 +117,7 @@ container:
   mip:
     executable:
       mip:
-    uri: docker.io/clinicalgenomics/mip
+    uri: docker.io/clinicalgenomics/mip:develop
   multiqc:
     executable:
       multiqc:

--- a/templates/mip_install_config.yaml
+++ b/templates/mip_install_config.yaml
@@ -161,7 +161,7 @@ container:
       junction_saturation.py:
       read_distribution.py:
       read_duplication.py:
-    uri: clinicalgenomics/rseqc:4.0.0
+    uri: docker.io/clinicalgenomics/rseqc:4.0.0
   rtg-tools:
     executable:
       rtg:


### PR DESCRIPTION
### This PR adds | fixes:

- The biocontainer version of rseqc lacked wigtobigwig so this PR updates the clinical genomics build of rseqc
- locks the image of mip to a somewhat recent version of develop so that MIP don't repeatedly fetches and converts the most recent docker image of mip

### How to test:

- Automatic and continuous test suite

### Expected outcome:
- [ ] Installation, unit and integration test suite pass

### Review:
- [ ] Code review
- [ ] Tests pass

This [version](https://semver.org/) is a:
- [ ] **MAJOR** - when you make incompatible API changes. If applicable record manual test results in PR header
- [ ] **MINOR** - when you add functionality in a backwards compatible manner. If applicable record manual test results in PR header
- [ ] **PATCH** - when you make backwards compatible bug fixes or documentation/instructions
