### PR TITLE
remove duplicates from glnexus output

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,10 @@
 All notable changes to this project will be documented in this file.
 This project adheres to [Semantic Versioning](http://semver.org/).
 
+## [10.0.3]
+
+- Remove duplicates from Glnexus output
+
 ## [10.0.2]
 
 - Glnexus are used to genotype the gvcf regardless of how many samples that are analysed.

--- a/lib/MIP/Constants.pm
+++ b/lib/MIP/Constants.pm
@@ -81,7 +81,7 @@ Readonly our %ANALYSIS => (
 );
 
 ## Set MIP version
-Readonly our $MIP_VERSION => q{10.0.2};
+Readonly our $MIP_VERSION => q{10.0.3};
 
 ## Cli
 Readonly our $MOOSEX_APP_SCEEN_WIDTH => 160;

--- a/lib/MIP/Recipes/Analysis/Glnexus.pm
+++ b/lib/MIP/Recipes/Analysis/Glnexus.pm
@@ -204,13 +204,14 @@ sub analysis_glnexus {
 
     bcftools_norm(
         {
-            filehandle     => $filehandle,
-            infile_path    => $DASH,
-            multiallelic   => q{-},
-            outfile_path   => $outfile_path,
-            output_type    => q{z},
-            reference_path => $active_parameter_href->{human_genome_reference},
-            threads        => $core_number,
+            filehandle        => $filehandle,
+            infile_path       => $DASH,
+            multiallelic      => q{-},
+            outfile_path      => $outfile_path,
+            output_type       => q{z},
+            reference_path    => $active_parameter_href->{human_genome_reference},
+            remove_duplicates => 1,
+            threads           => $core_number,
         }
     );
     say {$filehandle} $NEWLINE;

--- a/lib/MIP/Recipes/Analysis/Glnexus.pm
+++ b/lib/MIP/Recipes/Analysis/Glnexus.pm
@@ -202,11 +202,24 @@ sub analysis_glnexus {
     );
     print {$filehandle} $PIPE . $SPACE;
 
+    ## Normalize
+    bcftools_norm(
+        {
+            filehandle     => $filehandle,
+            infile_path    => $DASH,
+            multiallelic   => q{-},
+            output_type    => q{u},
+            reference_path => $active_parameter_href->{human_genome_reference},
+            threads        => $core_number,
+        }
+    );
+    print {$filehandle} $PIPE . $SPACE;
+
+    ## Remove duplicates
     bcftools_norm(
         {
             filehandle        => $filehandle,
             infile_path       => $DASH,
-            multiallelic      => q{-},
             outfile_path      => $outfile_path,
             output_type       => q{z},
             reference_path    => $active_parameter_href->{human_genome_reference},

--- a/templates/mip_install_config.yaml
+++ b/templates/mip_install_config.yaml
@@ -117,7 +117,7 @@ container:
   mip:
     executable:
       mip:
-    uri: docker.io/clinicalgenomics/mip:v10.0.2
+    uri: docker.io/clinicalgenomics/mip:v10.0.3
   multiqc:
     executable:
       multiqc:


### PR DESCRIPTION
### This PR adds | fixes:

There are still duplicate variants in the output from the glnexus recipe. This PR activates the flag `--rm-dups none` in the bcftools command of the glnexus recipe

### How to test:

- Automatic and continuous test suite
- Run brightcaiman from the glnexus step. 

### Expected outcome:
- [ ] Installation, unit and integration test suite pass
- [ ] No duplicate variants in the output from the glnexus recipe

### Review:
- [ ] Code review
- [ ] Tests pass

This [version](https://semver.org/) is a:
- [ ] **MAJOR** - when you make incompatible API changes. If applicable record manual test results in PR header
- [ ] **MINOR** - when you add functionality in a backwards compatible manner. If applicable record manual test results in PR header
- [ ] **PATCH** - when you make backwards compatible bug fixes or documentation/instructions
