### PR TITLE
updates tiddit

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,13 @@
 All notable changes to this project will be documented in this file.
 This project adheres to [Semantic Versioning](http://semver.org/).
 
+## Develop
+
+Changes sv annotation overlap back to 0.8 (from 0.5) with the new tiddit update
+### Tools
+
+Tiddit 3.3.2 -> 3.4.0
+
 ## [11.1.1]
 
 - Updates chromgraph to version 1.3.1

--- a/definitions/rd_dna_parameters.yaml
+++ b/definitions/rd_dna_parameters.yaml
@@ -1001,7 +1001,7 @@ sv_svdb_query_overlap:
   associated_recipe:
     - sv_annotate
   data_type: SCALAR
-  default: 0.5
+  default: 0.8
   type: recipe_argument
 sv_vcfanno_config:
   associated_recipe:

--- a/lib/MIP/Constants.pm
+++ b/lib/MIP/Constants.pm
@@ -82,7 +82,7 @@ Readonly our %ANALYSIS => (
 );
 
 ## Set MIP version
-Readonly our $MIP_VERSION => q{11.1.1-develop};
+Readonly our $MIP_VERSION => q{11.1.2};
 
 ## Cli
 Readonly our $MOOSEX_APP_SCEEN_WIDTH => 160;

--- a/lib/MIP/Constants.pm
+++ b/lib/MIP/Constants.pm
@@ -82,7 +82,7 @@ Readonly our %ANALYSIS => (
 );
 
 ## Set MIP version
-Readonly our $MIP_VERSION => q{11.1.1};
+Readonly our $MIP_VERSION => q{11.1.1-develop};
 
 ## Cli
 Readonly our $MOOSEX_APP_SCEEN_WIDTH => 160;

--- a/templates/mip_install_config.yaml
+++ b/templates/mip_install_config.yaml
@@ -125,7 +125,7 @@ container:
   mip:
     executable:
       mip:
-    uri: docker.io/clinicalgenomics/mip:v11.1.1
+    uri: docker.io/clinicalgenomics/mip:develop
   multiqc:
     executable:
       multiqc:
@@ -221,7 +221,7 @@ container:
   tiddit:
     executable:
       tiddit:
-    uri: quay.io/biocontainers/tiddit:3.3.2--py39h5094d80_0
+    uri: quay.io/repository/biocontainers/tiddit:3.4.0--py310hc2b7f4b_0
   trim-galore:
     executable:
       trim_galore:

--- a/templates/mip_install_config.yaml
+++ b/templates/mip_install_config.yaml
@@ -221,7 +221,7 @@ container:
   tiddit:
     executable:
       tiddit:
-    uri: quay.io/repository/biocontainers/tiddit:3.4.0--py310hc2b7f4b_0
+    uri: quay.io/biocontainers/tiddit:3.4.0--py310hc2b7f4b_0
   trim-galore:
     executable:
       trim_galore:


### PR DESCRIPTION
### This PR adds | fixes:

- Tiddit version 3.4.0 improves the positioning of the SV calls as well as introducing a basic scoring algorithm. The improved positioning means that we try to switch back to sv a sv annotation overlap of 0.8

#. ## How to test:

- Automatic and continuous test suite

### Expected outcome:
- [ ] Installation, unit and integration test suite pass

### Review:
- [ ] Code review
- [ ] Tests pass

This [version](https://semver.org/) is a:
- [ ] **MAJOR** - when you make incompatible API changes. If applicable record manual test results in PR header
- [ ] **MINOR** - when you add functionality in a backwards compatible manner. If applicable record manual test results in PR header
- [ ] **PATCH** - when you make backwards compatible bug fixes or documentation/instructions
