### PR TITLE
remove rseqc read duplication analysis

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 - Updates expansionhunter variant catalog
 - Changes sv annotation overlap back to 0.8 (from 0.5) with the new tiddit update
 - New version of MegaFusion. A bug in the previous version prevented SVDB from writing the format and sample field in the vcf.
+- Remove the RSeQC read duplication analysis as it fails often.
 
 ### Tools
 

--- a/lib/MIP/Recipes/Analysis/Rseqc.pm
+++ b/lib/MIP/Recipes/Analysis/Rseqc.pm
@@ -292,16 +292,6 @@ sub analysis_rseqc {
     );
     say {$filehandle} $NEWLINE;
 
-    say {$filehandle} q{## Rseqc read_duplication};
-    rseqc_read_duplication(
-        {
-            filehandle           => $filehandle,
-            infile_path          => $infile_path,
-            outfiles_path_prefix => $outfile_path_prefix . $UNDERSCORE . q{read_duplication},
-        }
-    );
-    say {$filehandle} $NEWLINE;
-
     close $filehandle;
 
     if ( $recipe{mode} == 1 ) {


### PR DESCRIPTION
### This PR adds | fixes:

- This PR removes the  rseqc program that analyses read duplication as it crashes often and we already run markduplicates which will give us an idea of the duplication levels.

### How to test:

- Automatic and continuous test suite

### Expected outcome:
- [ ] Installation, unit and integration test suite pass

### Review:
- [ ] Code review
- [ ] Tests pass

This [version](https://semver.org/) is a:
- [ ] **MAJOR** - when you make incompatible API changes. If applicable record manual test results in PR header
- [ ] **MINOR** - when you add functionality in a backwards compatible manner. If applicable record manual test results in PR header
- [ ] **PATCH** - when you make backwards compatible bug fixes or documentation/instructions
