### PR TITLE
turning off haplotypecaller

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 ## [Develop]
 
 - HmtNote: annotate mitochondrial variants in VCF file
+- Mitochondrial deletion analysis
+- GATK Haplotypecaller has been turned off in favour of Deepvariant
 
 ### Tools
 

--- a/definitions/rd_dna_parameters.yaml
+++ b/definitions/rd_dna_parameters.yaml
@@ -523,7 +523,7 @@ gatk_baserecalibration:
   associated_recipe:
     - mip
   data_type: SCALAR
-  default: 1
+  default: 0
   file_tag: _brecal
   outfile_suffix: ".bam"
   program_executables:
@@ -1192,7 +1192,7 @@ gatk_haplotypecaller:
   associated_recipe:
     - mip
   data_type: SCALAR
-  default: 1
+  default: 0
   file_tag: _haptc
   outfile_suffix: ".vcf"
   program_executables:
@@ -1263,7 +1263,7 @@ gatk_genotypegvcfs:
   associated_recipe:
     - mip
   data_type: SCALAR
-  default: 1
+  default: 0
   file_tag: _gent
   outfile_suffix: ".vcf"
   program_executables:
@@ -1288,7 +1288,7 @@ gatk_gathervcfs:
   associated_recipe:
     - mip
   data_type: SCALAR
-  default: 1
+  default: 0
   file_tag: ""
   outfile_suffix: ".vcf"
   program_executables:
@@ -1306,7 +1306,7 @@ gatk_variantrecalibration:
   associated_recipe:
     - mip
   data_type: SCALAR
-  default: 1
+  default: 0
   file_tag: _vrecal
   program_executables:
     - bcftools
@@ -1459,12 +1459,15 @@ gatk_combinevariants_prioritize_caller:
   associated_recipe:
     - gatk_combinevariantcallsets
   data_type: SCALAR
+  default: deepvariant
   mandatory: no
   type: recipe_argument
 gatk_combinevariants_callers_to_combine:
   associated_recipe:
     - gatk_combinevariantcallsets
   data_type: ARRAY
+  default:
+    - glnexus_merge
   mandatory: no
   type: recipe_argument
 prepareforvariantannotationblock:

--- a/lib/MIP/Cli/Mip/Analyse/Rd_dna.pm
+++ b/lib/MIP/Cli/Mip/Analyse/Rd_dna.pm
@@ -1397,6 +1397,7 @@ q{Number of hom-ref genotypes to infer at sites not present in a panel. Connecte
         q{gatk_combinevariants_callers_to_combine} => (
             cmd_flag      => q{gatk_combinevar_use_callers},
             documentation => q{Combine vcf output from these recipes},
+            cmd_tags      => [q{Defaults: glnexus_merge}],
             is            => q{rw},
             isa           => ArrayRef [ enum( [qw{ gatk_variantrecalibration glnexus_merge }] ), ],
         )

--- a/templates/grch38_mip_rd_dna_config.yaml
+++ b/templates/grch38_mip_rd_dna_config.yaml
@@ -66,10 +66,6 @@ vcfanno_config: grch38_vcfanno_config_-v0.2-.toml
 ### Analysis
 ## Programs
 ## Parameters
-gatk_combinevariants_prioritize_caller: deepvariant,haplotypecaller
-gatk_combinevariants_callers_to_combine:
-  - gatk_variantrecalibration
-  - glnexus_merge
 gatk_path: /opt/conda/opt/gatk-3.8
 qccollect_sampleinfo_file: cluster_constant_path!/case_id!/analysis_constant_path!/case_id!_qc_sample_info.yaml
 picardtools_path: /usr/picard/

--- a/templates/mip_rd_dna_config.yaml
+++ b/templates/mip_rd_dna_config.yaml
@@ -47,10 +47,6 @@ fqf_annotations:
   - GNOMADAF
   - GNOMADAF_popmax
   - SWEGENAF
-gatk_combinevariants_prioritize_caller: deepvariant,haplotypecaller
-gatk_combinevariants_callers_to_combine:
-  - gatk_variantrecalibration
-  - glnexus_merge
 gatk_path: /usr
 picardtools_path: /usr/picard
 qccollect_sampleinfo_file: cluster_constant_path!/case_id!/analysis_constant_path!/case_id!_qc_sample_info.yaml


### PR DESCRIPTION
### This PR adds | fixes:

- The haplotypecaller chain is turned off and only variants from deepvariant will be used for annotation and scoring

### How to test:

- Automatic and continuous test suite

### Expected outcome:
- [ ] Installation, unit and integration test suite pass

### Review:
- [ ] Code review
- [ ] Tests pass

This [version](https://semver.org/) is a:
- [ ] **MAJOR** - when you make incompatible API changes. If applicable record manual test results in PR header
- [ ] **MINOR** - when you add functionality in a backwards compatible manner. If applicable record manual test results in PR header
- [ ] **PATCH** - when you make backwards compatible bug fixes or documentation/instructions
