### PR TITLE
feat(atomize): Turns off atomize

### DIFF
--- a/lib/MIP/Recipes/Analysis/Bcftools_core.pm
+++ b/lib/MIP/Recipes/Analysis/Bcftools_core.pm
@@ -237,11 +237,8 @@ sub analysis_bcftools_core {
 
     bcftools_norm(
         {
-            atomize           => 1,
-            atom_overlaps     => $DOT,
             filehandle        => $filehandle,
             infile_path       => q{-},
-            old_rec_tag       => 1,
             remove_duplicates => 1,
         }
     );

--- a/lib/MIP/Recipes/Analysis/Expansionhunter.pm
+++ b/lib/MIP/Recipes/Analysis/Expansionhunter.pm
@@ -337,13 +337,10 @@ sub analysis_expansionhunter {
         say {$filehandle} $NEWLINE;
         bcftools_norm(
             {
-                atomize       => 1,
-                atom_overlaps => $DOT,
-                filehandle    => $filehandle,
-                infile_path   => $decompose_infile_path_prefix . q{.bcf},
-                multiallelic  => q{-},
-                old_rec_tag   => 1,
-                outfile_path  => $decompose_outfile_path,
+                filehandle   => $filehandle,
+                infile_path  => $decompose_infile_path_prefix . q{.bcf},
+                multiallelic => q{-},
+                outfile_path => $decompose_outfile_path,
             }
         );
         say {$filehandle} $NEWLINE;

--- a/lib/MIP/Recipes/Analysis/Gatk_cnnscorevariants.pm
+++ b/lib/MIP/Recipes/Analysis/Gatk_cnnscorevariants.pm
@@ -277,12 +277,9 @@ sub analysis_gatk_cnnscorevariants {
         $mv_infile_path = $norm_outfile_path;
         bcftools_norm(
             {
-                atomize         => 1,
-                atom_overlaps   => $DOT,
                 filehandle      => $filehandle,
                 infile_path     => $cnn_outfile_path,
                 multiallelic    => $DASH,
-                old_rec_tag     => 1,
                 outfile_path    => $norm_outfile_path,
                 output_type     => q{v},
                 reference_path  => $referencefile_path,

--- a/lib/MIP/Recipes/Analysis/Gatk_variantrecalibration.pm
+++ b/lib/MIP/Recipes/Analysis/Gatk_variantrecalibration.pm
@@ -336,12 +336,9 @@ sub analysis_gatk_variantrecalibration_wes {
           $outfile_path_prefix . $UNDERSCORE . q{normalized} . $outfile_suffix;
         bcftools_norm(
             {
-                atomize         => 1,
-                atom_overlaps   => $DOT,
                 filehandle      => $filehandle,
                 infile_path     => $norm_infile_path,
                 multiallelic    => $DASH,
-                old_rec_tag     => 1,
                 outfile_path    => $norm_outfile_path,
                 output_type     => q{v},
                 reference_path  => $referencefile_path,
@@ -423,12 +420,9 @@ sub analysis_gatk_variantrecalibration_wes {
           $outfile_path_prefix . $UNDERSCORE . q{selected_normalized} . $outfile_suffix;
         bcftools_norm(
             {
-                atomize        => 1,
-                atom_overlaps  => $DOT,
                 filehandle     => $filehandle,
                 infile_path    => $outfile_path,
                 multiallelic   => $DASH,
-                old_rec_tag    => 1,
                 outfile_path   => $selected_norm_outfile_path,
                 output_type    => q{v},
                 reference_path => $referencefile_path,
@@ -890,12 +884,9 @@ sub analysis_gatk_variantrecalibration_wgs {
           $outfile_path_prefix . $UNDERSCORE . q{normalized} . $outfile_suffix;
         bcftools_norm(
             {
-                atomize        => 1,
-                atom_overlaps  => $DOT,
                 filehandle     => $filehandle,
                 infile_path    => $outfile_path,
                 multiallelic   => $DASH,
-                old_rec_tag    => 1,
                 output_type    => q{v},
                 outfile_path   => $bcftools_outfile_path,
                 reference_path => $referencefile_path,

--- a/lib/MIP/Recipes/Analysis/Plink.pm
+++ b/lib/MIP/Recipes/Analysis/Plink.pm
@@ -316,11 +316,8 @@ sub analysis_plink {
     my $uniq_outfile_path = $outfile_path_prefix . $UNDERSCORE . q{no_indels_ann_uniq.vcf};
     bcftools_norm(
         {
-            atomize           => 1,
-            atom_overlaps     => $DOT,
             filehandle        => $filehandle,
             infile_path       => $DASH,
-            old_rec_tag       => 1,
             outfile_path      => $uniq_outfile_path,
             remove_duplicates => 1,
         }

--- a/lib/MIP/Recipes/Analysis/Sv_combinevariantcallsets.pm
+++ b/lib/MIP/Recipes/Analysis/Sv_combinevariantcallsets.pm
@@ -299,13 +299,10 @@ sub analysis_sv_combinevariantcallsets {
         say {$filehandle} q{## Split multiallelic variants};
         bcftools_norm(
             {
-                atomize       => 1,
-                atom_overlaps => $DOT,
-                filehandle    => $filehandle,
-                infile_path   => $outfile_path,
-                multiallelic  => q{-},
-                old_rec_tag   => 1,
-                outfile_path  => $outfile_path_prefix . $alt_file_tag . $outfile_suffix,
+                filehandle   => $filehandle,
+                infile_path  => $outfile_path,
+                multiallelic => q{-},
+                outfile_path => $outfile_path_prefix . $alt_file_tag . $outfile_suffix,
             }
         );
         say {$filehandle} $NEWLINE;
@@ -582,13 +579,10 @@ sub _preprocess_joint_callers_file {
             say {$filehandle} q{## Split multiallelic variants};
             bcftools_norm(
                 {
-                    atomize       => 1,
-                    atom_overlaps => $DOT,
-                    filehandle    => $filehandle,
-                    infile_path   => $infile_path,
-                    multiallelic  => q{-},
-                    old_rec_tag   => 1,
-                    outfile_path  => $decompose_outfile_path,
+                    filehandle   => $filehandle,
+                    infile_path  => $infile_path,
+                    multiallelic => q{-},
+                    outfile_path => $decompose_outfile_path,
                 }
             );
             say {$filehandle} $NEWLINE;


### PR DESCRIPTION
### This PR adds | fixes:

- bcftools norm behaves funny with the atomize option turned on. 

variant before norm 
```
#CHROM  POS ID  REF ALT QUAL    FILTER  INFO    FORMAT  earlycasualcaiman   hugelymodelbat  slowlycivilbuck
1   1284490 rs150789461 G   A   779.31  PASS    AC=6;AF=1.00;AN=6;DB;DP=20;ExcessHet=3.0103;FS=0.000;MLEAC=6;MLEAF=1.00;MQ=60.00;QD=25.36;SOR=5.892;VQSLOD=11.34;culprit=MQ GT:AD:DP:GQ:PL  1/1:0,6:6:18:269,18,0   1/1:0,7:7:21:300,21,0   1/1:0,5:5:15:224,15,0
```

after norm with atomize
```
#CHROM  POS ID  REF ALT QUAL    FILTER  INFO    FORMAT  earlycasualcaiman   hugelymodelbat  slowlycivilbuck
1   1284490 rs150789461 G   A   779.31  PASS    AC=6;AF=1;AN=6;DB=^F;DP=20;ExcessHet=3.0103;FS=0;MLEAC=6;MLEAF=1;MQ=60;QD=25.36;SOR=5.892;VQSLOD=11.34;culprit=MQ;OLD_REC_TAG=1|1284490|G|A|1   GT:AD:DP:GQ:PL  1/1:0,0:6:18:269,18,0   1/1:0,0:7:21:300,21,0   1/1:0,0:5:15:224,15,0
```
Note how the DB flag in the info field has been given a value in the later record 

This is the info from the header
```
##INFO=<ID=DB,Number=0,Type=Flag,Description="dbSNP Membership">
```

Funny enough the DB is left untouched when a record is split

Before split:
```
1   3350134 rs10752734  T   *,C 1297.94 PASS    AC=1,4;AF=0.167,0.667;AN=6;DB;DP=88;ExcessHet=3.0103;FS=10.212;MLEAC=1,4;MLEAF=0.167,0.667;MQ=60.00;NEGATIVE_TRAIN_SITE;QD=34.42;SOR=0.346;VQSLOD=-1.303e+00;culprit=MQ GT:AD:DP:GQ:PL  0/1:7,7,0:16:99:571,0,400,460,376,799   2/2:0,0,10:10:94:1106,810,755,97,94,0   2/2:0,0,7:7:65:759,559,519,67,65,0
````
After split:
```
1   3350134 rs10752734  T   *   1297.94 PASS    AC=1;AF=0.167;AN=6;DB;DP=88;ExcessHet=3.0103;FS=10.212;MLEAC=1;MLEAF=0.167;MQ=60;NEGATIVE_TRAIN_SITE;QD=34.42;SOR=0.346;VQSLOD=-1.303;culprit=MQ;OLD_REC_TAG=1|3350134|T|*,|1   GT:AD:DP:GQ:PL  0/1:7,7:16:99:571,0,400 0/0:0,0:10:94:1106,810,755  0/0:0,0:7:65:759,559,519
1   3350134 rs10752734  T   C   1297.94 PASS    AC=4;AF=0.667;AN=6;DB;DP=88;ExcessHet=3.0103;FS=10.212;MLEAC=4;MLEAF=0.667;MQ=60;NEGATIVE_TRAIN_SITE;QD=34.42;SOR=0.346;VQSLOD=-1.303;culprit=MQ;OLD_REC_TAG=1|3350134|T|*,|2   GT:AD:DP:GQ:PL  0/0:7,0:16:99:571,460,799   1/1:0,10:10:94:1106,97,0    1/1:0,7:7:65:759,67,0
```

This PR turns off atomize for now


### How to test:

- Automatic and continuous test suite

### Expected outcome:
- [ ] Installation, unit and integration test suite pass

### Review:
- [ ] Code review
- [ ] Tests pass

This [version](https://semver.org/) is a:
- [ ] **MAJOR** - when you make incompatible API changes. If applicable record manual test results in PR header
- [ ] **MINOR** - when you add functionality in a backwards compatible manner. If applicable record manual test results in PR header
- [ ] **PATCH** - when you make backwards compatible bug fixes or documentation/instructions
