### PR TITLE
feat(bind_paths): Don't overwrite executable bind paths

### DIFF
--- a/lib/MIP/Active_parameter.pm
+++ b/lib/MIP/Active_parameter.pm
@@ -169,17 +169,9 @@ sub add_recipe_bind_paths {
 
     check( $tmpl, $arg_href, 1 ) or croak q{Could not parse arguments!};
 
-    use MIP::Environment::Path qw{ reduce_dir_paths };
-
     return if ( not $active_parameter_href->{recipe_bind_path}{$recipe_name} );
 
     push @{$export_bind_paths_ref}, @{ $active_parameter_href->{recipe_bind_path}{$recipe_name} };
-
-    @{$export_bind_paths_ref} = reduce_dir_paths(
-        {
-            dir_paths_ref => $export_bind_paths_ref
-        }
-    );
 
     return;
 }


### PR DESCRIPTION
### This PR adds | fixes:
Previously the bind paths for an executable would be overwritten if the executable was used in more than one recipe. This appends the bind paths to the array rather than overwriting it.

### How to test:

- Automatic and continuous test suite

### Expected outcome:
- [ ] Installation, unit and integration test suite pass

### Review:
- [ ] Code review
- [ ] Tests pass

This [version](https://semver.org/) is a:
- [ ] **MAJOR** - when you make incompatible API changes. If applicable record manual test results in PR header
- [ ] **MINOR** - when you add functionality in a backwards compatible manner. If applicable record manual test results in PR header
- [ ] **PATCH** - when you make backwards compatible bug fixes or documentation/instructions
