### PR TITLE
increases AF cutoff to 0.7

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 - Mitochondrial deletion analysis
 - GATK Haplotypecaller has been turned off in favour of Deepvariant
 - Introduces possibility to store singularity images locally as a .sif file
+- Increased allele frequency cut off for when a variant is filtered out to 0.7
 
 ### Tools
 

--- a/definitions/dragen_rd_dna_parameters.yaml
+++ b/definitions/dragen_rd_dna_parameters.yaml
@@ -530,7 +530,7 @@ fqf_bcftools_filter_threshold:
   associated_recipe:
     - frequency_filter
   data_type: SCALAR
-  default: 0.40
+  default: 0.70
   type: recipe_argument
 cadd_ar:
   analysis_mode: case

--- a/definitions/rd_dna_panel_parameters.yaml
+++ b/definitions/rd_dna_panel_parameters.yaml
@@ -831,7 +831,7 @@ fqf_bcftools_filter_threshold:
   associated_recipe:
     - frequency_filter
   data_type: SCALAR
-  default: 0.40
+  default: 0.70
   type: recipe_argument
 cadd_ar:
   analysis_mode: case

--- a/definitions/rd_dna_parameters.yaml
+++ b/definitions/rd_dna_parameters.yaml
@@ -1670,7 +1670,7 @@ fqf_bcftools_filter_threshold:
   associated_recipe:
     - frequency_filter
   data_type: SCALAR
-  default: 0.40
+  default: 0.70
   type: recipe_argument
 cadd_ar:
   analysis_mode: case

--- a/definitions/rd_dna_vcf_rerun_parameters.yaml
+++ b/definitions/rd_dna_vcf_rerun_parameters.yaml
@@ -526,7 +526,7 @@ fqf_bcftools_filter_threshold:
   associated_recipe:
     - frequency_filter
   data_type: SCALAR
-  default: 0.40
+  default: 0.70
   type: recipe_argument
 cadd_ar:
   analysis_mode: case


### PR DESCRIPTION
### This PR adds | fixes:

- #1963 

### How to test:

- Automatic and continuous test suite

### Expected outcome:
- [ ] Installation, unit and integration test suite pass

### Review:
- [ ] Code review
- [ ] Tests pass

This [version](https://semver.org/) is a:
- [ ] **MAJOR** - when you make incompatible API changes. If applicable record manual test results in PR header
- [ ] **MINOR** - when you add functionality in a backwards compatible manner. If applicable record manual test results in PR header
- [ ] **PATCH** - when you make backwards compatible bug fixes or documentation/instructions
