### PR TITLE
feat(qccollect): limit output

### DIFF
--- a/definitions/rd_dna_panel_parameters.yaml
+++ b/definitions/rd_dna_panel_parameters.yaml
@@ -1188,6 +1188,12 @@ qccollect_eval_metric_file:
   is_reference: 1
   reference: reference_dir
   type: path
+qccollect_limit_qc_output:
+  associated_recipe:
+    - qccollect_ar
+  data_type: SCALAR
+  default: 1
+  type: recipe_argument
 qccollect_regexp_file:
   associated_recipe:
     - qccollect_ar

--- a/definitions/rd_dna_parameters.yaml
+++ b/definitions/rd_dna_parameters.yaml
@@ -2060,6 +2060,12 @@ qccollect_eval_metric_file:
   is_reference: 1
   reference: reference_dir
   type: path
+qccollect_limit_qc_output:
+  associated_recipe:
+    - qccollect_ar
+  data_type: SCALAR
+  default: 1
+  type: recipe_argument
 qccollect_store_metrics_outfile:
   associated_recipe:
     - qccollect_ar

--- a/definitions/rd_rna_parameters.yaml
+++ b/definitions/rd_rna_parameters.yaml
@@ -1076,6 +1076,12 @@ qccollect_eval_metric_file:
   is_reference: 1
   reference: reference_dir
   type: path
+qccollect_limit_qc_output:
+  associated_recipe:
+    - qccollect_ar
+  data_type: SCALAR
+  default: 1
+  type: recipe_argument
 qccollect_regexp_file:
   associated_recipe:
     - qccollect_ar

