### PR TITLE
Feature/gens preproc container fix

### DIFF
--- a/containers/gens_preproc/Dockerfile
+++ b/containers/gens_preproc/Dockerfile
@@ -1,0 +1,4 @@
+# syntax=docker/dockerfile:1
+FROM clinicalgenomics/htslib:1.13
+WORKDIR /bin
+COPY . .

--- a/containers/gens_preproc/generate_gens_data.pl
+++ b/containers/gens_preproc/generate_gens_data.pl
@@ -1,0 +1,126 @@
+#!/usr/bin/env perl
+use strict;
+use warnings;
+use Data::Dumper;
+use List::Util qw(sum);
+use File::Basename qw(dirname);
+
+if ($ARGV[0] eq "--version") {
+    print "generate_gens_data.pl 1.0.0\n";
+    exit 0;
+}
+
+my $SCRIPT_ROOT = dirname($0);
+
+my @COV_WINDOW_SIZES = (100000, 25000, 5000, 1000, 100);
+my @BAF_SKIP_N = (160, 40, 10, 4, 1);
+my @PREFIXES = qw( o a b c d );
+my $cov_fn = $ARGV[0];
+my $gvcf_fn = $ARGV[1];
+
+my $SAMPLE_ID = $ARGV[2];
+my $GNOMAD = $ARGV[3];
+
+my $COV_OUTPUT = $SAMPLE_ID.".cov.bed";
+my $BAF_OUTPUT = $SAMPLE_ID.".baf.bed";
+
+print STDERR "Calculating coverage data\n";
+# Calculate coverage data
+open( COVOUT, ">".$COV_OUTPUT );
+for my $i (0..$#COV_WINDOW_SIZES) {
+    generate_cov_bed($cov_fn, $COV_WINDOW_SIZES[$i], $PREFIXES[$i]);
+}
+close COVOUT;
+
+
+print STDERR "Calculating BAFs from gvcf...\n";
+# Calculate BAFs
+system( 
+    $SCRIPT_ROOT."/gvcfvaf.pl ".
+    "$gvcf_fn $GNOMAD > baf.tmp"
+    );
+open( BAFOUT, ">".$BAF_OUTPUT );
+for my $i (0..$#BAF_SKIP_N) {
+    print STDERR "Outputting BAF $PREFIXES[$i]...\n";
+    generate_baf_bed("baf.tmp", $BAF_SKIP_N[$i], $PREFIXES[$i]);
+}
+close BAFOUT;
+
+
+system("bgzip -f -\@10 $BAF_OUTPUT");
+system("tabix -f -p bed $BAF_OUTPUT.gz");
+system("bgzip -f -\@10 $COV_OUTPUT");
+system("tabix -f -p bed $COV_OUTPUT.gz");
+unlink("baf.tmp");
+
+sub generate_baf_bed {
+    my( $fn, $skip, $prefix ) = @_;
+    open( my $fh, $fn );
+    my $i = 0;
+    while(<$fh>) {
+	if( $i++ % $skip == 0 ) {
+	    chomp;
+	    my @a = split /\t/;
+	    print BAFOUT $prefix."_".$a[0]."\t".($a[1]-1)."\t".$a[1]."\t".$a[2]."\n";
+	}
+    }
+    close $fn;
+}
+
+sub generate_cov_bed {
+
+    my( $fn, $win_size, $prefix ) = @_;
+    
+    open(my $fh, $fn);
+    my( $reg_start, $reg_end, $reg_chr, $force_end );
+    my @reg_ratios;
+    while(<$fh>) {
+	next if /^@/ or /^CONTIG/;
+	chomp;
+	my ($chr, $start, $end, $ratio ) = split /\t/;
+	my $orig_end = $end;
+	unless( $reg_start ) {
+	    $reg_start = $start;
+	    $reg_end = $end;
+	    $reg_chr = $chr;
+	}
+
+	if( $chr eq $reg_chr ) {
+	    if( $start - $reg_end < $win_size ) {
+		push @reg_ratios, $ratio;
+		$reg_end = $end;
+	    }
+
+	    # If there is a large gap to the next region, prematurely end region
+	    else {
+		$force_end = 1;
+		$end = $reg_end;
+	    }
+	}
+	else {
+	    $force_end = 1;
+	    $end = $reg_end;
+	}
+	if( $end - $reg_start + 1 >= $win_size or $force_end ) {
+	    my $mid_point = $reg_start + int(($end - $reg_start)/2);
+	    print COVOUT $prefix."_".$reg_chr."\t".($mid_point-1)."\t".$mid_point."\t".mean(@reg_ratios)."\n";
+	    undef $reg_start;
+	    undef $reg_end;
+	    undef $reg_chr;
+	    undef @reg_ratios;
+	}
+
+	if( $force_end ) {
+	    $reg_start = $start;
+	    $reg_end = $orig_end;
+	    $reg_chr = $chr;
+	    push @reg_ratios, $ratio;
+	    undef $force_end;
+	}
+    }
+    close $fh;
+}
+    
+sub mean {
+    return sum(@_)/@_;
+}

