### PR TITLE
feat(bcftools_base): --output --> -o

### DIFF
--- a/lib/MIP/Program/Bcftools.pm
+++ b/lib/MIP/Program/Bcftools.pm
@@ -290,7 +290,7 @@ sub bcftools_base {
     }
     if ($outfile_path) {
 
-        push @commands, q{--output} . $SPACE . $outfile_path;
+        push @commands, q{-o} . $SPACE . $outfile_path;
     }
 
     if ($output_type) {

--- a/t/bcftools_annotate.t
+++ b/t/bcftools_annotate.t
@@ -23,16 +23,13 @@ use lib catdir( dirname($Bin), q{lib} );
 use MIP::Constants qw{ $COMMA $SPACE };
 use MIP::Test::Commands qw{ test_function };
 
-
 BEGIN {
 
     use MIP::Test::Fixtures qw{ test_import };
 
 ### Check all internal dependency modules and imports
 ## Modules with import
-    my %perl_module = (
-        q{MIP::Program::Bcftools} => [qw{ bcftools_annotate }],
-);
+    my %perl_module = ( q{MIP::Program::Bcftools} => [qw{ bcftools_annotate }], );
 
     test_import( { perl_module_href => \%perl_module, } );
 }
@@ -97,7 +94,7 @@ my %specific_argument = (
     },
     outfile_path => {
         input           => q{outfile.txt},
-        expected_output => q{--output outfile.txt},
+        expected_output => q{-o outfile.txt},
     },
     output_type => {
         input           => q{v},

--- a/t/bcftools_base.t
+++ b/t/bcftools_base.t
@@ -23,16 +23,13 @@ use lib catdir( dirname($Bin), q{lib} );
 use MIP::Constants qw{ $COMMA $SPACE };
 use MIP::Test::Commands qw{ test_function };
 
-
 BEGIN {
 
     use MIP::Test::Fixtures qw{ test_import };
 
 ### Check all internal dependency modules and imports
 ## Modules with import
-    my %perl_module = (
-        q{MIP::Program::Bcftools} => [qw{ bcftools_base }],
-);
+    my %perl_module = ( q{MIP::Program::Bcftools} => [qw{ bcftools_base }], );
 
     test_import( { perl_module_href => \%perl_module, } );
 }
@@ -80,7 +77,7 @@ my %specific_argument = (
     },
     outfile_path => {
         input           => catfile(qw{ a test file }),
-        expected_output => q{--output} . $SPACE . catfile(qw{ a test file }),
+        expected_output => q{-o} . $SPACE . catfile(qw{ a test file }),
     },
     output_type => {
         input           => q{b},

--- a/t/bcftools_call.t
+++ b/t/bcftools_call.t
@@ -23,16 +23,13 @@ use lib catdir( dirname($Bin), q{lib} );
 use MIP::Constants qw{ $COMMA $SPACE };
 use MIP::Test::Commands qw{ test_function };
 
-
 BEGIN {
 
     use MIP::Test::Fixtures qw{ test_import };
 
 ### Check all internal dependency modules and imports
 ## Modules with import
-    my %perl_module = (
-        q{MIP::Program::Bcftools} => [qw{ bcftools_call }],
-);
+    my %perl_module = ( q{MIP::Program::Bcftools} => [qw{ bcftools_call }], );
 
     test_import( { perl_module_href => \%perl_module, } );
 }
@@ -93,7 +90,7 @@ my %specific_argument = (
     },
     outfile_path => {
         input           => q{outfile.txt},
-        expected_output => q{--output outfile.txt},
+        expected_output => q{-o outfile.txt},
     },
     output_type => {
         input           => q{v},

--- a/t/bcftools_concat.t
+++ b/t/bcftools_concat.t
@@ -23,16 +23,13 @@ use lib catdir( dirname($Bin), q{lib} );
 use MIP::Constants qw{ $COMMA $SPACE };
 use MIP::Test::Commands qw{ test_function };
 
-
 BEGIN {
 
     use MIP::Test::Fixtures qw{ test_import };
 
 ### Check all internal dependency modules and imports
 ## Modules with import
-    my %perl_module = (
-        q{MIP::Program::Bcftools} => [qw{ bcftools_concat }],
-);
+    my %perl_module = ( q{MIP::Program::Bcftools} => [qw{ bcftools_concat }], );
 
     test_import( { perl_module_href => \%perl_module, } );
 }
@@ -84,7 +81,7 @@ my %specific_argument = (
     },
     outfile_path => {
         input           => q{outfile.txt},
-        expected_output => q{--output outfile.txt},
+        expected_output => q{-o outfile.txt},
     },
     output_type => {
         input           => q{v},

--- a/t/bcftools_merge.t
+++ b/t/bcftools_merge.t
@@ -23,16 +23,13 @@ use lib catdir( dirname($Bin), q{lib} );
 use MIP::Constants qw{ $COMMA $SPACE };
 use MIP::Test::Commands qw{ test_function };
 
-
 BEGIN {
 
     use MIP::Test::Fixtures qw{ test_import };
 
 ### Check all internal dependency modules and imports
 ## Modules with import
-    my %perl_module = (
-        q{MIP::Program::Bcftools} => [qw{ bcftools_merge }],
-);
+    my %perl_module = ( q{MIP::Program::Bcftools} => [qw{ bcftools_merge }], );
 
     test_import( { perl_module_href => \%perl_module, } );
 }
@@ -78,7 +75,7 @@ my %specific_argument = (
     },
     outfile_path => {
         input           => q{outfile.txt},
-        expected_output => q{--output outfile.txt},
+        expected_output => q{-o outfile.txt},
     },
     output_type => {
         input           => q{v},

--- a/t/bcftools_mpileup.t
+++ b/t/bcftools_mpileup.t
@@ -23,16 +23,13 @@ use lib catdir( dirname($Bin), q{lib} );
 use MIP::Constants qw{ $COMMA $SPACE };
 use MIP::Test::Commands qw{ test_function };
 
-
 BEGIN {
 
     use MIP::Test::Fixtures qw{ test_import };
 
 ### Check all internal dependency modules and imports
 ## Modules with import
-    my %perl_module = (
-        q{MIP::Program::Bcftools} => [qw{ bcftools_mpileup }],
-);
+    my %perl_module = ( q{MIP::Program::Bcftools} => [qw{ bcftools_mpileup }], );
 
     test_import( { perl_module_href => \%perl_module, } );
 }
@@ -96,7 +93,7 @@ my %required_argument = (
 my %specific_argument = (
     outfile_path => {
         input           => catfile(qw{ dir outfile_1 }),
-        expected_output => q{--output} . $SPACE . catfile(qw{ dir outfile_1 }),
+        expected_output => q{-o} . $SPACE . catfile(qw{ dir outfile_1 }),
     },
     per_sample_increased_sensitivity => {
         input           => 1,

--- a/t/bcftools_reheader.t
+++ b/t/bcftools_reheader.t
@@ -23,16 +23,13 @@ use lib catdir( dirname($Bin), q{lib} );
 use MIP::Constants qw{ $COMMA $SPACE };
 use MIP::Test::Commands qw{ test_function };
 
-
 BEGIN {
 
     use MIP::Test::Fixtures qw{ test_import };
 
 ### Check all internal dependency modules and imports
 ## Modules with import
-    my %perl_module = (
-        q{MIP::Program::Bcftools} => [qw{ bcftools_reheader }],
-);
+    my %perl_module = ( q{MIP::Program::Bcftools} => [qw{ bcftools_reheader }], );
 
     test_import( { perl_module_href => \%perl_module, } );
 }
@@ -79,7 +76,7 @@ my %specific_argument = (
     },
     outfile_path => {
         input           => q{outfile.txt},
-        expected_output => q{--output outfile.txt},
+        expected_output => q{-o outfile.txt},
     },
     samples_file_path => {
         input           => q{samples_file_path},

--- a/t/bcftools_roh.t
+++ b/t/bcftools_roh.t
@@ -23,16 +23,13 @@ use lib catdir( dirname($Bin), q{lib} );
 use MIP::Constants qw{ $COMMA $SPACE };
 use MIP::Test::Commands qw{ test_function };
 
-
 BEGIN {
 
     use MIP::Test::Fixtures qw{ test_import };
 
 ### Check all internal dependency modules and imports
 ## Modules with import
-    my %perl_module = (
-        q{MIP::Program::Bcftools} => [qw{ bcftools_roh }],
-);
+    my %perl_module = ( q{MIP::Program::Bcftools} => [qw{ bcftools_roh }], );
 
     test_import( { perl_module_href => \%perl_module, } );
 }
@@ -89,7 +86,7 @@ my %specific_argument = (
     },
     outfile_path => {
         input           => q{outfile.txt},
-        expected_output => q{--output outfile.txt},
+        expected_output => q{-o outfile.txt},
     },
     samples_ref => {
         inputs_ref      => [qw{ idref1 idref2 idref3 }],

--- a/t/bcftools_sort.t
+++ b/t/bcftools_sort.t
@@ -22,16 +22,13 @@ use lib catdir( dirname($Bin), q{lib} );
 use MIP::Constants qw{ $COMMA $SPACE };
 use MIP::Test::Commands qw{ test_function };
 
-
 BEGIN {
 
     use MIP::Test::Fixtures qw{ test_import };
 
 ### Check all internal dependency modules and imports
 ## Modules with import
-    my %perl_module = (
-        q{MIP::Program::Bcftools} => [qw{ bcftools_sort }],
-);
+    my %perl_module = ( q{MIP::Program::Bcftools} => [qw{ bcftools_sort }], );
 
     test_import( { perl_module_href => \%perl_module, } );
 }
@@ -88,7 +85,7 @@ my %specific_argument = (
     },
     outfile_path => {
         input           => q{outfile.bcf},
-        expected_output => q{--output} . $SPACE . q{outfile.bcf},
+        expected_output => q{-o} . $SPACE . q{outfile.bcf},
     },
     output_type => {
         input           => q{b},


### PR DESCRIPTION
### This PR adds | fixes:

bcftools sort (version 1.10.2) uses the option name `--output-file`, while most other bcftools commands uses `--output`. This has been harmonised in more recent versions of bcftools. This pr changes the long option name for bcftools outfile path to the short option name `-o`, which is the same across bcftools command 

### How to test:

- Automatic and continuous test suite

### Expected outcome:
- [ ] Installation, unit and integration test suite pass

### Review:
- [ ] Code review
- [ ] Tests pass

This [version](https://semver.org/) is a:
- [ ] **MAJOR** - when you make incompatible API changes. If applicable record manual test results in PR header
- [ ] **MINOR** - when you add functionality in a backwards compatible manner. If applicable record manual test results in PR header
- [ ] **PATCH** - when you make backwards compatible bug fixes or documentation/instructions
