### PR TITLE
Feature/norm rna and mt

### DIFF
--- a/definitions/analyse_parameters.yaml
+++ b/definitions/analyse_parameters.yaml
@@ -288,4 +288,6 @@ version_collect_ar:
   default: 1
   file_tag: _vcol
   outfile_suffix: ".yaml"
+  program_executables:
+    - mip
   type: recipe

--- a/definitions/dragen_rd_dna_parameters.yaml
+++ b/definitions/dragen_rd_dna_parameters.yaml
@@ -287,6 +287,8 @@ sv_vcfparser:
   default: 1
   file_tag: _parsed
   outfile_suffix: ".vcf"
+  program_executables:
+    - mip
   type: recipe
 sv_vcfparser_add_all_mt_var:
   associated_recipe:
@@ -640,6 +642,8 @@ vcfparser_ar:
   default: 1
   file_tag: _parsed
   outfile_suffix: ".vcf"
+  program_executables:
+    - mip
   type: recipe
 vcfparser_add_all_mt_var:
   associated_recipe:

--- a/definitions/rd_dna_panel_parameters.yaml
+++ b/definitions/rd_dna_panel_parameters.yaml
@@ -1002,6 +1002,11 @@ vcfparser_ar:
   default: 1
   file_tag: _parsed
   outfile_suffix: ".vcf"
+  program_executables:
+    - bcftools
+    - bgzip
+    - mip
+    - tabix
   type: recipe
 vcfparser_add_all_mt_var:
   associated_recipe:

--- a/definitions/rd_dna_parameters.yaml
+++ b/definitions/rd_dna_parameters.yaml
@@ -1073,6 +1073,8 @@ sv_vcfparser:
   default: 1
   file_tag: _parsed
   outfile_suffix: ".vcf"
+  program_executables:
+    - mip
   type: recipe
 sv_vcfparser_add_all_mt_var:
   associated_recipe:
@@ -1801,6 +1803,8 @@ vcfparser_ar:
   default: 1
   file_tag: _parsed
   outfile_suffix: ".vcf"
+  program_executables:
+    - mip
   type: recipe
 vcfparser_add_all_mt_var:
   associated_recipe:
@@ -2022,6 +2026,8 @@ qccollect_ar:
   default: 1
   file_tag: _qc_metrics
   outfile_suffix: ".yaml"
+  program_executables:
+    - mip
   type: recipe
 qccollect_eval_metric_file:
   associated_recipe:

--- a/definitions/rd_dna_vcf_rerun_parameters.yaml
+++ b/definitions/rd_dna_vcf_rerun_parameters.yaml
@@ -255,6 +255,8 @@ sv_vcfparser:
   default: 1
   file_tag: _parsed
   outfile_suffix: ".vcf"
+  program_executables:
+    - mip
   type: recipe
 sv_vcfparser_add_all_mt_var:
   associated_recipe:
@@ -637,6 +639,8 @@ vcfparser_ar:
   default: 1
   file_tag: _parsed
   outfile_suffix: ".vcf"
+  program_executables:
+    - mip
   type: recipe
 vcfparser_add_all_mt_var:
   associated_recipe:

--- a/definitions/rd_rna_initiation_map.yaml
+++ b/definitions/rd_rna_initiation_map.yaml
@@ -41,6 +41,7 @@ CHAIN_ALL:
       - gatk_asereadcounter
       - bootstrapann
       - bcftools_merge
+      - bcftools_norm
       - varianteffectpredictor
       - vcfparser_ar
   - qccollect_ar

--- a/definitions/rd_rna_parameters.yaml
+++ b/definitions/rd_rna_parameters.yaml
@@ -1017,6 +1017,11 @@ vcfparser_ar:
   default: 1
   file_tag: _parsed
   outfile_suffix: ".vcf.gz"
+  program_executables:
+    - bcftools
+    - bgzip
+    - mip
+    - tabix
   type: recipe
 vcfparser_add_all_mt_var:
   associated_recipe:
@@ -1059,6 +1064,8 @@ qccollect_ar:
   default: 1
   file_tag: _qc_metrics
   outfile_suffix: ".yaml"
+  program_executables:
+    - mip
   type: recipe
 qccollect_eval_metric_file:
   associated_recipe:

--- a/definitions/rd_rna_parameters.yaml
+++ b/definitions/rd_rna_parameters.yaml
@@ -139,6 +139,7 @@ recipe_time:
     analysisrunstatus: 1
     arriba_ar: 4
     bcftools_merge: 1
+    bcftools_norm: 2
     blobfish: 1
     bootstrapann: 2
     build_sj_tracks: 1
@@ -205,6 +206,7 @@ recipe_core_number:
     analysisrunstatus: 1
     arriba_ar: 24
     bcftools_merge: 1
+    bcftools_norm: 1
     blobfish: 1
     bootstrapann: 1
     build_sj_tracks: 1
@@ -897,6 +899,25 @@ bcftools_merge:
   program_executables:
     - bcftools
   type: recipe
+bcftools_norm:
+  analysis_mode: case
+  associated_recipe:
+    - mip
+  data_type: SCALAR
+  default: 1
+  file_tag: _norm
+  program_executables:
+    - bcftools
+    - bgzip
+    - tabix
+  outfile_suffix: ".vcf"
+  type: recipe
+bcftools_missing_alt_allele:
+  associated_recipe:
+    - bcftools_norm
+  data_type: SCALAR
+  default: 1
+  type: recipe_argument
 ## Reformat dna vcf
 dna_vcf_reformat:
   analysis_mode: sample

