### PR TITLE
updated reference to the offline flag, rm'd undef for the offline flag

### DIFF
--- a/lib/MIP/Program/HmtNote.pm
+++ b/lib/MIP/Program/HmtNote.pm
@@ -49,12 +49,14 @@ sub hmtnote_annotate {
     ## Flatten argument(s)
     my $filehandle;
     my $infile_path;
-    my $offline;
     my $outfile_path;
     my $stderrfile_path;
     my $stderrfile_path_append;
     my $stdinfile_path;
     my $stdoutfile_path;
+
+    ## Default(s)
+    my $offline;
 
     my $tmpl = {
         filehandle => {
@@ -68,6 +70,7 @@ sub hmtnote_annotate {
         },
         offline => {
             allow       => [ 0, 1 ],
+            default     => 1,
             store       => \$offline,
             strict_type => 1,
         },

--- a/lib/MIP/Program/HmtNote.pm
+++ b/lib/MIP/Program/HmtNote.pm
@@ -67,7 +67,7 @@ sub hmtnote_annotate {
             strict_type => 1,
         },
         offline => {
-            allow       => [ undef, 0, 1 ],
+            allow       => [ 0, 1 ],
             store       => \$offline,
             strict_type => 1,
         },

--- a/lib/MIP/Recipes/Analysis/Mt_annotation.pm
+++ b/lib/MIP/Recipes/Analysis/Mt_annotation.pm
@@ -211,7 +211,7 @@ sub analysis_mt_annotation {
                 {
                     filehandle   => $filehandle,
                     infile_path  => $infile_path{$contig},
-                    offline      => $active_parameter_href->{hmtnote_offline},
+                    offline      => $active_parameter_href->{mt_offline},
                     outfile_path => $outfile_no_suffix,
                 }
             );
@@ -274,13 +274,13 @@ sub analysis_mt_annotation {
 
         submit_recipe(
             {
-                base_command         => $profile_base_command,
-                case_id              => $case_id,
-                dependency_method    => q{sample_to_case},
-                job_id_chain         => $recipe{job_id_chain},
-                job_id_href          => $job_id_href,
-                job_reservation_name => $active_parameter_href->{job_reservation_name},
-                log                  => $log,
+                base_command                      => $profile_base_command,
+                case_id                           => $case_id,
+                dependency_method                 => q{sample_to_case},
+                job_id_chain                      => $recipe{job_id_chain},
+                job_id_href                       => $job_id_href,
+                job_reservation_name              => $active_parameter_href->{job_reservation_name},
+                log                               => $log,
                 max_parallel_processes_count_href =>
                   $file_info_href->{max_parallel_processes_count},
                 recipe_file_path   => $recipe_file_path,

--- a/t/analysis_mt_annotation.t
+++ b/t/analysis_mt_annotation.t
@@ -51,6 +51,7 @@ test_log( { log_name => q{MIP}, no_screen => 1, } );
 
 ## Given analysis parameters
 my $recipe_name    = q{mt_annotation};
+my $offline        = q{mt_offline};
 my $slurm_mock_cmd = catfile( $Bin, qw{ data modules slurm-mock.pl } );
 
 my %active_parameter = test_mip_hashes(
@@ -60,6 +61,7 @@ my %active_parameter = test_mip_hashes(
     }
 );
 $active_parameter{$recipe_name}                     = 1;
+$active_parameter{$offline}                         = 1;
 $active_parameter{recipe_core_number}{$recipe_name} = 1;
 $active_parameter{recipe_time}{$recipe_name}        = 1;
 my $case_id = $active_parameter{case_id};


### PR DESCRIPTION
### This PR adds | fixes:

- HmtNote didn't run offline because the reference to the parameter was undefined. I've updated the variable name in `Mt_annotation.pm` to match the parameter name in `rd_dna_parameters.yaml`. Additionally, the strictness of the `--offline` flag has been changed to only allow `[ 0, 1 ]`- this change is found in the `HmtNote.pm` file.

### How to test:

- Automatic and continuous test suite

### Expected outcome:
- [x] Installation, unit and integration test suite pass

### Review:
- [ ] Code review
- [ ] Tests pass

This [version](https://semver.org/) is a:
- [ ] **MAJOR** - when you make incompatible API changes. If applicable record manual test results in PR header
- [ ] **MINOR** - when you add functionality in a backwards compatible manner. If applicable record manual test results in PR header
- [ ] **PATCH** - when you make backwards compatible bug fixes or documentation/instructions
