### PR TITLE
adds MEDIAN_TARGET_COVERAGE to deliverables

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,10 @@
 All notable changes to this project will be documented in this file.
 This project adheres to [Semantic Versioning](http://semver.org/).
 
+## [10.2.2]
+
+- Adds missing median coverage metrics to metrics deliverable file
+
 ## [10.2.1]
 
 - Removed frequency filtering for mitochondrial sites

--- a/lib/MIP/Constants.pm
+++ b/lib/MIP/Constants.pm
@@ -81,7 +81,7 @@ Readonly our %ANALYSIS => (
 );
 
 ## Set MIP version
-Readonly our $MIP_VERSION => q{10.2.1};
+Readonly our $MIP_VERSION => q{10.2.2};
 
 ## Cli
 Readonly our $MOOSEX_APP_SCEEN_WIDTH => 160;

--- a/lib/MIP/Store.pm
+++ b/lib/MIP/Store.pm
@@ -117,6 +117,10 @@ sub define_qc_metrics_to_store {
             analysis_mode => q{sample},
             recipe_name   => q{collectmultiplemetricsinsertsize},
         },
+        MEDIAN_TARGET_COVERAGE => {
+            analysis_mode => q{sample},
+            recipe_name   => q{collecthsmetrics}
+        },
         PCT_INTERGENIC_BASES => {
             analysis_mode => q{sample},
             recipe_name   => q{collectrnaseqmetrics},

--- a/templates/mip_install_config.yaml
+++ b/templates/mip_install_config.yaml
@@ -117,7 +117,7 @@ container:
   mip:
     executable:
       mip:
-    uri: docker.io/clinicalgenomics/mip:v10.2.1
+    uri: docker.io/clinicalgenomics/mip:v10.2.2
   multiqc:
     executable:
       multiqc:


### PR DESCRIPTION
### This PR adds | fixes:

- Include MEDAIN_TARGET_COVERAGE in the metrics deliverable file. 

### How to test:

- Automatic and continuous test suite

### Expected outcome:
- [x] Installation, unit and integration test suite pass
- [x] median target coverage is part of the metrics deliverables file

### Review:
- [ ] Code review
- [x] Tests pass

This [version](https://semver.org/) is a:
- [ ] **MAJOR** - when you make incompatible API changes. If applicable record manual test results in PR header
- [ ] **MINOR** - when you add functionality in a backwards compatible manner. If applicable record manual test results in PR header
- [x] **PATCH** - when you make backwards compatible bug fixes or documentation/instructions
