### PR TITLE
bump memory for salmon quant

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,10 @@
 All notable changes to this project will be documented in this file.
 This project adheres to [Semantic Versioning](http://semver.org/).
 
+## Develop
+
+- Increased memory allocation for salmon
+
 ## [11.1.1]
 
 - Updates chromgraph to version 1.3.1

--- a/definitions/rd_rna_parameters.yaml
+++ b/definitions/rd_rna_parameters.yaml
@@ -194,7 +194,7 @@ recipe_memory:
     picardtools_mergesamfiles: 5
     preseq_ar: 8
     rseqc: 40
-    salmon_quant: 2
+    salmon_quant: 4
     star_aln: 5
     star_fusion: 25
     stringtie_ar: 2

--- a/lib/MIP/Constants.pm
+++ b/lib/MIP/Constants.pm
@@ -82,7 +82,7 @@ Readonly our %ANALYSIS => (
 );
 
 ## Set MIP version
-Readonly our $MIP_VERSION => q{11.1.1};
+Readonly our $MIP_VERSION => q{11.1.2};
 
 ## Cli
 Readonly our $MOOSEX_APP_SCEEN_WIDTH => 160;


### PR DESCRIPTION
### This PR adds | fixes:

- doubles the memory for salmon quant from 40 G to 80 G

### How to test:

- Automatic and continuous test suite

### Expected outcome:
- [ ] Installation, unit and integration test suite pass

### Review:
- [ ] Code review
- [ ] Tests pass

This [version](https://semver.org/) is a:
- [ ] **MAJOR** - when you make incompatible API changes. If applicable record manual test results in PR header
- [ ] **MINOR** - when you add functionality in a backwards compatible manner. If applicable record manual test results in PR header
- [ ] **PATCH** - when you make backwards compatible bug fixes or documentation/instructions
