### PR TITLE
feat(cadd_download): build cadd_snv index

### DIFF
--- a/lib/MIP/Recipes/Download/Cadd_whole_genome_snvs.pm
+++ b/lib/MIP/Recipes/Download/Cadd_whole_genome_snvs.pm
@@ -117,10 +117,11 @@ sub download_cadd_whole_genome_snvs {
 
     check( $tmpl, $arg_href, 1 ) or croak q{Could not parse arguments!};
 
+    use MIP::Processmanagement::Slurm_processes qw{ slurm_submit_job_no_dependency_dead_end };
+    use MIP::Program::Htslib qw{ htslib_tabix };
     use MIP::Recipe qw{ parse_recipe_prerequisites };
     use MIP::Recipes::Download::Get_reference qw{ get_reference };
     use MIP::Script::Setup_script qw{ setup_script };
-    use MIP::Processmanagement::Slurm_processes qw{ slurm_submit_job_no_dependency_dead_end };
 
     ### PREPROCESSING:
 
@@ -137,7 +138,6 @@ sub download_cadd_whole_genome_snvs {
         }
     );
 
-## Filehandle(s)
     # Create anonymous filehandle
     my $filehandle = IO::Handle->new();
 
@@ -176,7 +176,19 @@ sub download_cadd_whole_genome_snvs {
         }
     );
 
-    ## Close filehandleS
+    htslib_tabix(
+        {
+            begin       => 2,
+            end         => 2,
+            filehandle  => $filehandle,
+            force       => 1,
+            sequence    => 1,
+            infile_path => catfile( $reference_dir, $reference_href->{outfile} ),
+        }
+    );
+    say {$filehandle} $NEWLINE;
+
+    ## Close filehandle
     close $filehandle or $log->logcroak(q{Could not close filehandle});
 
     if ( $recipe{mode} == 1 ) {

--- a/templates/mip_download_rd_dna_config_-1.0-.yaml
+++ b/templates/mip_download_rd_dna_config_-1.0-.yaml
@@ -267,14 +267,9 @@ reference_feature:
       v1.6:
         file: whole_genome_SNVs.tsv.gz
         file_check: whole_genome_SNVs.tsv.gz.md5
-        file_index: whole_genome_SNVs.tsv.gz.tbi
-        file_index_check: whole_genome_SNVs.tsv.gz.tbi.md5
         outfile: grch37_cadd_whole_genome_snvs_-v1.6-.tsv.gz
         outfile_check: grch37_cadd_whole_genome_snvs_-v1.6-.tsv.gz.md5
         outfile_check_method: md5sum
-        outfile_index: grch37_cadd_whole_genome_snvs_-v1.6-.tsv.gz.tbi
-        outfile_index_check: grch37_cadd_whole_genome_snvs_-v1.6-.tsv.gz.tbi.md5
-        outfile_index_check_method: md5sum
         url_prefix: https://krishna.gs.washington.edu/download/CADD/v1.6/GRCh37/
     grch38:
       v1.5:
@@ -292,14 +287,9 @@ reference_feature:
       v1.6:
         file: whole_genome_SNVs.tsv.gz
         file_check: whole_genome_SNVs.tsv.gz.md5
-        file_index: whole_genome_SNVs.tsv.gz.tbi
-        file_index_check: whole_genome_SNVs.tsv.gz.tbi.md5
         outfile: grch38_cadd_whole_genome_snvs_-v1.6-.tsv.gz
         outfile_check: grch38_cadd_whole_genome_snvs_-v1.6-.tsv.gz.md5
         outfile_check_method: md5sum
-        outfile_index: grch38_cadd_whole_genome_snvs_-v1.6-.tsv.gz.tbi
-        outfile_index_check: grch38_cadd_whole_genome_snvs_-v1.6-.tsv.gz.tbi.md5
-        outfile_index_check_method: md5sum
         url_prefix: https://krishna.gs.washington.edu/download/CADD/v1.6/GRCh38/
   chromograph_cytoband:
     grch37:


### PR DESCRIPTION
### This PR adds | fixes:

- VCFanno fails to annotate SNVs with cadd scores. Regenerating the index file seems to fix the problem. Should close #1691 

### How to test:

- Automatic and continuous test suite

### Expected outcome:
- [ ] Installation, unit and integration test suite pass

### Review:
- [ ] Code review
- [ ] Tests pass

This [version](https://semver.org/) is a:
- [ ] **MAJOR** - when you make incompatible API changes. If applicable record manual test results in PR header
- [ ] **MINOR** - when you add functionality in a backwards compatible manner. If applicable record manual test results in PR header
- [ ] **PATCH** - when you make backwards compatible bug fixes or documentation/instructions
