### PR TITLE
feat(glnexus): split and normalize output vcf

### DIFF
--- a/definitions/rd_dna_parameters.yaml
+++ b/definitions/rd_dna_parameters.yaml
@@ -522,9 +522,9 @@ glnexus_merge:
   file_tag: _glnex
   outfile_suffix: ".vcf.gz"
   program_executables:
-    - glnexus_cli
     - bcftools
-    - bgzip
+    - glnexus_cli
+    - tabix
   recipe_type: variant_callers
   type: recipe
   variant_caller: deepvariant

--- a/lib/MIP/Program/Bcftools.pm
+++ b/lib/MIP/Program/Bcftools.pm
@@ -262,7 +262,7 @@ sub bcftools_base {
             strict_type => 1,
         },
         threads => {
-            allow       => qr/\A \d+ \z | undef /xms,
+            allow       => [ undef, qr{\A \d+ \z}xms ],
             store       => \$threads,
             strict_type => 1,
         },
@@ -1143,6 +1143,7 @@ sub bcftools_norm {
 ##          : $stderrfile_path        => Stderr file path to write to {OPTIONAL}
 ##          : $stderrfile_path_append => Append stderr info to file path
 ##          : $stdoutfile_path        => Stdoutfile path
+##          : $threads                => Number of threads to use
 
     my ($arg_href) = @_;
 
@@ -1163,6 +1164,7 @@ sub bcftools_norm {
     my $stderrfile_path;
     my $stderrfile_path_append;
     my $stdoutfile_path;
+    my $threads;
 
     ## Default(s)
     my $multiallelic_type;
@@ -1239,6 +1241,10 @@ sub bcftools_norm {
         stderrfile_path        => { store => \$stderrfile_path,        strict_type => 1, },
         stderrfile_path_append => { store => \$stderrfile_path_append, strict_type => 1, },
         stdoutfile_path        => { store => \$stdoutfile_path,        strict_type => 1, },
+        threads                => {
+            store       => \$threads,
+            strict_type => 1,
+        },
     };
 
     check( $tmpl, $arg_href, 1 ) or croak q{Could not parse arguments!};
@@ -1255,6 +1261,7 @@ sub bcftools_norm {
             output_type       => $output_type,
             samples_file_path => $samples_file_path,
             samples_ref       => $samples_ref,
+            threads           => $threads,
         }
     );
 


### PR DESCRIPTION
### This PR adds | fixes:

- Split and normalize glnexus output 

### How to test:

- Automatic and continuous test suite

### Expected outcome:
- [x] Installation, unit and integration test suite pass

### Review:
- [ ] Code review
- [x] Tests pass

This [version](https://semver.org/) is a:
- [ ] **MAJOR** - when you make incompatible API changes. If applicable record manual test results in PR header
- [ ] **MINOR** - when you add functionality in a backwards compatible manner. If applicable record manual test results in PR header
- [ ] **PATCH** - when you make backwards compatible bug fixes or documentation/instructions
