### PR TITLE
Adds index path to Gens deliverables

### DIFF
--- a/lib/MIP/Recipes/Analysis/Gens_generatedata.pm
+++ b/lib/MIP/Recipes/Analysis/Gens_generatedata.pm
@@ -253,6 +253,7 @@ sub analysis_gens_generatedata {
                     format           => q{bed},
                     id               => $sample_id,
                     path             => $outfile_path{$file_tag},
+                    path_index       => $outfile_path{$file_tag} . q{.tbi},
                     recipe_name      => $recipe_name,
                     sample_info_href => $sample_info_href,
                     tag              => $file_tag,


### PR DESCRIPTION
### Adds

- Missing `path_index` parameter, so the Gens index files are actually added to deliverables

### How to test:

- Automatic and continuous test suite
- Check that the index files are added to deliverables

### Expected outcome:
- [ ] Installation, unit and integration test suite pass
- [ ] Index files are added to deliverables

### Review:
- [ ] Code review
- [ ] Tests pass

This [version](https://semver.org/) is a:
- [ ] **MAJOR** - when you make incompatible API changes. If applicable record manual test results in PR header
- [ ] **MINOR** - when you add functionality in a backwards compatible manner. If applicable record manual test results in PR header
- [x] **PATCH** - when you make backwards compatible bug fixes or documentation/instructions
