### PR TITLE
Feature/start after recipe flag

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,9 @@
 All notable changes to this project will be documented in this file.
 This project adheres to [Semantic Versioning](http://semver.org/).
 
+## [10.1.0]
+- Only store qc_metrics_deliverables path in file store for downstream parsing
+
 ## [10.0.3]
 
 - Remove duplicates from Glnexus output

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,12 @@
 All notable changes to this project will be documented in this file.
 This project adheres to [Semantic Versioning](http://semver.org/).
 
+## [10.2.0]
+
+- Introduced the option `--start_after_recipe <recipe_name>` to start the pipeline after a given recipe
+
 ## [10.1.0]
+
 - Only store qc_metrics_deliverables path in file store for downstream parsing
 
 ## [10.0.3]

--- a/README.md
+++ b/README.md
@@ -169,7 +169,7 @@ MIP is called from the command line and takes input from the command line \(prec
 Lists are supplied as repeated flag entries on the command line or in the config using the yaml format for arrays.  
 Only flags that will actually be used needs to be specified and MIP will check that all required parameters are set before submitting to SLURM.
 
-Recipe parameters can be set to "0" \(=off\), "1" \(=on\) and "2" \(=dry run mode\). Any recipe can be set to dry run mode and MIP will create the sbatch scripts, but not submit them to SLURM. MIP can be restarted from any recipe using the ``--start_with_recipe`` flag.
+Recipe parameters can be set to "0" \(=off\), "1" \(=on\) and "2" \(=dry run mode\). Any recipe can be set to dry run mode and MIP will create the sbatch scripts, but not submit them to SLURM. MIP can be restarted from any recipe using the ``--start_with_recipe`` flag and after any recipe using the `--start_after_recipe` flag.
 
 MIP will overwrite data files when reanalyzing, but keeps all "versioned" sbatch scripts for traceability.
 

--- a/definitions/analyse_parameters.yaml
+++ b/definitions/analyse_parameters.yaml
@@ -204,6 +204,12 @@ slurm_quality_of_service:
   data_type: SCALAR
   default: normal
   type: mip
+start_after_recipe:
+  associated_recipe:
+    - mip
+  data_type: SCALAR
+  mandatory: no
+  type: mip
 start_with_recipe:
   associated_recipe:
     - mip

--- a/documentation/README.md
+++ b/documentation/README.md
@@ -169,7 +169,7 @@ MIP is called from the command line and takes input from the command line \(prec
 Lists are supplied as repeated flag entries on the command line or in the config using the yaml format for arrays.  
 Only flags that will actually be used needs to be specified and MIP will check that all required parameters are set before submitting to SLURM.
 
-Recipe parameters can be set to "0" \(=off\), "1" \(=on\) and "2" \(=dry run mode\). Any recipe can be set to dry run mode and MIP will create the sbatch scripts, but not submit them to SLURM. MIP can be restarted from any recipe using the ``--start_with_recipe`` flag.
+Recipe parameters can be set to "0" \(=off\), "1" \(=on\) and "2" \(=dry run mode\). Any recipe can be set to dry run mode and MIP will create the sbatch scripts, but not submit them to SLURM. MIP can be restarted from any recipe using the ``--start_with_recipe`` flag and after any recipe using the `--start_after_recipe` flag.
 
 MIP will overwrite data files when reanalyzing, but keeps all "versioned" sbatch scripts for traceability.
 

--- a/lib/MIP/Cli/Mip/Analyse.pm
+++ b/lib/MIP/Cli/Mip/Analyse.pm
@@ -321,6 +321,15 @@ q{Default: jobid, jobname%50, account, partition, alloccpus, TotalCPU, elapsed, 
     );
 
     option(
+        q{start_after_recipe} => (
+            cmd_aliases   => [qw{ sar }],
+            documentation => q{Start analysis after recipe},
+            is            => q{rw},
+            isa           => Str,
+        )
+    );
+
+    option(
         q{start_with_recipe} => (
             cmd_aliases   => [qw{ swr }],
             documentation => q{Start analysis with recipe},

--- a/lib/MIP/Constants.pm
+++ b/lib/MIP/Constants.pm
@@ -81,7 +81,7 @@ Readonly our %ANALYSIS => (
 );
 
 ## Set MIP version
-Readonly our $MIP_VERSION => q{10.0.3};
+Readonly our $MIP_VERSION => q{10.1.0};
 
 ## Cli
 Readonly our $MOOSEX_APP_SCEEN_WIDTH => 160;

--- a/lib/MIP/Constants.pm
+++ b/lib/MIP/Constants.pm
@@ -81,7 +81,7 @@ Readonly our %ANALYSIS => (
 );
 
 ## Set MIP version
-Readonly our $MIP_VERSION => q{10.1.0};
+Readonly our $MIP_VERSION => q{10.2.0};
 
 ## Cli
 Readonly our $MOOSEX_APP_SCEEN_WIDTH => 160;

--- a/lib/MIP/Main/Analyse.pm
+++ b/lib/MIP/Main/Analyse.pm
@@ -61,7 +61,7 @@ use MIP::Pedigree qw{ create_fam_file
 };
 use MIP::Pipeline qw{ run_analyse_pipeline };
 use MIP::Processmanagement::Processes qw{ write_job_ids_to_file };
-use MIP::Recipes::Parse qw{ parse_recipes parse_start_with_recipe };
+use MIP::Recipes::Parse qw{ parse_recipes parse_initiation_recipe };
 use MIP::Reference qw{ check_human_genome_file_endings };
 use MIP::Sample_info qw{
   reload_previous_pedigree_info
@@ -211,10 +211,9 @@ sub mip_analyse {
 ## Set default from parameter hash to active_parameter for uninitilized parameters
     set_default(
         {
-            active_parameter_href => $active_parameter_href,
-            custom_default_parameters_ref =>
-              $parameter_href->{custom_default_parameters}{default},
-            parameter_href => $parameter_href,
+            active_parameter_href         => $active_parameter_href,
+            custom_default_parameters_ref => $parameter_href->{custom_default_parameters}{default},
+            parameter_href                => $parameter_href,
         }
     );
 
@@ -237,10 +236,9 @@ sub mip_analyse {
 ## Detect version and source of the human_genome_reference: Source (hg19 or GRCh) and check compression status
     set_human_genome_reference_features(
         {
-            file_info_href => $file_info_href,
-            human_genome_reference =>
-              basename( $active_parameter_href->{human_genome_reference} ),
-            parameter_href => $parameter_href,
+            file_info_href         => $file_info_href,
+            human_genome_reference => basename( $active_parameter_href->{human_genome_reference} ),
+            parameter_href         => $parameter_href,
         }
     );
 
@@ -283,10 +281,9 @@ sub mip_analyse {
         {
             human_genome_reference_file_endings_ref =>
               $file_info_href->{human_genome_reference_file_endings},
-            human_genome_reference_path =>
-              $active_parameter_href->{human_genome_reference},
-            parameter_href => $parameter_href,
-            parameter_name => q{human_genome_reference_file_endings},
+            human_genome_reference_path => $active_parameter_href->{human_genome_reference},
+            parameter_href              => $parameter_href,
+            parameter_name              => q{human_genome_reference_file_endings},
         }
     );
 
@@ -392,7 +389,7 @@ sub mip_analyse {
         }
     );
 
-    parse_start_with_recipe(
+    parse_initiation_recipe(
         {
             active_parameter_href => $active_parameter_href,
             parameter_href        => $parameter_href,
@@ -494,10 +491,8 @@ sub mip_analyse {
         {
             case_id           => $active_parameter_href->{case_id},
             job_id_href       => \%job_id,
-            job_ids_file_path => catfile(
-                $active_parameter_href->{outdata_dir},
-                q{slurm_job_ids} . $DOT . q{yaml}
-            ),
+            job_ids_file_path =>
+              catfile( $active_parameter_href->{outdata_dir}, q{slurm_job_ids} . $DOT . q{yaml} ),
         }
     );
 

--- a/lib/MIP/Recipes/Analysis/Mip_qccollect.pm
+++ b/lib/MIP/Recipes/Analysis/Mip_qccollect.pm
@@ -201,18 +201,16 @@ sub analysis_mip_qccollect {
             }
         );
 
-        if ( defined $active_parameter_href->{qccollect_store_metrics_outfile} ) {
+        set_file_path_to_store(
+            {
+                format           => q{meta},
+                id               => $case_id,
+                path             => $active_parameter_href->{qccollect_store_metrics_outfile},
+                recipe_name      => $recipe_name,
+                sample_info_href => $sample_info_href,
+            }
+        );
 
-            set_file_path_to_store(
-                {
-                    format           => q{meta},
-                    id               => $case_id,
-                    path             => $active_parameter_href->{qccollect_store_metrics_outfile},
-                    recipe_name      => $recipe_name,
-                    sample_info_href => $sample_info_href,
-                }
-            );
-        }
         submit_recipe(
             {
                 base_command         => $profile_base_command,

--- a/lib/MIP/Recipes/Analysis/Mip_qccollect.pm
+++ b/lib/MIP/Recipes/Analysis/Mip_qccollect.pm
@@ -201,16 +201,6 @@ sub analysis_mip_qccollect {
             }
         );
 
-        set_file_path_to_store(
-            {
-                format           => q{meta},
-                id               => $case_id,
-                path             => $outfile_path,
-                recipe_name      => $recipe_name,
-                sample_info_href => $sample_info_href,
-            }
-        );
-
         if ( defined $active_parameter_href->{qccollect_store_metrics_outfile} ) {
 
             set_file_path_to_store(
@@ -222,7 +212,6 @@ sub analysis_mip_qccollect {
                     sample_info_href => $sample_info_href,
                 }
             );
-
         }
         submit_recipe(
             {

--- a/t/parse_initiation_recipe.t
+++ b/t/parse_initiation_recipe.t
@@ -30,16 +30,16 @@ BEGIN {
 ### Check all internal dependency modules and imports
 ## Modules with import
     my %perl_module = (
-        q{MIP::Recipes::Parse} => [qw{ parse_start_with_recipe }],
+        q{MIP::Recipes::Parse} => [qw{ parse_initiation_recipe }],
         q{MIP::Test::Fixtures} => [qw{ test_log test_mip_hashes }],
     );
 
     test_import( { perl_module_href => \%perl_module, } );
 }
 
-use MIP::Recipes::Parse qw{ parse_start_with_recipe };
+use MIP::Recipes::Parse qw{ parse_initiation_recipe };
 
-diag(   q{Test parse_start_with_recipe from Parse.pm}
+diag(   q{Test parse_initiation_recipe from Parse.pm}
       . $COMMA
       . $SPACE . q{Perl}
       . $SPACE
@@ -47,15 +47,18 @@ diag(   q{Test parse_start_with_recipe from Parse.pm}
       . $SPACE
       . $EXECUTABLE_NAME );
 
-my $log = test_log( {} );
+test_log( {} );
 
-## Given no defined start_with_recipe parameter
+## Given no defined start_with_recipe or start_after_recipe parameter
 my %active_parameter;
-my %parameter = ( bwa_mem => { default => 0, }, );
+my %parameter = (
+    bwa_mem        => { default => 0, },
+    markduplicates => { default => 0, },
+);
 my %dependency_tree = test_mip_hashes( { mip_hash_name => q{dependency_tree_dna} } );
 $parameter{dependency_tree_href} = \%dependency_tree;
 
-my $return = parse_start_with_recipe(
+my $return = parse_initiation_recipe(
     {
         active_parameter_href => \%active_parameter,
         parameter_href        => \%parameter,
@@ -68,7 +71,7 @@ is( $return, undef, q{Skip parsing} );
 ## Given start_with_recipe parameter, when defined
 $active_parameter{start_with_recipe} = q{bwa_mem};
 
-my $is_ok = parse_start_with_recipe(
+my $is_ok = parse_initiation_recipe(
     {
         active_parameter_href => \%active_parameter,
         parameter_href        => \%parameter,
@@ -77,5 +80,19 @@ my $is_ok = parse_start_with_recipe(
 
 ## Then return true for successful parsing
 ok( $is_ok, q{Parsed programs from start_with_flag} );
+
+## Given start_after_recipe parameter, when defined
+$active_parameter{start_after_recipe} = q{markduplicates};
+$active_parameter{start_with_recipe}  = undef;
+
+$is_ok = parse_initiation_recipe(
+    {
+        active_parameter_href => \%active_parameter,
+        parameter_href        => \%parameter,
+    },
+);
+
+## Then return true for successful parsing
+ok( $is_ok, q{Parsed programs from start_after_flag} );
 
 done_testing();

--- a/templates/mip_install_config.yaml
+++ b/templates/mip_install_config.yaml
@@ -117,7 +117,7 @@ container:
   mip:
     executable:
       mip:
-    uri: docker.io/clinicalgenomics/mip:v10.1.0
+    uri: docker.io/clinicalgenomics/mip:v10.2.0
   multiqc:
     executable:
       multiqc:

--- a/templates/mip_install_config.yaml
+++ b/templates/mip_install_config.yaml
@@ -117,7 +117,7 @@ container:
   mip:
     executable:
       mip:
-    uri: docker.io/clinicalgenomics/mip:v10.0.3
+    uri: docker.io/clinicalgenomics/mip:v10.1.0
   multiqc:
     executable:
       multiqc:


### PR DESCRIPTION
### This PR adds | fixes:

- There has been a request from production for a way to tell mip to start after a certain recipe. This is useful in cases when MIP crashes at a branching point (such as markduplicates), requiring some manual fixing. The --start_after_recipe flags works in the same way as the --start_with_recipe, only shifting the initiation point one recipe forward.

### How to test:

- Automatic and continuous test suite
- install on stage and do a test run


### Expected outcome:
- [x] Installation, unit and integration test suite pass

### Review:
- [x] Code review HS
- [x] Tests pass

This [version](https://semver.org/) is a:
- [ ] **MAJOR** - when you make incompatible API changes. If applicable record manual test results in PR header
- [x] **MINOR** - when you add functionality in a backwards compatible manner. If applicable record manual test results in PR header
- [ ] **PATCH** - when you make backwards compatible bug fixes or documentation/instructions
