### PR TITLE
Add mitodel recipe

### DIFF
--- a/definitions/rd_dna_initiation_map.yaml
+++ b/definitions/rd_dna_initiation_map.yaml
@@ -18,6 +18,8 @@ CHAIN_ALL:
     - CHAIN_TCOV:
       - tiddit_coverage
       - chromograph_cov
+    - CHAIN_MTDEL:
+      - mitodel
     - CHAIN_SBCOV:
       - sambamba_depth
     - CHAIN_SMN:

--- a/definitions/rd_dna_parameters.yaml
+++ b/definitions/rd_dna_parameters.yaml
@@ -175,6 +175,7 @@ recipe_core_number:
     gzip_fastq: 0
     manta: 36
     markduplicates: 13
+    mitodel: 1
     mt_annotation: 1
     multiqc_ar: 1
     peddy_ar: 4
@@ -240,6 +241,7 @@ recipe_memory:
     gatk_variantrecalibration: 30
     glnexus_merge: 10
     markduplicates: 10
+    mitodel: 2
     mt_annotation: 2
     picardtools_collecthsmetrics: 8
     picardtools_collectmultiplemetrics: 8
@@ -295,6 +297,7 @@ recipe_time:
     gzip_fastq: 2
     manta: 30
     markduplicates: 20
+    mitodel: 2
     mt_annotation: 1
     multiqc_ar: 5
     peddy_ar: 1
@@ -1532,6 +1535,15 @@ bcftools_core:
     - bcftools
     - bgzip
     - tabix
+  type: recipe
+mitodel:
+  analysis_mode: sample
+  associated_recipe:
+    - mip
+  data_type: SCALAR
+  default: 1
+  outfile_suffix: ".txt"
+  file_tag: _mitodel
   type: recipe
 mt_annotation:
   analysis_mode: case

--- a/definitions/rd_dna_parameters.yaml
+++ b/definitions/rd_dna_parameters.yaml
@@ -1544,6 +1544,8 @@ mitodel:
   default: 1
   outfile_suffix: ".txt"
   file_tag: _mitodel
+  program_executables:
+    - samtools
   type: recipe
 mt_annotation:
   analysis_mode: case

--- a/lib/MIP/Program/Samtools.pm
+++ b/lib/MIP/Program/Samtools.pm
@@ -887,7 +887,6 @@ sub samtools_stats {
         },
         insert_size => {
             allow       => qr/ ^\d+$ /sxm,
-            default     => 16000,
             store       => \$insert_size,
             strict_type => 1,
         },

