### PR TITLE
feat(download): use containers in download

### DIFF
--- a/definitions/download_parameters.yaml
+++ b/definitions/download_parameters.yaml
@@ -94,6 +94,10 @@ clinvar:
     - mip
   data_type: SCALAR
   default: 1
+  program_executables:
+    - bcftools
+    - bgzip
+    - tabix
   type: recipe
 config_file:
   associated_recipe:
@@ -120,6 +124,7 @@ custom_default_parameters:
     - mip
   data_type: ARRAY
   default:
+    - install_config_file
     - reference_dir
     - temp_directory
   type: mip
@@ -129,6 +134,9 @@ dbnsfp:
     - mip
   data_type: SCALAR
   default: 1
+  program_executables:
+    - bgzip
+    - tabix
   type: recipe
 dbsnp:
   analysis_mode: case
@@ -209,6 +217,9 @@ genomic_superdups:
     - mip
   data_type: SCALAR
   default: 1
+  program_executables:
+    - bgzip
+    - tabix
   type: recipe
 giab:
   analysis_mode: case
@@ -223,6 +234,11 @@ gnomad:
     - mip
   data_type: SCALAR
   default: 1
+  program_executables:
+    - bcftools
+    - bgzip
+    - tabix
+    - vcfanno
   type: recipe
 gnomad_pli_per_gene:
   analysis_mode: case
@@ -244,7 +260,16 @@ human_reference:
     - mip
   data_type: SCALAR
   default: 1
+  program_executables:
+    - samtools
   type: recipe
+install_config_file:
+  associated_recipe:
+    - mip
+  data_type: SCALAR
+  default: 0
+  type: path
+  update_path: absolute_path
 job_reservation_name:
   associated_recipe:
     - mip
@@ -296,6 +321,8 @@ pfam:
     - mip
   data_type: SCALAR
   default: 1
+  program_executables:
+    - hmmpress
   type: recipe
 print_parameter_default:
   associated_recipe:

--- a/lib/MIP/Cli/Mip/Download.pm
+++ b/lib/MIP/Cli/Mip/Download.pm
@@ -148,6 +148,14 @@ sub _build_usage {
     );
 
     option(
+        q{install_config_file} => (
+            documentation => q{File with install configuration parameters in YAML format},
+            is            => q{rw},
+            isa           => Str,
+        )
+    );
+
+    option(
         q{job_reservation_name} => (
             documentation => q{Allocate node resources from named reservation},
             is            => q{rw},

--- a/lib/MIP/Main/Download.pm
+++ b/lib/MIP/Main/Download.pm
@@ -29,7 +29,8 @@ use MIP::Active_parameter qw{
 };
 use MIP::Config qw{ check_cmd_config_vs_definition_file set_config_to_active_parameters };
 use MIP::Constants
-  qw{ $COLON $COMMA $DOT $LOG_NAME $MIP_VERSION $NEWLINE $SINGLE_QUOTE $SPACE $UNDERSCORE };
+  qw{ $COLON $COMMA $DOT $LOG_NAME $MIP_VERSION $NEWLINE $SINGLE_QUOTE $SPACE $UNDERSCORE set_container_constants };
+use MIP::Environment::Container qw{ parse_containers };
 use MIP::Download qw{ check_user_reference parse_download_reference_parameter };
 use MIP::Environment::Cluster qw{ check_max_core_number };
 use MIP::Environment::User qw{ check_email_address };
@@ -239,6 +240,15 @@ sub mip_download {
             reference_genome_versions_ref => $active_parameter_href->{reference_genome_versions},
             reference_ref                 => $active_parameter_href->{reference_feature},
             user_supplied_reference_ref   => $active_parameter_href->{reference},
+        }
+    );
+
+    set_container_constants( { active_parameter_href => $active_parameter_href, } );
+
+    parse_containers(
+        {
+            active_parameter_href => $active_parameter_href,
+            parameter_href        => $parameter_href,
         }
     );
 

--- a/lib/MIP/Recipes/Download/Cadd_offline_annotations.pm
+++ b/lib/MIP/Recipes/Download/Cadd_offline_annotations.pm
@@ -118,7 +118,7 @@ sub download_cadd_offline_annotations {
     check( $tmpl, $arg_href, 1 ) or croak q{Could not parse arguments!};
 
     use MIP::Recipe qw{ parse_recipe_prerequisites };
-    use MIP::Program::Gnu::Coreutils qw{ gnu_mkdir gnu_mv gnu_rm_and_echo };
+    use MIP::Program::Gnu::Coreutils qw{ gnu_mkdir gnu_rm_and_echo };
     use MIP::Processmanagement::Slurm_processes qw{ slurm_submit_job_no_dependency_dead_end };
     use MIP::Recipes::Download::Get_reference qw{ get_reference };
     use MIP::Script::Setup_script qw{ setup_script };

--- a/lib/MIP/Recipes/Download/Vcfanno_functions.pm
+++ b/lib/MIP/Recipes/Download/Vcfanno_functions.pm
@@ -117,7 +117,6 @@ sub download_vcfanno_functions {
 
     check( $tmpl, $arg_href, 1 ) or croak q{Could not parse arguments!};
 
-    use MIP::Program::Gnu::Coreutils qw{ gnu_mv};
     use MIP::Processmanagement::Slurm_processes qw{ slurm_submit_job_no_dependency_dead_end };
     use MIP::Recipe qw{ parse_recipe_prerequisites };
     use MIP::Recipes::Download::Get_reference qw{ get_reference };

--- a/lib/MIP/Recipes/Pipeline/Download.pm
+++ b/lib/MIP/Recipes/Pipeline/Download.pm
@@ -75,7 +75,6 @@ sub pipeline_download {
 
     check( $tmpl, $arg_href, 1 ) or croak q{Could not parse arguments!};
 
-    use MIP::Constants qw{ set_container_constants };
     use MIP::Recipes::Download::1000g_indels qw{ download_1000g_indels };
     use MIP::Recipes::Download::1000g_omni qw{ download_1000g_omni };
     use MIP::Recipes::Download::1000g_sites qw{ download_1000g_sites };
@@ -117,8 +116,6 @@ sub pipeline_download {
 
     ## Retrieve logger object now that log_file has been set
     my $log = Log::Log4perl->get_logger( uc q{mip_download} );
-
-    set_container_constants( { active_parameter_href => $active_parameter_href, } );
 
     ### Download recipes
     ## Create code reference table for download recipes


### PR DESCRIPTION
### This PR adds | fixes:

- The download scripts were trying to use bgzip, tabix, samtools etc but couldn't find the executables since the constants and the program executables weren't set.

### How to test:

- Automatic and continuous test suite

### Expected outcome:
- [ ] Installation, unit and integration test suite pass

### Review:
- [ ] Code review
- [ ] Tests pass

This [version](https://semver.org/) is a:
- [ ] **MAJOR** - when you make incompatible API changes. If applicable record manual test results in PR header
- [ ] **MINOR** - when you add functionality in a backwards compatible manner. If applicable record manual test results in PR header
- [ ] **PATCH** - when you make backwards compatible bug fixes or documentation/instructions