--- a/lib/MIP/Cli/Mip/Qccollect.pm
+++ b/lib/MIP/Cli/Mip/Qccollect.pm
@@ -40,6 +40,7 @@ sub run {
     # Flatten argument(s)
     my $eval_metric_file      = $arg_href->{eval_metric_file};
     my $evaluate_plink_gender = $arg_href->{evaluate_plink_gender};
+    my $limit_qc_output       = $arg_href->{limit_qc_output};
     my $log_file              = $arg_href->{log_file};
     my $outfile               = $arg_href->{outfile};
     my $print_regexp_outfile  = $arg_href->{print_regexp_outfile};
@@ -72,6 +73,7 @@ sub run {
         {
             eval_metric_file      => $eval_metric_file,
             evaluate_plink_gender => $evaluate_plink_gender,
+            limit_qc_output       => $limit_qc_output,
             outfile               => $outfile,
             regexp_file           => $regexp_file,
             sample_info_file      => $sample_info_file,
@@ -102,6 +104,14 @@ sub _build_usage {
     option(
         q{evaluate_plink_gender} => (
             documentation => q{Evaluate plink gender},
+            is            => q{rw},
+            isa           => Bool,
+        )
+    );
+
+    option(
+        q{limit_qc_output} => (
+            documentation => q{Only print a limited number of qc mettrics},
             is            => q{rw},
             isa           => Bool,
         )

--- a/lib/MIP/Main/Qccollect.pm
+++ b/lib/MIP/Main/Qccollect.pm
@@ -47,7 +47,7 @@ sub mip_qccollect {
 ## Returns  :
 ## Arguments: $eval_metric_file      => File with evaluation metrics
 ##          : $evaluate_plink_gender => Evaluate plink gender
-##          : $limit_qc_output       => Only print a limited number of qc values
+##          : $limit_qc_output       => Only print a limited number of qc metrics
 ##          : $outfile               => Data metric output file
 ##          : $regexp_file           => Regular expression file
 ##          : $sample_info_file      => Sample info file
@@ -526,7 +526,7 @@ sub parse_limit_qc_output {
 ## Function : Restrict output
 ## Returns  :
 ## Arguments: $limit_qc_output => Remove keys from regexp hash
-##          : $qc_href         => qccollect regexp hash {REF}
+##          : $qc_href         => Qccollect regexp hash {REF}
 
     my ($arg_href) = @_;
 
@@ -555,14 +555,14 @@ sub parse_limit_qc_output {
 
     return if not $limit_qc_output;
 
-    Readonly my @QC_TO_SKIP => qw{ collectmultiplemetrics variantevalall variantevalexome };
+    Readonly my @SKIP_QC_METRICS => qw{ collectmultiplemetrics variantevalall variantevalexome };
 
-    foreach my $delete_key (@QC_TO_SKIP) {
+    foreach my $delete_metric_key (@SKIP_QC_METRICS) {
 
         _delete_key(
             {
-                data_href => $qc_href,
-                delete_key       => $delete_key,
+                data_href  => $qc_href,
+                delete_key => $delete_metric_key,
             }
         );
     }
@@ -599,9 +599,9 @@ sub _delete_key {
     check( $tmpl, $arg_href, 1 ) or croak q{Could not parse arguments!};
 
   KEY_VALUE_PAIR:
-    while ( my ( $key, $value ) = each %{ $data_href } ) {
+    while ( my ( $key, $value ) = each %{$data_href} ) {
 
-        if ($key eq $delete_key) {
+        if ( $key eq $delete_key ) {
 
             delete $data_href->{$delete_key};
             return;
@@ -611,8 +611,8 @@ sub _delete_key {
 
             _delete_key(
                 {
-                    data_href => $value,
-                    delete_key       => $delete_key,
+                    data_href  => $value,
+                    delete_key => $delete_key,
                 }
             );
         }

--- a/lib/MIP/Main/Qccollect.pm
+++ b/lib/MIP/Main/Qccollect.pm
@@ -19,6 +19,7 @@ use warnings qw{ FATAL utf8 };
 ## CPANM
 use autodie qw{ open close :all };
 use Modern::Perl qw{ 2018 };
+use Readonly;
 
 ## MIPs lib/
 use MIP::Constants qw{ $LOG_NAME };
@@ -46,6 +47,7 @@ sub mip_qccollect {
 ## Returns  :
 ## Arguments: $eval_metric_file      => File with evaluation metrics
 ##          : $evaluate_plink_gender => Evaluate plink gender
+##          : $limit_qc_output       => Only print a limited number of qc values
 ##          : $outfile               => Data metric output file
 ##          : $regexp_file           => Regular expression file
 ##          : $sample_info_file      => Sample info file
@@ -57,6 +59,7 @@ sub mip_qccollect {
     ## Flatten argument(s)
     my $eval_metric_file;
     my $evaluate_plink_gender;
+    my $limit_qc_output;
     my $outfile;
     my $regexp_file;
     my $sample_info_file;
@@ -76,6 +79,10 @@ sub mip_qccollect {
             defined     => 1,
             required    => 1,
             store       => \$outfile,
+            strict_type => 1,
+        },
+        limit_qc_output => {
+            store       => \$limit_qc_output,
             strict_type => 1,
         },
         regexp_file => {
@@ -192,6 +199,13 @@ sub mip_qccollect {
             qc_data_href          => \%qc_data,
             sample_info_href      => \%sample_info,
             store_metrics_outfile => $store_metrics_outfile,
+        }
+    );
+
+    parse_limit_qc_output(
+        {
+            limit_qc_output => $limit_qc_output,
+            qc_href         => \%qc_data,
         }
     );
 
@@ -504,6 +518,111 @@ sub sample_qc {
             }
         }
     }
+    return;
+}
+
+sub parse_limit_qc_output {
+
+## Function : Restrict output
+## Returns  :
+## Arguments: $limit_qc_output => Remove keys from regexp hash
+##          : $qc_href         => qccollect regexp hash {REF}
+
+    my ($arg_href) = @_;
+
+    ## Flatten argument(s)
+    my $limit_qc_output;
+    my $qc_href;
+
+    my $tmpl = {
+        limit_qc_output => {
+            store       => \$limit_qc_output,
+            strict_type => 1,
+        },
+        qc_href => {
+            default     => {},
+            defined     => 1,
+            required    => 1,
+            store       => \$qc_href,
+            strict_type => 1,
+        },
+    };
+
+    check( $tmpl, $arg_href, 1 ) or croak q{Could not parse arguments!};
+
+    ## Delete surplus metrics
+    delete $qc_href->{metrics};
+
+    return if not $limit_qc_output;
+
+    Readonly my @QC_TO_SKIP => qw{ collectmultiplemetrics variantevalexome };
+
+    #  comp_overlap_data_header
+    #  count_variants_data_header
+    #  indel_summary_data_header
+    #  multiallelic_summary_data_header
+    #  titv_variant_evaluator_data_header
+    #  variant_summary_header
+    #  validation_report_header
+
+    foreach my $key (@QC_TO_SKIP) {
+
+        _delete_key(
+            {
+                data_href => $qc_href,
+                key       => $key,
+            }
+        );
+    }
+    return;
+}
+
+sub _delete_key {
+
+## Function : Delete key from nested hash
+## Returns  :
+## Arguments: $data_href => Data {REF}
+##          : $key       => Key
+
+    my ($arg_href) = @_;
+
+    ## Flatten argument(s)
+    my $data_href;
+    my $key;
+
+    my $tmpl = {
+        data_href => {
+            default     => {},
+            defined     => 1,
+            required    => 1,
+            store       => \$data_href,
+            strict_type => 1,
+        },
+        key => {
+            store       => \$key,
+            strict_type => 1,
+        },
+    };
+
+    check( $tmpl, $arg_href, 1 ) or croak q{Could not parse arguments!};
+
+    ## Copy hash to enable recursive removal of keys
+    my %info = %{$data_href};
+
+    if ( $info{$key} ) {
+
+        delete $info{$key};
+    }
+    elsif ( ref $info{$key} eq q{HASH} ) {
+
+        _delete_key(
+            {
+                data_href => $info{$key},
+                key       => $key,
+            }
+        );
+    }
+
     return;
 }
 

--- a/lib/MIP/Program/Mip.pm
+++ b/lib/MIP/Program/Mip.pm
@@ -147,6 +147,7 @@ sub mip_qccollect {
 ## Arguments: $eval_metric_file       => Mip qc evaluation metrics file
 ##          : $filehandle             => Filehandle to write to
 ##          : $infile_path            => Infile path
+##          : $limit_qc_output        => Limit the qc metrics that is printed to the qc outfile
 ##          : $log_file_path          => Log file path
 ##          : $outfile_path           => Outfile path
 ##          : $regexp_file_path       => Regular expression file
@@ -172,6 +173,7 @@ sub mip_qccollect {
 
     ## Default(s)
     my $skip_evaluation;
+    my $limit_qc_output;
 
     my $tmpl = {
         eval_metric_file => {
@@ -185,6 +187,12 @@ sub mip_qccollect {
             defined     => 1,
             required    => 1,
             store       => \$infile_path,
+            strict_type => 1,
+        },
+        limit_qc_output => {
+            allow       => [ undef, 0, 1 ],
+            default     => 1,
+            store       => \$limit_qc_output,
             strict_type => 1,
         },
         log_file_path => { store => \$log_file_path, strict_type => 1, },
@@ -239,6 +247,10 @@ sub mip_qccollect {
         push @commands, q{--log_file} . $SPACE . $log_file_path;
     }
 
+    if ($limit_qc_output) {
+
+        push @commands, q{--limit_qc_output};
+    }
     push @commands, q{--outfile} . $SPACE . $outfile_path;
 
     push @commands, q{--regexp_file} . $SPACE . $regexp_file_path;

--- a/lib/MIP/Recipes/Analysis/Mip_qccollect.pm
+++ b/lib/MIP/Recipes/Analysis/Mip_qccollect.pm
@@ -208,6 +208,18 @@ sub analysis_mip_qccollect {
                 path             => $active_parameter_href->{qccollect_store_metrics_outfile},
                 recipe_name      => $recipe_name,
                 sample_info_href => $sample_info_href,
+                tag              => q{deliverable},
+            }
+        );
+
+        set_file_path_to_store(
+            {
+                format           => q{meta},
+                id               => $case_id,
+                path             => $active_parameter_href->{qccollect_eval_metric_file},
+                recipe_name      => $recipe_name,
+                sample_info_href => $sample_info_href,
+                tag              => q{audit},
             }
         );
 

--- a/lib/MIP/Recipes/Analysis/Mip_qccollect.pm
+++ b/lib/MIP/Recipes/Analysis/Mip_qccollect.pm
@@ -216,7 +216,7 @@ sub analysis_mip_qccollect {
             {
                 format           => q{meta},
                 id               => $case_id,
-                path             => $active_parameter_href->{qccollect_eval_metric_file},
+                path             => $outfile_path,
                 recipe_name      => $recipe_name,
                 sample_info_href => $sample_info_href,
                 tag              => q{audit},

--- a/t/mip_qccollect.t
+++ b/t/mip_qccollect.t
@@ -99,6 +99,10 @@ my %specific_argument = (
           . $SPACE
           . catfile(qw{ outdata_dir case_id case_id_qc_sample_info.yaml }),
     },
+    limit_qc_output => {
+        input           => 1,
+        expected_output => q{--limit_qc_output},
+    },
     log_file_path => {
         input           => catfile(qw{ outcase_directory case_id _qccollect.log }),
         expected_output => q{--log_file}

--- a/t/mip_qccollect.test
+++ b/t/mip_qccollect.test
@@ -83,6 +83,7 @@ my $cmds_ref = [
     $sample_info_file,          q{--evaluate_plink_gender},
     q{--store_metrics_outfile}, $store_metrics_outfile,
     q{--outfile},               $outfile,
+    q{--limit_qc_output}
 ];
 
 my %process_return = child_process(


### PR DESCRIPTION
### This PR adds | fixes:

- Removes lots of info from the qc metrics file.
- Saves the qc_metrics file to deliverables

### How to test:

- Automatic and continuous test suite

### Expected outcome:
- [ ] Installation, unit and integration test suite pass

### Review:
- [ ] Code review
- [ ] Tests pass

This [version](https://semver.org/) is a:
- [ ] **MAJOR** - when you make incompatible API changes. If applicable record manual test results in PR header
- [ ] **MINOR** - when you add functionality in a backwards compatible manner. If applicable record manual test results in PR header
- [ ] **PATCH** - when you make backwards compatible bug fixes or documentation/instructions
