### PR TITLE
updates megafusion

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,10 +8,12 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 - Increased memory allocation for salmon and picardtools_mergersamfiles (RNA)
 - Updates expansionhunter variant catalog
 - Changes sv annotation overlap back to 0.8 (from 0.5) with the new tiddit update
+- New version of MegaFusion. A bug in the previous version prevented SVDB from writing the format and sample field in the vcf.
 
 ### Tools
 
-Tiddit 3.3.2 -> 3.4.0
+- Tiddit 3.3.2 -> 3.4.0
+- MegaFusion 66a3a80 -> d3feacf
 
 ## [11.1.1]
 

--- a/containers/megafusion/Dockerfile
+++ b/containers/megafusion/Dockerfile
@@ -7,7 +7,7 @@ FROM clinicalgenomics/mip_base:2.1
 LABEL base_image="clinicalgenomics/mip_base:2.1"
 LABEL version="4"
 LABEL software="MegaFusion"
-LABEL software.version="66a3a80"
+LABEL software.version="d3feacf"
 LABEL extra.binaries="MegaFusion.py"
 LABEL maintainer="Clinical-Genomics/MIP"
 
@@ -25,5 +25,5 @@ RUN git clone https://github.com/J35P312/MegaFusion.git /opt/conda/share/MegaFus
 WORKDIR /opt/conda/share/MegaFusion
 
 ## Make sure we're on the right commit
-RUN git reset --hard 66a3a80
+RUN git reset --hard d3feacf
 

--- a/templates/mip_install_config.yaml
+++ b/templates/mip_install_config.yaml
@@ -121,7 +121,7 @@ container:
   megafusion:
     executable:
       MegaFusion.py: "python /opt/conda/share/MegaFusion/MegaFusion.py"
-    uri: docker.io/clinicalgenomics/megafusion:66a3a80
+    uri: docker.io/clinicalgenomics/megafusion:d3feacf
   mip:
     executable:
       mip:


### PR DESCRIPTION
### This PR adds | fixes:

- New version of MegaFusion. A bug in the previous version prevented SVDB from writing the format and sample field in the vcf.

### How to test:

- Automatic and continuous test suite

### Expected outcome:
- [ ] Installation, unit and integration test suite pass

### Review:
- [ ] Code review
- [ ] Tests pass

This [version](https://semver.org/) is a:
- [ ] **MAJOR** - when you make incompatible API changes. If applicable record manual test results in PR header
- [ ] **MINOR** - when you add functionality in a backwards compatible manner. If applicable record manual test results in PR header
- [ ] **PATCH** - when you make backwards compatible bug fixes or documentation/instructions
