### PR TITLE
Revert telomerecat from 4.0.0 to 3.4.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,7 +43,6 @@ smncopynumbercaller: 4b2c1ad -> v1.1.1
 star: 2.7.4a -> 2.7.8a
 stranger: 0.7 -> 0.7.1
 svdb: 2.2.0 -> 2.4.0--py37h77a2a36_4
-telomerecat: 3.4.0 -> 4.0.0
 tiddit: 2.8.1 -> 2.12.1
 upd: 0.1 -> 0.1.1
 

--- a/documentation/Setup.md
+++ b/documentation/Setup.md
@@ -75,7 +75,7 @@ You can speed up, for instance, the Readonly module by also installing the compa
 - [Stranger] (version: 0.7)
 - [StringTie] (version: 2.1.3b)
 - [Svdb] (version: 2.4.0)
-- [Telomerecat] (version: 4.0.0)
+- [Telomerecat] (version: 3.4.0)
 - [Tiddit] (version: 2.12.1)
 - [Upd] (version: 0.1.1)
 - [Varg] (version: 1.2.0)

--- a/t/data/test_data/miptest_install_config.yaml
+++ b/t/data/test_data/miptest_install_config.yaml
@@ -206,7 +206,7 @@ container:
   telomerecat:
     executable:
       telomerecat:
-    uri: docker.io/clinicalgenomics/telomerecat:4.0.0
+    uri: quay.io/wtsicgp/telomerecat:3.4.0
   tiddit:
     executable:
       TIDDIT.py:

--- a/templates/mip_install_config.yaml
+++ b/templates/mip_install_config.yaml
@@ -209,7 +209,7 @@ container:
   telomerecat:
     executable:
       telomerecat:
-    uri: docker.io/clinicalgenomics/telomerecat:4.0.0
+    uri: quay.io/wtsicgp/telomerecat:3.4.0
   tiddit:
     executable:
       TIDDIT.py:


### PR DESCRIPTION
### This PR adds | fixes:

- Revert from 4.0.0 to 3.4.0

### How to test:

- Automatic and continuous test suite

### Expected outcome:
- [ ] Installation, unit and integration test suite pass

### Review:
- [ ] Code review
- [ ] Tests pass

This [version](https://semver.org/) is a:
- [ ] **MAJOR** - when you make incompatible API changes. If applicable record manual test results in PR header
- [ ] **MINOR** - when you add functionality in a backwards compatible manner. If applicable record manual test results in PR header
- [ ] **PATCH** - when you make backwards compatible bug fixes or documentation/instructions