--- a/containers/gens_preproc/gvcfvaf.pl
+++ b/containers/gens_preproc/gvcfvaf.pl
@@ -1,0 +1,128 @@
+#!/usr/bin/perl -w
+use strict;
+use Data::Dumper;
+use List::Util qw(max);
+use File::Basename qw(dirname);
+
+die "Give GVCF as only argument!" unless -s $ARGV[0];
+
+my $SCRIPT_ROOT = dirname($0);
+
+my @chr_order = qw(1 2 3 4 5 6 7 8 9 10 11 12 13 14 15 16 17 18 19 20 21 22 X Y MT);
+my %chr_order_hash;
+foreach my $i (0..$#chr_order ) {
+    $chr_order_hash{$chr_order[$i]} = $i;
+}
+
+open(GNOMAD, $ARGV[1]);
+
+open(GVCF, "zcat $ARGV[0]|");
+my $gvcf_line;
+while($gvcf_line = <GVCF>) {
+    last unless $gvcf_line =~ /^#/;
+}
+
+#my $gvcf = parse_gvcf_entry($gvcf_line);
+my $gvcf = gvcf_position($gvcf_line);
+my $skipped = 0;
+while(<GNOMAD>) {
+    chomp;
+    my( $gnomad_chr, $gnomad_pos ) = split /\t/;
+    print STDERR "Skipping gnomad $gnomad_chr $gnomad_pos ".$gvcf->{chr}." ".$gvcf->{start}."\n" if chr_less($gnomad_chr, $gvcf->{chr});
+    next if chr_less($gnomad_chr, $gvcf->{chr});
+    if( $gvcf->{start} < $gnomad_pos or chr_less($gvcf->{chr}, $gnomad_chr) ) {
+	my $prev_gvcf_chr = $gvcf->{chr};
+	do {
+	    $gvcf_line = <GVCF>;
+	    #$gvcf = parse_gvcf_entry($a);
+	    $gvcf = gvcf_position($gvcf_line);
+	} until eof(GVCF) or ( $gvcf->{end} >= $gnomad_pos or $gvcf->{start} >= $gnomad_pos or $gvcf->{chr} ne $prev_gvcf_chr );
+    }
+    if( $gnomad_pos >= $gvcf->{start} and $gnomad_chr eq $gvcf->{chr} ) {
+	if( $gnomad_pos <= $gvcf->{end} ) {
+	    $gvcf = parse_gvcf_entry($gvcf_line);
+	    print $gnomad_chr."\t".$gnomad_pos."\t".($gvcf->{frq} or 0)."\n" if defined $gvcf->{frq};
+	}
+	else {
+	    $skipped ++;
+	}
+    }
+    last if eof(GVCF);
+}   
+print STDERR "$skipped variants skipped!\n";
+
+
+sub chr_less {
+    my( $chr1, $chr2 ) = @_;
+    return $chr_order_hash{$chr1} < $chr_order_hash{$chr2};
+}
+
+sub gvcf_position {
+    my $str = shift;
+    my %data;
+    my @a = split /\t/, $str;
+    $data{chr} = $a[0];
+    $data{start} = $a[1];
+    $a[7] =~ /(^|;)END=(.*?)(;|$)/;
+    $data{end} = ($2 or $a[1]);
+    return \%data;
+}
+ 
+sub parse_gvcf_entry {
+    my $str = shift;
+    chomp $str;
+    my %data;
+    my @a = split /\t/, $str;
+    $data{str} = $str;
+    $data{chr} = $a[0];
+    $data{start} = $a[1];
+    $a[7] =~ /(^|;)END=(.*?)(;|$)/;
+    $data{end} = ($2 or $a[1]);
+
+    return \%data if length($a[3]) > 1;
+
+
+    unless( $a[8] =~ /:AD:/ ) {
+	$data{frq} = 0;
+    }
+    else {
+	my @ALT = split /,/, $a[4];
+    	my @fmt = split /:/, $a[8];
+	my @sam = split /:/, $a[9];
+	my( $alt, $alt_cnt, $dp );
+	for my $i (0..@fmt) {
+	    if( $fmt[$i] eq "GT" ) {
+		my( $a, $b ) = (split /\//, $sam[$i]);
+		$alt = $b;
+		return \%data if $alt != 0 and( !defined $ALT[$alt-1] or length($ALT[$alt-1]) > 1);	
+	    }
+	}
+	for my $i (0..@fmt) {
+	    if( $fmt[$i] eq "AD" ) {
+		if( $alt != 0 ) {
+		    $alt_cnt = (split /,/, $sam[$i])[$alt];
+		}
+		else {
+		    my @cnts = split /,/, $sam[$i];
+		    shift @cnts;
+		    pop @cnts;
+		    $alt_cnt = max(@cnts);
+		}
+	    }
+	}
+	for my $i (0..@fmt) {
+	    if( $fmt[$i] eq "DP" ) {
+		$dp = $sam[$i];
+		last;
+	    }   
+	}
+	return \%data if $dp < 10;
+	$data{frq} = $alt_cnt/$dp;
+	$data{alt} = $ALT[$alt];
+	$data{ref} = $a[3];
+	$data{all} = $a[9];
+    }
+    
+    
+    return \%data;
+}

--- a/t/data/test_data/install_active_parameters.yaml
+++ b/t/data/test_data/install_active_parameters.yaml
@@ -95,7 +95,7 @@ container:
   gens_preproc:
     executable:
       generate_gens_data.pl: ~
-    uri: docker.io/raysloks/gens_preproc:1.0.0
+    uri: docker.io/raysloks/gens_preproc:1.0.1
   gffcompare:
     executable:
       gffcompare: ~

--- a/t/data/test_data/miptest_container_config.yaml
+++ b/t/data/test_data/miptest_container_config.yaml
@@ -94,7 +94,7 @@ genmod:
 gens_preproc:
   executable:
     generate_gens_data.pl: ~
-  uri: docker.io/raysloks/gens_preproc:1.0.0
+  uri: docker.io/raysloks/gens_preproc:1.0.1
 gffcompare:
   executable:
     gffcompare: ~

--- a/t/data/test_data/miptest_install_config.yaml
+++ b/t/data/test_data/miptest_install_config.yaml
@@ -95,7 +95,7 @@ container:
   gens_preproc:
     executable:
       generate_gens_data.pl:
-    uri: docker.io/raysloks/gens_preproc:1.0.0
+    uri: docker.io/raysloks/gens_preproc:1.0.1
   gffcompare:
     executable:
       gffcompare:

--- a/templates/mip_install_config.yaml
+++ b/templates/mip_install_config.yaml
@@ -93,7 +93,7 @@ container:
   gens_preproc:
     executable:
       generate_gens_data.pl:
-    uri: docker.io/raysloks/gens_preproc:1.0.0
+    uri: docker.io/raysloks/gens_preproc:1.0.1
   gffcompare:
     executable:
       gffcompare:


### PR DESCRIPTION
### This PR adds | fixes:

- Makes MIP actually use the fixed 1.0.1 version of gens_preproc
- Adds the Dockerfile for gens_preproc and its perl scripts to containers/gens_preproc/

### How to test:

- Automatic and continuous test suite

### Expected outcome:
- [ ] Installation, unit and integration test suite pass

### Review:
- [ ] Code review
- [ ] Tests pass

This [version](https://semver.org/) is a:
- [ ] **MAJOR** - when you make incompatible API changes. If applicable record manual test results in PR header
- [ ] **MINOR** - when you add functionality in a backwards compatible manner. If applicable record manual test results in PR header
- [x] **PATCH** - when you make backwards compatible bug fixes or documentation/instructions
