### PR TITLE
added conditional to remove filtering for mitochondrial vcfs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,10 @@
 All notable changes to this project will be documented in this file.
 This project adheres to [Semantic Versioning](http://semver.org/).
 
+## [10.2.1]
+
+- Removed frequency filtering for mitochondrial sites
+
 ## [10.2.0]
 
 - Introduced the option `--start_after_recipe <recipe_name>` to start the pipeline after a given recipe

--- a/lib/MIP/Constants.pm
+++ b/lib/MIP/Constants.pm
@@ -81,7 +81,7 @@ Readonly our %ANALYSIS => (
 );
 
 ## Set MIP version
-Readonly our $MIP_VERSION => q{10.2.0};
+Readonly our $MIP_VERSION => q{10.2.1};
 
 ## Cli
 Readonly our $MOOSEX_APP_SCEEN_WIDTH => 160;

--- a/lib/MIP/Recipes/Analysis/Frequency_filter.pm
+++ b/lib/MIP/Recipes/Analysis/Frequency_filter.pm
@@ -144,6 +144,7 @@ sub analysis_frequency_filter {
     use MIP::File_info qw{ get_io_files parse_io_outfiles };
     use MIP::Processmanagement::Processes qw{ submit_recipe };
     use MIP::Program::Bcftools qw{ bcftools_index bcftools_view };
+    use MIP::Program::Gnu::Coreutils qw { gnu_cp };
     use MIP::Recipe qw{ parse_recipe_prerequisites };
     use MIP::Recipes::Analysis::Xargs qw{ xargs_command };
     use MIP::Sample_info qw{ set_recipe_outfile_in_sample_info };
@@ -254,17 +255,32 @@ sub analysis_frequency_filter {
             }
         );
 
-        bcftools_view(
-            {
-                exclude                => $exclude_filter,
-                filehandle             => $xargsfilehandle,
-                infile_path            => $infile_path{$contig},
-                outfile_path           => $outfile_path{$contig},
-                output_type            => q{z},
-                stderrfile_path_append => $stderrfile_path,
-            }
-        );
-        print {$xargsfilehandle} $SEMICOLON . $SPACE;
+        if ( not $contig =~ / MT|M /xsm ) {
+
+            bcftools_view(
+                {
+                    exclude                => $exclude_filter,
+                    filehandle             => $xargsfilehandle,
+                    infile_path            => $infile_path{$contig},
+                    outfile_path           => $outfile_path{$contig},
+                    output_type            => q{z},
+                    stderrfile_path_append => $stderrfile_path,
+                }
+            );
+            print {$xargsfilehandle} $SEMICOLON . $SPACE;
+        }
+        else {
+
+            gnu_cp(
+                {
+                    filehandle             => $xargsfilehandle,
+                    infile_path            => $infile_path{$contig},
+                    outfile_path           => $outfile_path{$contig},
+                    stderrfile_path_append => $stderrfile_path,
+                }
+            );
+            print {$xargsfilehandle} $SEMICOLON . $SPACE;
+        }
 
         bcftools_index(
             {

--- a/templates/mip_install_config.yaml
+++ b/templates/mip_install_config.yaml
@@ -117,7 +117,7 @@ container:
   mip:
     executable:
       mip:
-    uri: docker.io/clinicalgenomics/mip:v10.2.0
+    uri: docker.io/clinicalgenomics/mip:v10.2.1
   multiqc:
     executable:
       multiqc:
@@ -249,4 +249,3 @@ container:
     executable:
       vcf2cytosure:
     uri: docker.io/jemten/vcf2cytosure:0.5.1
-


### PR DESCRIPTION
### This PR adds | fixes:

- https://github.com/Clinical-Genomics/MIP/issues/1944
- Added conditional to remove frequency filtering for mitochondrial vcf from `bcftools view` and instead use `gnu_cp` for them so it can still be indexed by `bcftools index`

![image](https://user-images.githubusercontent.com/25568561/132687457-d807ea68-c132-48c2-a339-d974aad05edf.png)

### How to test:

- Automatic and continuous test suite

### Expected outcome:
- [x] Installation, unit and integration test suite pass

### Review:
- [ ] Code review
- [x] Tests pass

This [version](https://semver.org/) is a:
- [ ] **MAJOR** - when you make incompatible API changes. If applicable record manual test results in PR header
- [ ] **MINOR** - when you add functionality in a backwards compatible manner. If applicable record manual test results in PR header
- [x] **PATCH** - when you make backwards compatible bug fixes or documentation/instructions
