### PR TITLE
feat(store): Only add metrics deliverables to file store

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,9 @@
 All notable changes to this project will be documented in this file.
 This project adheres to [Semantic Versioning](http://semver.org/).
 
+## [10.1.0]
+- Only store qc_metrics_deliverables path in file store for downstream parsing
+
 ## [10.0.3]
 
 - Remove duplicates from Glnexus output

--- a/lib/MIP/Constants.pm
+++ b/lib/MIP/Constants.pm
@@ -81,7 +81,7 @@ Readonly our %ANALYSIS => (
 );
 
 ## Set MIP version
-Readonly our $MIP_VERSION => q{10.0.3};
+Readonly our $MIP_VERSION => q{10.1.0};
 
 ## Cli
 Readonly our $MOOSEX_APP_SCEEN_WIDTH => 160;

--- a/lib/MIP/Recipes/Analysis/Mip_qccollect.pm
+++ b/lib/MIP/Recipes/Analysis/Mip_qccollect.pm
@@ -201,18 +201,16 @@ sub analysis_mip_qccollect {
             }
         );
 
-        if ( defined $active_parameter_href->{qccollect_store_metrics_outfile} ) {
+        set_file_path_to_store(
+            {
+                format           => q{meta},
+                id               => $case_id,
+                path             => $active_parameter_href->{qccollect_store_metrics_outfile},
+                recipe_name      => $recipe_name,
+                sample_info_href => $sample_info_href,
+            }
+        );
 
-            set_file_path_to_store(
-                {
-                    format           => q{meta},
-                    id               => $case_id,
-                    path             => $active_parameter_href->{qccollect_store_metrics_outfile},
-                    recipe_name      => $recipe_name,
-                    sample_info_href => $sample_info_href,
-                }
-            );
-        }
         submit_recipe(
             {
                 base_command         => $profile_base_command,

--- a/lib/MIP/Recipes/Analysis/Mip_qccollect.pm
+++ b/lib/MIP/Recipes/Analysis/Mip_qccollect.pm
@@ -201,16 +201,6 @@ sub analysis_mip_qccollect {
             }
         );
 
-        set_file_path_to_store(
-            {
-                format           => q{meta},
-                id               => $case_id,
-                path             => $outfile_path,
-                recipe_name      => $recipe_name,
-                sample_info_href => $sample_info_href,
-            }
-        );
-
         if ( defined $active_parameter_href->{qccollect_store_metrics_outfile} ) {
 
             set_file_path_to_store(
@@ -222,7 +212,6 @@ sub analysis_mip_qccollect {
                     sample_info_href => $sample_info_href,
                 }
             );
-
         }
         submit_recipe(
             {

--- a/templates/mip_install_config.yaml
+++ b/templates/mip_install_config.yaml
@@ -117,7 +117,7 @@ container:
   mip:
     executable:
       mip:
-    uri: docker.io/clinicalgenomics/mip:v10.0.3
+    uri: docker.io/clinicalgenomics/mip:v10.1.0
   multiqc:
     executable:
       multiqc:


### PR DESCRIPTION
### This PR adds | fixes:
- Only add metric deliverables as output file for downstream use 

### How to test:

- Automatic and continuous test suite

### Expected outcome:
- [x] Installation, unit and integration test suite pass

### Review:
- [x] Code review
- [x] Tests pass

This [version](https://semver.org/) is a:
- [ ] **MAJOR** - when you make incompatible API changes. If applicable record manual test results in PR header
- [x] **MINOR** - when you add functionality in a backwards compatible manner. If applicable record manual test results in PR header
- [ ] **PATCH** - when you make backwards compatible bug fixes or documentation/instructions
