### PR TITLE
add ghcr to parse_container_uri sub

### DIFF
--- a/lib/MIP/Environment/Container.pm
+++ b/lib/MIP/Environment/Container.pm
@@ -337,7 +337,7 @@ sub parse_container_uri {
 
     return if ( ${$uri_ref} =~ m{ \A docker:[/]{2} }xms );
 
-    if ( ${$uri_ref} =~ /\A quay|docker[.]io /xms ) {
+    if ( ${$uri_ref} =~ /\A ghcr|quay|docker[.]io /xms ) {
 
         ${$uri_ref} = q{docker://} . ${$uri_ref};
     }

--- a/t/parse_container_uri.t
+++ b/t/parse_container_uri.t
@@ -21,16 +21,13 @@ use Modern::Perl qw{ 2018 };
 use lib catdir( dirname($Bin), q{lib} );
 use MIP::Constants qw{ $COMMA $SPACE };
 
-
 BEGIN {
 
     use MIP::Test::Fixtures qw{ test_import };
 
 ### Check all internal dependency modules and imports
 ## Modules with import
-    my %perl_module = (
-        q{MIP::Environment::Container} => [qw{ parse_container_uri }],
-);
+    my %perl_module = ( q{MIP::Environment::Container} => [qw{ parse_container_uri }], );
 
     test_import( { perl_module_href => \%perl_module, } );
 }
@@ -87,4 +84,19 @@ parse_container_uri(
 ## Then leave uri unchanged
 $expected_uri = q{docker://quay.io/clinicalgenomics/chanjo:4.2.0};
 is( $uri, $expected_uri, q{Parse quay uri for singularity} );
+
+## Given a ghcr uri
+my $uri = q{ghcr.io/dnanexus-rnd/glnexus:v1.4.1};
+## When container manager is singularity
+parse_container_uri(
+    {
+        container_manager => q{singularity},
+        uri_ref           => \$uri,
+    }
+);
+
+## Then prepend docker://
+my $expected_uri = q{docker://ghcr.io/dnanexus-rnd/glnexus:v1.4.1};
+is( $uri, $expected_uri, q{Parse uri for singularity} );
+
 done_testing();

--- a/t/parse_container_uri.t
+++ b/t/parse_container_uri.t
@@ -86,7 +86,7 @@ $expected_uri = q{docker://quay.io/clinicalgenomics/chanjo:4.2.0};
 is( $uri, $expected_uri, q{Parse quay uri for singularity} );
 
 ## Given a ghcr uri
-my $uri = q{ghcr.io/dnanexus-rnd/glnexus:v1.4.1};
+$uri = q{ghcr.io/dnanexus-rnd/glnexus:v1.4.1};
 ## When container manager is singularity
 parse_container_uri(
     {
@@ -96,7 +96,7 @@ parse_container_uri(
 );
 
 ## Then prepend docker://
-my $expected_uri = q{docker://ghcr.io/dnanexus-rnd/glnexus:v1.4.1};
+$expected_uri = q{docker://ghcr.io/dnanexus-rnd/glnexus:v1.4.1};
 is( $uri, $expected_uri, q{Parse uri for singularity} );
 
 done_testing();


### PR DESCRIPTION
### This PR adds | fixes:

- Add condition to deal with ghcr uris

### How to test:

- Automatic and continuous test suite

### Expected outcome:
- [ ] Installation, unit and integration test suite pass

### Review:
- [ ] Code review
- [ ] Tests pass

This [version](https://semver.org/) is a:
- [ ] **MAJOR** - when you make incompatible API changes. If applicable record manual test results in PR header
- [x] **MINOR** - when you add functionality in a backwards compatible manner. If applicable record manual test results in PR header
- [ ] **PATCH** - when you make backwards compatible bug fixes or documentation/instructions
