### PR TITLE
Updates gens_preproc to version 1.0.2

### DIFF
--- a/containers/gens_preproc/generate_gens_data.pl
+++ b/containers/gens_preproc/generate_gens_data.pl
@@ -6,7 +6,7 @@ use List::Util qw(sum);
 use File::Basename qw(dirname);
 
 if ($ARGV[0] eq "--version") {
-    print "generate_gens_data.pl 1.0.1\n";
+    print "generate_gens_data.pl 1.0.2\n";
     exit 0;
 }
 
@@ -64,7 +64,7 @@ sub generate_baf_bed {
 	    print BAFOUT $prefix."_".$a[0]."\t".($a[1]-1)."\t".$a[1]."\t".$a[2]."\n";
 	}
     }
-    close $fn;
+    close $fh;
 }
 
 sub generate_cov_bed {

--- a/t/data/test_data/install_active_parameters.yaml
+++ b/t/data/test_data/install_active_parameters.yaml
@@ -95,7 +95,7 @@ container:
   gens_preproc:
     executable:
       generate_gens_data.pl: ~
-    uri: docker.io/raysloks/gens_preproc:1.0.1
+    uri: docker.io/raysloks/gens_preproc:1.0.2
   gffcompare:
     executable:
       gffcompare: ~

--- a/t/data/test_data/miptest_container_config.yaml
+++ b/t/data/test_data/miptest_container_config.yaml
@@ -94,7 +94,7 @@ genmod:
 gens_preproc:
   executable:
     generate_gens_data.pl: ~
-  uri: docker.io/raysloks/gens_preproc:1.0.1
+  uri: docker.io/raysloks/gens_preproc:1.0.2
 gffcompare:
   executable:
     gffcompare: ~

--- a/t/data/test_data/miptest_install_config.yaml
+++ b/t/data/test_data/miptest_install_config.yaml
@@ -96,7 +96,7 @@ container:
   gens_preproc:
     executable:
       generate_gens_data.pl:
-    uri: docker.io/raysloks/gens_preproc:1.0.1
+    uri: docker.io/raysloks/gens_preproc:1.0.2
   gffcompare:
     executable:
       gffcompare:

--- a/templates/mip_install_config.yaml
+++ b/templates/mip_install_config.yaml
@@ -93,7 +93,7 @@ container:
   gens_preproc:
     executable:
       generate_gens_data.pl:
-    uri: docker.io/raysloks/gens_preproc:1.0.1
+    uri: docker.io/raysloks/gens_preproc:1.0.2
   gffcompare:
     executable:
       gffcompare:


### PR DESCRIPTION
### This PR adds | fixes:

- Updates the gens_preproc container to version 1.0.2

### How to test:

- Automatic and continuous test suite

### Expected outcome:
- [ ] Installation, unit and integration test suite pass

### Review:
- [ ] Code review
- [ ] Tests pass

This [version](https://semver.org/) is a:
- [ ] **MAJOR** - when you make incompatible API changes. If applicable record manual test results in PR header
- [ ] **MINOR** - when you add functionality in a backwards compatible manner. If applicable record manual test results in PR header
- [x] **PATCH** - when you make backwards compatible bug fixes or documentation/instructions
