### PR TITLE
adds regex for hmtnote version

### DIFF
--- a/lib/MIP/Environment/Executable.pm
+++ b/lib/MIP/Environment/Executable.pm
@@ -379,6 +379,11 @@ q?'my ($version) = /genmod\s+version:\s+(\S+)/xms; if($version) {print $version;
             version_regexp =>
               q?'my ($version) = /gzip\s+(\S+)/xms; if($version) {print $version;last;}'?,
         },
+        hmtnote => {
+            version_cmd    => q{--version},
+            version_regexp =>
+              q?'my ($version) = /version\s(\S+)/xms; if($version) {print $version;last;}'?,
+        },
         q{infer_exeperiment.py} => {
             version_cmd    => q{--version},
             version_regexp =>


### PR DESCRIPTION
### This PR adds | fixes:

- adds a regex for capturing hmtnote's version

### How to test:

- Automatic and continuous test suite

### Expected outcome:
- [ ] Installation, unit and integration test suite pass

### Review:
- [ ] Code review
- [ ] Tests pass

This [version](https://semver.org/) is a:
- [ ] **MAJOR** - when you make incompatible API changes. If applicable record manual test results in PR header
- [ ] **MINOR** - when you add functionality in a backwards compatible manner. If applicable record manual test results in PR header
- [ ] **PATCH** - when you make backwards compatible bug fixes or documentation/instructions
