### PR TITLE
feat(vcfparser): moved copy of mt variants

### DIFF
--- a/lib/MIP/Recipes/Analysis/Mip_vcfparser.pm
+++ b/lib/MIP/Recipes/Analysis/Mip_vcfparser.pm
@@ -351,13 +351,12 @@ sub analysis_mip_vcfparser {
             {
                 add_all_mt_var => $active_parameter_href->{vcfparser_add_all_mt_var},
                 contig         => $contig,
-                filehandle     => $xargsfilehandle,
+                filehandle     => $filehandle,
                 infile_path    => $outfile_path{$contig},
                 outfile_path   => $select_outfile,
             }
         );
     }
-    say {$xargsfilehandle} $NEWLINE;
 
     if ( $recipe{mode} == 1 ) {
 
@@ -1420,13 +1419,12 @@ sub analysis_mip_vcfparser_sv_wgs {
             {
                 add_all_mt_var => $active_parameter_href->{sv_vcfparser_add_all_mt_var},
                 contig         => $contig,
-                filehandle     => $xargsfilehandle,
+                filehandle     => $filehandle,
                 infile_path    => $vcfparser_outfile_path,
                 outfile_path   => $select_outfile,
             }
         );
     }
-    say {$xargsfilehandle} $NEWLINE;
 
   ANALYSIS_SUFFIXES:
     foreach my $analysis_suffix (@outfile_suffixes) {


### PR DESCRIPTION
### This PR adds | fixes:

The copying of mt research variants used to be part of the xargs file which could lead to the copying happening before vcfparser had finished producing the mt file. This PR moves the copying step to the main script file in order to ensure htat all files have been created prior to copying. 

### How to test:

- Automatic and continuous test suite

### Expected outcome:
- [ ] Installation, unit and integration test suite pass

### Review:
- [ ] Code review
- [ ] Tests pass

This [version](https://semver.org/) is a:
- [ ] **MAJOR** - when you make incompatible API changes. If applicable record manual test results in PR header
- [ ] **MINOR** - when you add functionality in a backwards compatible manner. If applicable record manual test results in PR header
- [ ] **PATCH** - when you make backwards compatible bug fixes or documentation/instructions
