### PR TITLE
sed command for adding INFO tag to vcf

### DIFF
--- a/lib/MIP/Recipes/Analysis/Glnexus.pm
+++ b/lib/MIP/Recipes/Analysis/Glnexus.pm
@@ -17,7 +17,7 @@ use autodie qw{ :all };
 use Readonly;
 
 ## MIPs lib/
-use MIP::Constants qw{ $DASH $LOG_NAME $NEWLINE $PIPE $SPACE };
+use MIP::Constants qw{ $DASH $LOG_NAME $NEWLINE $PIPE $SINGLE_QUOTE $SPACE };
 
 BEGIN {
 
@@ -114,7 +114,8 @@ sub analysis_glnexus {
     use MIP::File_info qw{ get_io_files parse_io_outfiles };
     use MIP::Program::Bcftools qw{ bcftools_norm };
     use MIP::Program::Glnexus qw{ glnexus_merge };
-    use MIP::Program::Htslib qw{ htslib_tabix };
+    use MIP::Program::Gnu::Software::Gnu_sed qw{ gnu_sed };
+    use MIP::Program::Htslib qw{ htslib_bgzip htslib_tabix };
     use MIP::Processmanagement::Processes qw{ submit_recipe };
     use MIP::Recipe qw{ parse_recipe_prerequisites };
     use MIP::Sample_info qw{ set_file_path_to_store set_recipe_outfile_in_sample_info };
@@ -220,11 +221,30 @@ sub analysis_glnexus {
         {
             filehandle        => $filehandle,
             infile_path       => $DASH,
-            outfile_path      => $outfile_path,
-            output_type       => q{z},
+            output_type       => q{v},
             reference_path    => $active_parameter_href->{human_genome_reference},
             remove_duplicates => 1,
             threads           => $core_number,
+        }
+    );
+    print {$filehandle} $PIPE . $SPACE;
+
+    ## Add to info filed so that scout can identify the caller
+    my $sed_script = _build_sed_script( {} );
+    gnu_sed(
+        {
+            filehandle => $filehandle,
+            script     => $sed_script,
+        }
+    );
+    print {$filehandle} $PIPE . $SPACE;
+
+    htslib_bgzip(
+        {
+            filehandle      => $filehandle,
+            stdoutfile_path => $outfile_path,
+            threads         => $core_number,
+
         }
     );
     say {$filehandle} $NEWLINE;
@@ -278,6 +298,27 @@ sub analysis_glnexus {
         );
     }
     return 1;
+}
+
+sub _build_sed_script {
+
+    ## Function : Build sed script to add caller information to vcf
+
+    my $header_info =
+      q{##INFO=<ID=FOUND_IN,Number=1,Type=Str,Description="Program that called the variant">};
+    my $info_tag = q{FOUND_IN=deepvariant};
+
+    my $sed_script = $SINGLE_QUOTE
+      ## Find first occurence of ##INFO
+      . q{0,/^##INFO.*/}
+
+      ## Prepend header to line
+      . q{s//} . $header_info . q{\n&/; }
+
+      ## Append new info tag to all INFO columns (8th)
+      . q{s/[^\t]*/&;} . $info_tag . q{/8} . $SINGLE_QUOTE;
+
+    return $sed_script;
 }
 
 1;

--- a/lib/MIP/Recipes/Analysis/Glnexus.pm
+++ b/lib/MIP/Recipes/Analysis/Glnexus.pm
@@ -229,12 +229,11 @@ sub analysis_glnexus {
     );
     print {$filehandle} $PIPE . $SPACE;
 
-    ## Add to info filed so that scout can identify the caller
-    my $sed_script = _build_sed_script( {} );
+    ## Add to info field so that scout can identify the caller
     gnu_sed(
         {
             filehandle => $filehandle,
-            script     => $sed_script,
+            script     => _build_sed_script( {} ),
         }
     );
     print {$filehandle} $PIPE . $SPACE;

--- a/lib/MIP/Recipes/Analysis/Glnexus.pm
+++ b/lib/MIP/Recipes/Analysis/Glnexus.pm
@@ -305,7 +305,7 @@ sub _build_sed_script {
     ## Function : Build sed script to add caller information to vcf
 
     my $header_info =
-      q{##INFO=<ID=FOUND_IN,Number=1,Type=Str,Description="Program that called the variant">};
+      q{##INFO=<ID=FOUND_IN,Number=1,Type=String,Description="Program that called the variant">};
     my $info_tag = q{FOUND_IN=deepvariant};
 
     my $sed_script = $SINGLE_QUOTE


### PR DESCRIPTION
### This PR adds | fixes:

Scout need to be able to identify the variant caller that made the call (https://github.com/Clinical-Genomics/scout/issues/2792). This PR adds the FOUND_IN tag to the info field of the vcf. This addresses #1934 

### How to test:

- Automatic and continuous test suite

### Expected outcome:
- [ ] Installation, unit and integration test suite pass

### Review:
- [ ] Code review
- [ ] Tests pass

This [version](https://semver.org/) is a:
- [ ] **MAJOR** - when you make incompatible API changes. If applicable record manual test results in PR header
- [ ] **MINOR** - when you add functionality in a backwards compatible manner. If applicable record manual test results in PR header
- [ ] **PATCH** - when you make backwards compatible bug fixes or documentation/instructions