--- a/lib/MIP/Program/Samtools.pm
+++ b/lib/MIP/Program/Samtools.pm
@@ -919,7 +919,7 @@ sub samtools_stats {
 
     if ($insert_size) {
 
-        push @commands, q{-i} . $SPACE . $insert_size;
+        push @commands, q{--insert-size} . $SPACE . $insert_size;
     }
 
     if ($remove_overlap) {

--- a/lib/MIP/Program/Samtools.pm
+++ b/lib/MIP/Program/Samtools.pm
@@ -325,11 +325,10 @@ sub samtools_faidx {
             store       => \$infile_path,
             strict_type => 1,
         },
-        outfile_path => { store => \$outfile_path, strict_type => 1, },
-        regions_ref => { default => [], store => \$regions_ref, strict_type => 1, },
-        stderrfile_path => { store => \$stderrfile_path, strict_type => 1, },
-        stderrfile_path_append =>
-          { store => \$stderrfile_path_append, strict_type => 1, },
+        outfile_path           => { store   => \$outfile_path, strict_type => 1, },
+        regions_ref            => { default => [], store => \$regions_ref, strict_type => 1, },
+        stderrfile_path        => { store   => \$stderrfile_path,        strict_type => 1, },
+        stderrfile_path_append => { store   => \$stderrfile_path_append, strict_type => 1, },
     };
 
     check( $tmpl, $arg_href, 1 ) or croak q{Could not parse arguments!};
@@ -412,10 +411,8 @@ sub samtools_flagstat {
 
     check( $tmpl, $arg_href, 1 ) or croak q{Could not parse arguments!};
 
-    my @commands = (
-        get_executable_base_command( { base_command => $BASE_COMMAND, } ),
-        qw{ flagstat }
-    );
+    my @commands =
+      ( get_executable_base_command( { base_command => $BASE_COMMAND, } ), qw{ flagstat } );
 
     push @commands, $infile_path;
 
@@ -484,10 +481,8 @@ sub samtools_idxstats {
 
     check( $tmpl, $arg_href, 1 ) or croak q{Could not parse arguments!};
 
-    my @commands = (
-        get_executable_base_command( { base_command => $BASE_COMMAND, } ),
-        qw{ idxstats }
-    );
+    my @commands =
+      ( get_executable_base_command( { base_command => $BASE_COMMAND, } ), qw{ idxstats } );
 
     push @commands, $infile_path;
 
@@ -541,10 +536,9 @@ sub samtools_index {
             store       => \$infile_path,
             strict_type => 1,
         },
-        stderrfile_path => { store => \$stderrfile_path, strict_type => 1, },
-        stderrfile_path_append =>
-          { store => \$stderrfile_path_append, strict_type => 1, },
-        stdoutfile_path => { store => \$stdoutfile_path, strict_type => 1, },
+        stderrfile_path        => { store => \$stderrfile_path,        strict_type => 1, },
+        stderrfile_path_append => { store => \$stderrfile_path_append, strict_type => 1, },
+        stdoutfile_path        => { store => \$stdoutfile_path,        strict_type => 1, },
     };
 
     check( $tmpl, $arg_href, 1 ) or croak q{Could not parse arguments!};
@@ -643,10 +637,9 @@ sub samtools_merge {
             store       => \$region,
             strict_type => 1,
         },
-        stderrfile_path => { store => \$stderrfile_path, strict_type => 1, },
-        stderrfile_path_append =>
-          { store => \$stderrfile_path_append, strict_type => 1, },
-        stdoutfile_path => {
+        stderrfile_path        => { store => \$stderrfile_path,        strict_type => 1, },
+        stderrfile_path_append => { store => \$stderrfile_path_append, strict_type => 1, },
+        stdoutfile_path        => {
             strict_type => 1,
             store       => \$stdoutfile_path,
         },
@@ -775,10 +768,9 @@ sub samtools_sort {
             store       => \$referencefile_path,
             strict_type => 1,
         },
-        stderrfile_path => { store => \$stderrfile_path, strict_type => 1, },
-        stderrfile_path_append =>
-          { store => \$stderrfile_path_append, strict_type => 1, },
-        stdoutfile_path => {
+        stderrfile_path        => { store => \$stderrfile_path,        strict_type => 1, },
+        stderrfile_path_append => { store => \$stderrfile_path_append, strict_type => 1, },
+        stdoutfile_path        => {
             strict_type => 1,
             store       => \$stdoutfile_path,
         },
@@ -855,6 +847,7 @@ sub samtools_stats {
 ##          : $auto_detect_input_format => Ignored (input format is auto-detected)
 ##          : $filehandle               => Sbatch filehandle to write to
 ##          : $infile_path              => Infile path
+##          : $insert_size              => Maximum insert size
 ##          : $outfile_path             => Outfile path
 ##          : $regions_ref              => Regions to process {REF}
 ##          : $remove_overlap           => Remove overlaps of paired-end reads from coverage and base count computations
@@ -867,6 +860,7 @@ sub samtools_stats {
     ## Flatten argument(s)
     my $filehandle;
     my $infile_path;
+    my $insert_size;
     my $outfile_path;
     my $regions_ref;
     my $stderrfile_path;
@@ -891,6 +885,12 @@ sub samtools_stats {
             store       => \$infile_path,
             strict_type => 1,
         },
+        insert_size => {
+            allow       => qr/ ^\d+$ /sxm,
+            default     => 8000,
+            store       => \$insert_size,
+            strict_type => 1,
+        },
         outfile_path   => { store => \$outfile_path, strict_type => 1, },
         remove_overlap => {
             allow       => [ undef, 0, 1 ],
@@ -898,11 +898,10 @@ sub samtools_stats {
             store       => \$remove_overlap,
             strict_type => 1,
         },
-        regions_ref => { default => [], store => \$regions_ref, strict_type => 1, },
-        stderrfile_path => { store => \$stderrfile_path, strict_type => 1, },
-        stderrfile_path_append =>
-          { store => \$stderrfile_path_append, strict_type => 1, },
-        stdoutfile_path => {
+        regions_ref            => { default => [], store => \$regions_ref, strict_type => 1, },
+        stderrfile_path        => { store   => \$stderrfile_path,        strict_type => 1, },
+        stderrfile_path_append => { store   => \$stderrfile_path_append, strict_type => 1, },
+        stdoutfile_path        => {
             strict_type => 1,
             store       => \$stdoutfile_path,
         },
@@ -916,6 +915,11 @@ sub samtools_stats {
     if ($auto_detect_input_format) {
 
         push @commands, q{-s};
+    }
+
+    if ($insert_size) {
+
+        push @commands, q{-i} . $SPACE . $insert_size;
     }
 
     if ($remove_overlap) {

--- a/lib/MIP/Program/Samtools.pm
+++ b/lib/MIP/Program/Samtools.pm
@@ -887,7 +887,7 @@ sub samtools_stats {
         },
         insert_size => {
             allow       => qr/ ^\d+$ /sxm,
-            default     => 8000,
+            default     => 16000,
             store       => \$insert_size,
             strict_type => 1,
         },

--- a/lib/MIP/Recipes/Analysis/Mitodel.pm
+++ b/lib/MIP/Recipes/Analysis/Mitodel.pm
@@ -252,6 +252,7 @@ sub analysis_mitodel {
                 path             => $outfile_path,
                 recipe_name      => $recipe_name,
                 sample_info_href => $sample_info_href,
+                tag              => q{mitodel},
             }
         );
 

--- a/lib/MIP/Recipes/Analysis/Mitodel.pm
+++ b/lib/MIP/Recipes/Analysis/Mitodel.pm
@@ -151,13 +151,13 @@ sub analysis_mitodel {
 
     my $mt_infile_path;
 
-    foreach my $chr_suffix ( @{ $io{in}{file_suffixes} } ) {
-        if ( $chr_suffix eq ".MT.bam" ) {
-            $mt_infile_path = $io{in}{file_path_prefix} . $chr_suffix;
+    foreach my $contig ( keys %infile_path ) {
+
+        if ( $contig =~ / MT|M /xsm ) {
+            
+            $mt_infile_path = $infile_path{$contig};
         }
-        elsif ( $chr_suffix eq ".chrM.bam" ) {
-            $mt_infile_path = $io{in}{file_path_prefix} . $chr_suffix;
-        }
+
     }
 
     my %recipe = parse_recipe_prerequisites(

--- a/lib/MIP/Recipes/Analysis/Mitodel.pm
+++ b/lib/MIP/Recipes/Analysis/Mitodel.pm
@@ -34,12 +34,12 @@ sub analysis_mitodel {
 ## Function : Report mitochondria deletion signatures from WGS data
 ## Returns  :
 ## Arguments: $active_parameter_href   => Active parameters for this analysis hash {REF}
-##          : $case_id                 => Family id
 ##          : $file_info_href          => File_info hash {REF}
 ##          : $job_id_href             => Job id hash {REF}
 ##          : $parameter_href          => Parameter hash {REF}
 ##          : $profile_base_command    => Submission profile base command
 ##          : $recipe_name             => Recipe name
+##          : $sample_id               => Sample id
 ##          : $sample_info_href        => Info on samples and case hash {REF}
 
     my ($arg_href) = @_;
@@ -126,7 +126,7 @@ sub analysis_mitodel {
     use MIP::Program::Samtools qw{ samtools_stats };
     use MIP::Processmanagement::Processes qw{ submit_recipe };
     use MIP::Recipe qw{ parse_recipe_prerequisites };
-    use MIP::Sample_info qw{ set_recipe_outfile_in_sample_info };
+    use MIP::Sample_info qw{ set_file_path_to_store set_recipe_outfile_in_sample_info };
     use MIP::Script::Setup_script qw{ setup_script };
 
     ### PREPROCESSING:
@@ -206,7 +206,7 @@ sub analysis_mitodel {
             auto_detect_input_format => 1,
             filehandle               => $filehandle,
             infile_path              => $mt_infile_path,
-            insert_size              => 16000,
+            insert_size              => 16_000,
         }
     );
     print {$filehandle} $PIPE . $SPACE;

--- a/lib/MIP/Recipes/Analysis/Mitodel.pm
+++ b/lib/MIP/Recipes/Analysis/Mitodel.pm
@@ -167,20 +167,18 @@ sub analysis_mitodel {
         }
     );
 
-    my @contig_iterator = qw(MT);
     ## Set and get the io files per chain, id and stream
     %io = (
         %io,
         parse_io_outfiles(
             {
-                chain_id         => $recipe{job_id_chain},
-                id               => $case_id,
-                file_info_href   => $file_info_href,
-                file_name_prefix => $infile_name_prefix,
-                iterators_ref    => \@contig_iterator,
-                outdata_dir      => $active_parameter_href->{outdata_dir},
-                parameter_href   => $parameter_href,
-                recipe_name      => $recipe_name,
+                chain_id               => $recipe{job_id_chain},
+                id                     => $case_id,
+                file_info_href         => $file_info_href,
+                file_name_prefixes_ref => [$infile_name_prefix],
+                outdata_dir            => $active_parameter_href->{outdata_dir},
+                parameter_href         => $parameter_href,
+                recipe_name            => $recipe_name,
             }
         )
     );

--- a/lib/MIP/Recipes/Analysis/Mitodel.pm
+++ b/lib/MIP/Recipes/Analysis/Mitodel.pm
@@ -1,0 +1,278 @@
+package MIP::Recipes::Analysis::Mitodel;
+
+use 5.026;
+use Carp;
+use charnames qw{ :full :short };
+use English qw{ -no_match_vars };
+use File::Basename qw{ dirname };
+use File::Spec::Functions qw{ catdir catfile devnull };
+use open qw{ :encoding(UTF-8) :std };
+use Params::Check qw{ allow check last_error };
+use utf8;
+use warnings;
+use warnings qw{ FATAL utf8 };
+
+## CPANM
+use autodie qw{ :all };
+use Readonly;
+
+## MIPs lib/
+use MIP::Constants qw{ $DASH $LOG_NAME $NEWLINE $PIPE $SPACE $UNDERSCORE };
+
+BEGIN {
+
+    require Exporter;
+    use base qw{ Exporter };
+
+    # Functions and variables which can be optionally exported
+    our @EXPORT_OK = qw{ analysis_mitodel };
+
+}
+
+sub analysis_mitodel {
+
+## Function : Report mitochondria deletion signatures from WGS data
+## Returns  :
+## Arguments: $active_parameter_href   => Active parameters for this analysis hash {REF}
+##          : $case_id                 => Family id
+##          : $file_info_href          => File_info hash {REF}
+##          : $job_id_href             => Job id hash {REF}
+##          : $parameter_href          => Parameter hash {REF}
+##          : $profile_base_command    => Submission profile base command
+##          : $recipe_name             => Recipe name
+##          : $sample_info_href        => Info on samples and case hash {REF}
+
+    my ($arg_href) = @_;
+
+    ## Flatten argument(s)
+    my $active_parameter_href;
+    my $file_info_href;
+    my $job_id_href;
+    my $parameter_href;
+    my $recipe_name;
+    my $sample_id;
+    my $sample_info_href;
+
+    ## Default(s)
+    my $case_id;
+    my $profile_base_command;
+
+    my $tmpl = {
+        active_parameter_href => {
+            default     => {},
+            defined     => 1,
+            required    => 1,
+            store       => \$active_parameter_href,
+            strict_type => 1,
+        },
+        case_id => {
+            default     => $arg_href->{active_parameter_href}{case_id},
+            store       => \$case_id,
+            strict_type => 1,
+        },
+        file_info_href => {
+            default     => {},
+            defined     => 1,
+            required    => 1,
+            store       => \$file_info_href,
+            strict_type => 1,
+        },
+        job_id_href => {
+            default     => {},
+            defined     => 1,
+            required    => 1,
+            store       => \$job_id_href,
+            strict_type => 1,
+        },
+        parameter_href => {
+            default     => {},
+            defined     => 1,
+            required    => 1,
+            store       => \$parameter_href,
+            strict_type => 1,
+        },
+        profile_base_command => {
+            default     => q{sbatch},
+            store       => \$profile_base_command,
+            strict_type => 1,
+        },
+        recipe_name => {
+            defined     => 1,
+            required    => 1,
+            store       => \$recipe_name,
+            strict_type => 1,
+        },
+        sample_id => {
+            defined     => 1,
+            required    => 1,
+            store       => \$sample_id,
+            strict_type => 1,
+        },
+        sample_info_href => {
+            default     => {},
+            defined     => 1,
+            required    => 1,
+            store       => \$sample_info_href,
+            strict_type => 1,
+        },
+    };
+
+    check( $tmpl, $arg_href, 1 ) or croak q{Could not parse arguments!};
+
+    use MIP::File_info qw{ get_io_files parse_io_outfiles };
+    use MIP::File::Path qw { remove_file_path_suffix };
+    use MIP::Language::Awk qw{ awk };
+    use MIP::Program::Gnu::Software::Gnu_grep qw{ gnu_grep };
+    use MIP::Program::Samtools qw{ samtools_stats };
+    use MIP::Processmanagement::Processes qw{ submit_recipe };
+    use MIP::Recipe qw{ parse_recipe_prerequisites };
+    use MIP::Sample_info qw{ set_recipe_outfile_in_sample_info };
+    use MIP::Script::Setup_script qw{ setup_script };
+
+    ### PREPROCESSING:
+
+    ## Retrieve logger object
+    my $log = Log::Log4perl->get_logger($LOG_NAME);
+
+    ## Unpack parameters
+    ## Get the io infiles per chain and id
+    my %io = get_io_files(
+        {
+            id             => $sample_id,
+            file_info_href => $file_info_href,
+            parameter_href => $parameter_href,
+            recipe_name    => $recipe_name,
+            stream         => q{in},
+        }
+    );
+
+    my $infile_name_prefix = $io{in}{file_name_prefix};
+    my %infile_path        = %{ $io{in}{file_path_href} };
+    my $mt_infile_path     = $io{in}{file_path_prefix} . q{.MT.bam};
+
+    my %recipe = parse_recipe_prerequisites(
+        {
+            active_parameter_href => $active_parameter_href,
+            parameter_href        => $parameter_href,
+            recipe_name           => $recipe_name,
+        }
+    );
+
+    my @contig_iterator = qw(MT);
+    ## Set and get the io files per chain, id and stream
+    %io = (
+        %io,
+        parse_io_outfiles(
+            {
+                chain_id         => $recipe{job_id_chain},
+                id               => $case_id,
+                file_info_href   => $file_info_href,
+                file_name_prefix => $infile_name_prefix,
+                iterators_ref    => \@contig_iterator,
+                outdata_dir      => $active_parameter_href->{outdata_dir},
+                parameter_href   => $parameter_href,
+                recipe_name      => $recipe_name,
+            }
+        )
+    );
+
+    my $outfile_path = $io{out}{file_path};
+
+    ## Filehandles
+    # Create anonymous filehandle
+    my $filehandle = IO::Handle->new();
+
+    ## Creates recipe directories (info & data & script), recipe script filenames and writes sbatch header
+    my ( $recipe_file_path, $recipe_info_path ) = setup_script(
+        {
+            active_parameter_href => $active_parameter_href,
+            core_number           => $recipe{core_number},
+            directory_id          => $case_id,
+            filehandle            => $filehandle,
+            job_id_href           => $job_id_href,
+            memory_allocation     => $recipe{memory},
+            process_time          => $recipe{time},
+            recipe_directory      => $recipe_name,
+            recipe_name           => $recipe_name,
+        }
+    );
+
+    ### SHELL:
+
+    say {$filehandle} q{## } . $recipe_name;
+
+    samtools_stats(
+        {
+            auto_detect_input_format => 1,
+            filehandle               => $filehandle,
+            infile_path              => $mt_infile_path,
+            insert_size              => 16000,
+        }
+    );
+    print {$filehandle} $PIPE . $SPACE;
+
+    gnu_grep(
+        {
+            filehandle  => $filehandle,
+            infile_path => $DASH,
+            pattern     => q{^IS},
+        }
+    );
+    print {$filehandle} $PIPE . $SPACE;
+
+    my $awk_statement =
+'($2>=1200 && $2<=15000) {sum=sum+$3} ($2<1200 || $2>15000) {sum_norm=sum_norm+$3} END {print "intermediate discordant ", sum, "normal ", sum_norm, "ratio ppk", sum*1000/(sum_norm+sum)}';
+
+    awk(
+        {
+            filehandle => $filehandle,
+            statement  => $awk_statement,
+        }
+    );
+    print {$filehandle} q{>} . $outfile_path;
+
+    ## Close filehandle
+    close $filehandle or $log->logcroak(q{Could not close filehandle});
+
+    if ( $recipe{mode} == 1 ) {
+
+        ## Collect QC metadata info for later use
+        set_recipe_outfile_in_sample_info(
+            {
+                path             => $outfile_path,
+                recipe_name      => $recipe_name,
+                sample_info_href => $sample_info_href,
+            }
+        );
+
+        set_file_path_to_store(
+            {
+                format           => q{meta},
+                id               => $sample_id,
+                path             => $outfile_path,
+                recipe_name      => $recipe_name,
+                sample_info_href => $sample_info_href,
+            }
+        );
+
+        submit_recipe(
+            {
+                base_command                      => $profile_base_command,
+                case_id                           => $case_id,
+                dependency_method                 => q{sample_to_case},
+                job_id_chain                      => $recipe{job_id_chain},
+                job_id_href                       => $job_id_href,
+                job_reservation_name              => $active_parameter_href->{job_reservation_name},
+                log                               => $log,
+                max_parallel_processes_count_href =>
+                  $file_info_href->{max_parallel_processes_count},
+                recipe_file_path   => $recipe_file_path,
+                sample_ids_ref     => \@{ $active_parameter_href->{sample_ids} },
+                submission_profile => $active_parameter_href->{submission_profile},
+            }
+        );
+    }
+    return 1;
+}
+
+1;

--- a/lib/MIP/Recipes/Analysis/Mitodel.pm
+++ b/lib/MIP/Recipes/Analysis/Mitodel.pm
@@ -173,7 +173,7 @@ sub analysis_mitodel {
         parse_io_outfiles(
             {
                 chain_id               => $recipe{job_id_chain},
-                id                     => $case_id,
+                id                     => $sample_id,
                 file_info_href         => $file_info_href,
                 file_name_prefixes_ref => [$infile_name_prefix],
                 outdata_dir            => $active_parameter_href->{outdata_dir},
@@ -194,7 +194,7 @@ sub analysis_mitodel {
         {
             active_parameter_href => $active_parameter_href,
             core_number           => $recipe{core_number},
-            directory_id          => $case_id,
+            directory_id          => $sample_id,
             filehandle            => $filehandle,
             job_id_href           => $job_id_href,
             memory_allocation     => $recipe{memory},
@@ -280,7 +280,7 @@ sub analysis_mitodel {
             {
                 base_command                      => $profile_base_command,
                 case_id                           => $case_id,
-                dependency_method                 => q{sample_to_case},
+                dependency_method                 => q{sample_to_island},
                 job_id_chain                      => $recipe{job_id_chain},
                 job_id_href                       => $job_id_href,
                 job_reservation_name              => $active_parameter_href->{job_reservation_name},
@@ -288,7 +288,7 @@ sub analysis_mitodel {
                 max_parallel_processes_count_href =>
                   $file_info_href->{max_parallel_processes_count},
                 recipe_file_path   => $recipe_file_path,
-                sample_ids_ref     => \@{ $active_parameter_href->{sample_ids} },
+                sample_id          => $sample_id,
                 submission_profile => $active_parameter_href->{submission_profile},
             }
         );

--- a/lib/MIP/Recipes/Pipeline/Analyse_rd_dna.pm
+++ b/lib/MIP/Recipes/Pipeline/Analyse_rd_dna.pm
@@ -129,7 +129,7 @@ sub parse_rd_dna {
     Readonly my @MIP_VEP_PLUGINS                 => qw{ sv_vep_plugin vep_plugin };
     Readonly my @ONLY_WGS_VARIANT_CALLER_RECIPES => qw{ cnvnator_ar delly_reformat tiddit };
     Readonly my @ONLY_WGS_RECIPIES               =>
-      qw{ chromograph_rhoviz cnvnator_ar delly_call delly_reformat expansionhunter
+      qw{ chromograph_rhoviz cnvnator_ar delly_call delly_reformat expansionhunter mitodel
       samtools_subsample_mt smncopynumbercaller star_caller telomerecat_ar tiddit };
     Readonly my @REMOVE_CONFIG_KEYS => qw{ associated_recipe };
 

--- a/lib/MIP/Recipes/Pipeline/Analyse_rd_dna.pm
+++ b/lib/MIP/Recipes/Pipeline/Analyse_rd_dna.pm
@@ -474,6 +474,7 @@ sub pipeline_analyse_rd_dna {
     use MIP::Recipes::Analysis::Mip_qccollect qw{ analysis_mip_qccollect };
     use MIP::Recipes::Analysis::Mip_vcfparser qw{ analysis_mip_vcfparser };
     use MIP::Recipes::Analysis::Mip_vercollect qw{ analysis_mip_vercollect };
+    use MIP::Recipes::Analysis::Mitodel qw{ analysis_mitodel };
     use MIP::Recipes::Analysis::Mt_annotation qw{ analysis_mt_annotation };
     use MIP::Recipes::Analysis::Multiqc qw{ analysis_multiqc };
     use MIP::Recipes::Analysis::Peddy qw{ analysis_peddy };
@@ -578,6 +579,7 @@ sub pipeline_analyse_rd_dna {
         gzip_fastq                         => \&analysis_gzip_fastq,
         manta                              => \&analysis_manta,
         markduplicates                     => \&analysis_markduplicates,
+        mitodel                            => \&analysis_mitodel,
         mt_annotation                      => \&analysis_mt_annotation,
         multiqc_ar                         => \&analysis_multiqc,
         peddy_ar                           => \&analysis_peddy,

--- a/t/analysis_mitodel.t
+++ b/t/analysis_mitodel.t
@@ -62,7 +62,6 @@ my %active_parameter = test_mip_hashes(
 $active_parameter{$recipe_name}                     = 1;
 $active_parameter{recipe_core_number}{$recipe_name} = 1;
 $active_parameter{recipe_time}{$recipe_name}        = 1;
-my $case_id   = $active_parameter{case_id};
 my $sample_id = $active_parameter{sample_ids}[0];
 
 my %file_info = test_mip_hashes(
@@ -106,5 +105,22 @@ my $is_ok = analysis_mitodel(
 
 ## Then return TRUE
 ok( $is_ok, q{ Executed analysis recipe } . $recipe_name );
+
+delete $file_info{io}{TEST}{ADM1059A1}{mitodel}{in}{file_paths}[-1];
+
+$is_ok = analysis_mitodel(
+    {
+        active_parameter_href => \%active_parameter,
+        file_info_href        => \%file_info,
+        job_id_href           => \%job_id,
+        parameter_href        => \%parameter,
+        profile_base_command  => $slurm_mock_cmd,
+        recipe_name           => $recipe_name,
+        sample_id             => $sample_id,
+        sample_info_href      => \%sample_info,
+    }
+);
+
+ok( $is_ok, qq{ Skipped analysis recipe $recipe_name when no Mitochondrial contig} );
 
 done_testing();

--- a/t/analysis_mitodel.t
+++ b/t/analysis_mitodel.t
@@ -1,0 +1,110 @@
+#!/usr/bin/env perl
+
+use 5.026;
+use Carp;
+use charnames qw{ :full :short };
+use English qw{ -no_match_vars };
+use File::Basename qw{ dirname };
+use File::Spec::Functions qw{ catdir catfile };
+use FindBin qw{ $Bin };
+use open qw{ :encoding(UTF-8) :std };
+use Params::Check qw{ allow check last_error };
+use Test::More;
+use utf8;
+use warnings qw{ FATAL utf8 };
+
+## CPANM
+use autodie qw { :all };
+use Modern::Perl qw{ 2018 };
+use Test::Trap;
+
+## MIPs lib/
+use lib catdir( dirname($Bin), q{lib} );
+use MIP::Constants qw{ $COLON $COMMA $SPACE };
+use MIP::Test::Fixtures qw{ test_add_io_for_recipe test_log test_mip_hashes };
+
+BEGIN {
+
+    use MIP::Test::Fixtures qw{ test_import };
+
+### Check all internal dependency modules and imports
+## Modules with import
+    my %perl_module = (
+        q{MIP::Recipes::Analysis::Mitodel} => [qw{ analysis_mitodel }],
+        q{MIP::Test::Fixtures} => [qw{ test_add_io_for_recipe test_log test_mip_hashes }],
+    );
+
+    test_import( { perl_module_href => \%perl_module, } );
+}
+
+use MIP::Recipes::Analysis::Mitodel qw{ analysis_mitodel };
+
+diag(   q{Test analysis_mitodel from Mitodel.pm}
+      . $COMMA
+      . $SPACE . q{Perl}
+      . $SPACE
+      . $PERL_VERSION
+      . $SPACE
+      . $EXECUTABLE_NAME );
+
+test_log( { log_name => q{MIP}, no_screen => 1, } );
+
+## Given analysis parameters
+my $recipe_name    = q{mitodel};
+my $slurm_mock_cmd = catfile( $Bin, qw{ data modules slurm-mock.pl } );
+
+my %active_parameter = test_mip_hashes(
+    {
+        mip_hash_name => q{active_parameter},
+        recipe_name   => $recipe_name,
+    }
+);
+$active_parameter{$recipe_name}                     = 1;
+$active_parameter{recipe_core_number}{$recipe_name} = 1;
+$active_parameter{recipe_time}{$recipe_name}        = 1;
+my $case_id   = $active_parameter{case_id};
+my $sample_id = $active_parameter{sample_ids}[0];
+
+my %file_info = test_mip_hashes(
+    {
+        mip_hash_name => q{file_info},
+        recipe_name   => $recipe_name,
+    }
+);
+
+my %job_id;
+my %parameter = test_mip_hashes(
+    {
+        mip_hash_name => q{recipe_parameter},
+        recipe_name   => $recipe_name,
+    }
+);
+test_add_io_for_recipe(
+    {
+        file_info_href => \%file_info,
+        id             => $sample_id,
+        parameter_href => \%parameter,
+        recipe_name    => $recipe_name,
+        step           => q{bam},
+    }
+);
+
+my %sample_info;
+
+my $is_ok = analysis_mitodel(
+    {
+        active_parameter_href => \%active_parameter,
+        file_info_href        => \%file_info,
+        job_id_href           => \%job_id,
+        parameter_href        => \%parameter,
+        profile_base_command  => $slurm_mock_cmd,
+        recipe_name           => $recipe_name,
+        sample_id             => $sample_id,
+        sample_info_href      => \%sample_info,
+    }
+);
+
+## Then return TRUE
+ok( $is_ok, q{ Executed analysis recipe } . $recipe_name );
+
+done_testing();

--- a/t/samtools_stats.t
+++ b/t/samtools_stats.t
@@ -88,7 +88,7 @@ my %specific_argument = (
     },
     insert_size => {
         input           => q{16000},
-        expected_output => q{-i 16000},
+        expected_output => q{--insert-size 16000},
     },
     outfile_path => {
         input           => q{outpath},

--- a/t/samtools_stats.t
+++ b/t/samtools_stats.t
@@ -23,16 +23,13 @@ use lib catdir( dirname($Bin), q{lib} );
 use MIP::Constants qw{ $COMMA $SPACE };
 use MIP::Test::Commands qw{ test_function };
 
-
 BEGIN {
 
     use MIP::Test::Fixtures qw{ test_import };
 
 ### Check all internal dependency modules and imports
 ## Modules with import
-    my %perl_module = (
-        q{MIP::Program::Samtools} => [qw{ samtools_stats }],
-);
+    my %perl_module = ( q{MIP::Program::Samtools} => [qw{ samtools_stats }], );
 
     test_import( { perl_module_href => \%perl_module, } );
 }
@@ -88,6 +85,10 @@ my %specific_argument = (
     auto_detect_input_format => {
         input           => 1,
         expected_output => q{-s},
+    },
+    insert_size => {
+        input           => q{16000},
+        expected_output => q{-i 16000},
     },
     outfile_path => {
         input           => q{outpath},


### PR DESCRIPTION
### This PR adds | fixes:

- Adds functionality to identify mtDNA deletion signatures

### How to test:

- Automatic and continuous test suite

### Expected outcome:
- [x] Installation, unit and integration test suite pass

### Review:
- [ ] Code review
- [ ] Tests pass

This [version](https://semver.org/) is a:
- [ ] **MAJOR** - when you make incompatible API changes. If applicable record manual test results in PR header
- [x] **MINOR** - when you add functionality in a backwards compatible manner. If applicable record manual test results in PR header
- [ ] **PATCH** - when you make backwards compatible bug fixes or documentation/instructions
