### PR TITLE
Release/10.0.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 - Fix to gene panel regexp
 - Use automated build of MIP
+- Increased memory allocation for version_collect
 
 ## [10.0.0]
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 - Use automated build of MIP
 - Increased memory allocation for version_collect
 
+### Tools
+stranger: 0.7.1 -> 0.8.0
+
+
 ## [10.0.0]
 
 - Remove unused recipe split_fastq_file

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 ## [10.0.1]
 
 - Fix to gene panel regexp
+- Use automated build of MIP
 
 ## [10.0.0]
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,10 @@
 All notable changes to this project will be documented in this file.
 This project adheres to [Semantic Versioning](http://semver.org/).
 
+## [10.0.1]
+
+- Fix to gene panel regexp
+
 ## [10.0.0]
 
 - Remove unused recipe split_fastq_file

--- a/containers/stranger/Dockerfile
+++ b/containers/stranger/Dockerfile
@@ -5,9 +5,9 @@ FROM clinicalgenomics/mip_base:2.1
 ################## METADATA ######################
 
 LABEL base_image="clinicalgenomics/mip_base:2.1"
-LABEL version="4"
+LABEL version="5"
 LABEL software="stranger"
-LABEL software.version="0.7"
+LABEL software.version="0.8.0"
 LABEL extra.binaries="stranger"
 LABEL maintainer="Clinical-Genomics/MIP"
 
@@ -16,6 +16,6 @@ RUN conda install pip python=3.7
 ## Clean up after conda
 RUN /opt/conda/bin/conda clean -ya
 
-RUN pip install --no-cache-dir stranger==0.7.1
+RUN pip install --no-cache-dir stranger==0.8.0
 
 WORKDIR /data/

--- a/definitions/dragen_rd_dna_parameters.yaml
+++ b/definitions/dragen_rd_dna_parameters.yaml
@@ -110,6 +110,7 @@ recipe_memory:
     sv_reformat: 24
     sv_varianteffectpredictor: 7
     varianteffectpredictor: 7
+    version_collect_ar: 8
   type: mip
 recipe_time:
   associated_recipe:

--- a/definitions/rd_dna_panel_parameters.yaml
+++ b/definitions/rd_dna_panel_parameters.yaml
@@ -178,6 +178,7 @@ recipe_memory:
     sambamba_depth: 10
     varianteffectpredictor: 7
     vcfparser_ar: 7
+    version_collect_ar: 8
   type: mip
 set_recipe_memory:
   associated_recipe:

--- a/definitions/rd_dna_parameters.yaml
+++ b/definitions/rd_dna_parameters.yaml
@@ -238,7 +238,6 @@ recipe_memory:
     delly_reformat: 3
     endvariantannotationblock: 8
     expansionhunter: 2
-    variant_annotation: 3
     gatk_baserecalibration: 10
     gatk_combinevariantcallsets: 25
     gatk_gathervcfs: 7
@@ -258,8 +257,10 @@ recipe_memory:
     sv_varianteffectpredictor: 9
     tiddit: 8
     upd_ar: 3
-    vcf2cytosure_ar: 6
+    variant_annotation: 3
     varianteffectpredictor: 7
+    vcf2cytosure_ar: 6
+    version_collect_ar: 8
   type: mip
 set_recipe_memory:
   associated_recipe:

--- a/definitions/rd_dna_vcf_rerun_parameters.yaml
+++ b/definitions/rd_dna_vcf_rerun_parameters.yaml
@@ -98,6 +98,7 @@ recipe_memory:
     sv_reformat: 24
     sv_varianteffectpredictor: 9
     varianteffectpredictor: 7
+    version_collect_ar: 8
   type: mip
 recipe_time:
   associated_recipe:

--- a/documentation/Setup.md
+++ b/documentation/Setup.md
@@ -72,7 +72,7 @@ You can speed up, for instance, the Readonly module by also installing the compa
 - [SMNCopyNumberCaller] (version: v1.1.1)
 - [STAR-Fusion] (version: 1.10.0)
 - [STAR] (version: 2.7.8a)
-- [Stranger] (version: 0.7)
+- [Stranger] (version: 0.8.0)
 - [StringTie] (version: 2.1.3b)
 - [Svdb] (version: 2.4.0)
 - [Telomerecat] (version: 3.4.0)

--- a/lib/MIP/Constants.pm
+++ b/lib/MIP/Constants.pm
@@ -81,7 +81,7 @@ Readonly our %ANALYSIS => (
 );
 
 ## Set MIP version
-Readonly our $MIP_VERSION => q{10.0.0};
+Readonly our $MIP_VERSION => q{10.0.1};
 
 ## Cli
 Readonly our $MOOSEX_APP_SCEEN_WIDTH => 160;

--- a/lib/MIP/Language/Perl.pm
+++ b/lib/MIP/Language/Perl.pm
@@ -755,11 +755,17 @@ sub _get_gene_panel_info {
 
     my ($arg_href) = @_;
 
-    # If line starts with gene panel comment
-    my $gene_panel_info_regexp = q?'if (/ \A [#]{2} (gene_panel= .*) \n /xms ){ ?;
+    ## Create array for storing
+    my $gene_panel_info_regexp = q?'BEGIN{ @panels } ?;
 
-    # Append ":". Skip rest if it's a comment
-    $gene_panel_info_regexp .= q?print $1 . q{:}} elsif (/ \A [#]{1} \w /xms ) {last;}'?;
+    ## Store gene panel to array
+    $gene_panel_info_regexp .= q?if (/ \A [#]{2} (gene_panel=[^,]*) /xms ){ push @panels, $1;} ?;
+
+    ## Skip rest if comment
+    $gene_panel_info_regexp .= q?elsif (/ \A [^#] /xms) {last;} ?;
+
+    ## Join array to string separated by ':' and print
+    $gene_panel_info_regexp .= q?END {print join q{:}, @panels }'?;
 
     return $gene_panel_info_regexp;
 }

--- a/lib/MIP/Sample_info.pm
+++ b/lib/MIP/Sample_info.pm
@@ -840,7 +840,7 @@ sub set_gene_panel {
     foreach my $line ( split /:/sxm, $ret ) {
 
         # Split each info line into gene panel hash
-        my %gene_panel = ( split /[,=]/sxm, $line );
+        my %gene_panel = ( split /[=]/sxm, $line );
 
         # Gene panel name must exist
         if (    ( defined $gene_panel{gene_panel} )

--- a/t/data/test_data/install_active_parameters.yaml
+++ b/t/data/test_data/install_active_parameters.yaml
@@ -183,7 +183,7 @@ container:
   stranger:
     executable:
       stranger: ~
-    uri: docker.io/clinicalgenomics/stranger:0.5.5
+    uri: docker.io/clinicalgenomics/stranger:0.8.0
   stringtie:
     executable:
       stringtie: ~

--- a/t/data/test_data/miptest_install_config.yaml
+++ b/t/data/test_data/miptest_install_config.yaml
@@ -194,7 +194,7 @@ container:
   stranger:
     executable:
       stranger:
-    uri: docker.io/clinicalgenomics/stranger:0.5.5
+    uri: docker.io/clinicalgenomics/stranger:0.8.0
   stringtie:
     executable:
       stringtie:

--- a/t/set_gene_panel.t
+++ b/t/set_gene_panel.t
@@ -58,10 +58,7 @@ my %sample_info;
 
 my %header_info = (
     $gene_panel => {
-        display_name => q{gene_panel_test},
-        gene_panel   => $gene_panel,
-        updated_at   => q{2016-12-08},
-        version      => q{1.0},
+        gene_panel => $gene_panel,
     }
 );
 
@@ -106,20 +103,14 @@ trap {
 };
 
 ## Then warn
-like(
-    $trap->stderr,
-    qr/Unable \s+ to \s+ write \s+ select_file/xms,
-    q{Throw warning log message}
-);
+like( $trap->stderr, qr/Unable \s+ to \s+ write \s+ select_file/xms, q{Throw warning log message} );
 
 ## Given a file without gene_panel information
 trap {
     set_gene_panel(
         {
-            aggregate_gene_panel_file => catfile(
-                $Bin,
-                qw{ data references grch37_agilent_sureselect_targets_cre_-v1-.bed }
-            ),
+            aggregate_gene_panel_file =>
+              catfile( $Bin, qw{ data references grch37_agilent_sureselect_targets_cre_-v1-.bed } ),
             aggregate_gene_panels_key => $aggregate_gene_panels_key,
             recipe_name               => $recipe_name_test,
             sample_info_href          => \%sample_info,

--- a/templates/mip_install_config.yaml
+++ b/templates/mip_install_config.yaml
@@ -117,7 +117,7 @@ container:
   mip:
     executable:
       mip:
-    uri: docker.io/clinicalgenomics/mip:v10.0.0
+    uri: docker.io/clinicalgenomics/mip:v10.0.1
   multiqc:
     executable:
       multiqc:

--- a/templates/mip_install_config.yaml
+++ b/templates/mip_install_config.yaml
@@ -197,7 +197,7 @@ container:
   stranger:
     executable:
       stranger:
-    uri: docker.io/clinicalgenomics/stranger:0.7.1
+    uri: docker.io/clinicalgenomics/stranger:0.8.0
   stringtie:
     executable:
       stringtie:

--- a/templates/mip_install_config.yaml
+++ b/templates/mip_install_config.yaml
@@ -117,7 +117,7 @@ container:
   mip:
     executable:
       mip:
-    uri: docker.io/clinicalgenomics/mip:10.0.0
+    uri: docker.io/clinicalgenomics/mip:v10.0.0
   multiqc:
     executable:
       multiqc:


### PR DESCRIPTION
### This PR adds | fixes:

- The previous gene panel regexp didn't work for gene panel header lines that had extra commas, such as `##gene_panel=NBS-M,version=17.0,updated_at=2021-02-24,display_name=New born screening, metabolic` 
- Use the automated build of MIP
- Bumps memory for version_collect

### How to test:

- Automatic and continuous test suite

### Expected outcome:
- [x] Installation, unit and integration test suite pass

### Review:
- [ ] Code review
- [ ] Tests pass

This [version](https://semver.org/) is a:
- [ ] **MAJOR** - when you make incompatible API changes. If applicable record manual test results in PR header
- [ ] **MINOR** - when you add functionality in a backwards compatible manner. If applicable record manual test results in PR header
- [x] **PATCH** - when you make backwards compatible bug fixes or documentation/instructions