--- a/lib/MIP/Cli/Mip/Analyse/Rd_rna.pm
+++ b/lib/MIP/Cli/Mip/Analyse/Rd_rna.pm
@@ -158,6 +158,23 @@ sub _build_usage {
     );
 
     option(
+        q{bcftools_norm} => (
+            cmd_tags      => [q{Analysis recipe switch}],
+            documentation => q{Decompose and normalize},
+            is            => q{rw},
+            isa           => enum( [ 0, 1, 2 ] ),
+        )
+    );
+
+    option(
+        q{bcftools_missing_alt_allele} => (
+            documentation => q{Remove missing alternative alleles '*'},
+            is            => q{rw},
+            isa           => Bool,
+        )
+    );
+
+    option(
         q{blobfish} => (
             cmd_tags      => [q{Analysis recipe switch}],
             documentation => q{Run BlobFish on salmon quant files},

--- a/lib/MIP/Contigs.pm
+++ b/lib/MIP/Contigs.pm
@@ -201,7 +201,8 @@ sub delete_non_wes_contig {
     use MIP::List qw{ check_allowed_array_values };
     use MIP::Contigs qw{ delete_contig_elements };
 
-    return @{$contigs_ref} if ( $consensus_analysis_type eq q{wgs} );
+    return @{$contigs_ref}
+      if ( $consensus_analysis_type eq q{wgs} || $consensus_analysis_type eq q{wts} );
 
     ## Removes contig M | chrMT from contigs
     my @contigs = delete_contig_elements(

--- a/lib/MIP/Recipes/Pipeline/Analyse_rd_rna.pm
+++ b/lib/MIP/Recipes/Pipeline/Analyse_rd_rna.pm
@@ -377,6 +377,7 @@ sub pipeline_analyse_rd_rna {
     use MIP::Recipes::Analysis::Analysisrunstatus qw{ analysis_analysisrunstatus };
     use MIP::Recipes::Analysis::Arriba qw{ analysis_arriba };
     use MIP::Recipes::Analysis::Bcftools_merge qw{ analysis_bcftools_merge };
+    use MIP::Recipes::Analysis::Bcftools_norm qw{ analysis_bcftools_norm_panel };
     use MIP::Recipes::Analysis::Blobfish qw{ analysis_blobfish };
     use MIP::Recipes::Analysis::BootstrapAnn qw{ analysis_bootstrapann };
     use MIP::Recipes::Analysis::Build_sj_tracks qw{ analysis_build_sj_tracks };
@@ -443,6 +444,7 @@ sub pipeline_analyse_rd_rna {
         analysisrunstatus                => \&analysis_analysisrunstatus,
         arriba_ar                        => \&analysis_arriba,
         bcftools_merge                   => \&analysis_bcftools_merge,
+        bcftools_norm                    => \&analysis_bcftools_norm_panel,
         blobfish                         => \&analysis_blobfish,
         bootstrapann                     => \&analysis_bootstrapann,
         build_sj_tracks                  => \&analysis_build_sj_tracks,

--- a/t/delete_non_wes_contig.t
+++ b/t/delete_non_wes_contig.t
@@ -91,6 +91,16 @@ my @has_wes_contigs = delete_non_wes_contig(
 my @expected_wes_contigs = qw{ 1 2 3 4 MT };
 
 ## Then keep the non wes contigs
-is_deeply( \@has_wes_contigs, \@expected_wes_contigs, q{Keept non wes contigs} );
+is_deeply( \@has_wes_contigs, \@expected_wes_contigs, q{Keept non wes contigs for wgs} );
 
+## Given contigs, when a wts consensus type of run
+@has_wes_contigs = delete_non_wes_contig(
+    {
+        consensus_analysis_type => q{wts},
+        contigs_ref             => \@contigs,
+    }
+);
+
+## Then keep the non wes contigs
+is_deeply( \@has_wes_contigs, \@expected_wes_contigs, q{Keept non wes contigs for wts} );
 done_testing();

--- a/templates/grch38_mip_rd_rna_config.yaml
+++ b/templates/grch38_mip_rd_rna_config.yaml
@@ -8,6 +8,9 @@ load_env:
   MIP_rd_rna:
     method: conda
     mip:
+recipe_bind_path:
+  vcfparser_ar:
+    - cluster_constant_path!/case_id!
 slurm_quality_of_service: low
 ## Input
 pedigree_file: cluster_constant_path!/case_id!/case_id!_pedigree.yaml


### PR DESCRIPTION
### This PR adds | fixes:

- Adds norm recipe to RNA pipeline
- No longer remove MT from RNA pipeline
- Bind paths for vcfparser parser
- Adds Mip to program_executables in parameter files

### How to test:

- Automatic and continuous test suite

### Expected outcome:
- [ ] Installation, unit and integration test suite pass

### Review:
- [ ] Code review
- [ ] Tests pass

This [version](https://semver.org/) is a:
- [ ] **MAJOR** - when you make incompatible API changes. If applicable record manual test results in PR header
- [ ] **MINOR** - when you add functionality in a backwards compatible manner. If applicable record manual test results in PR header
- [ ] **PATCH** - when you make backwards compatible bug fixes or documentation/instructions
