### PR TITLE
prepare bam files for retroseq

### DIFF
--- a/definitions/rd_dna_initiation_map.yaml
+++ b/definitions/rd_dna_initiation_map.yaml
@@ -50,6 +50,7 @@ CHAIN_ALL:
       - sv_reformat
       - vcf2cytosure_ar
     - CHAIN_MOBILE_ELEMENTS:
+      - merge_bam_me
       - retroseq
   - CHAIN_MAIN:
     # PARALLEL chains, which inherit from MAIN in initiation, but are merged back to CHAIN_MAIN after execution

--- a/definitions/rd_dna_initiation_map.yaml
+++ b/definitions/rd_dna_initiation_map.yaml
@@ -50,7 +50,7 @@ CHAIN_ALL:
       - sv_reformat
       - vcf2cytosure_ar
     - CHAIN_MOBILE_ELEMENTS:
-      - merge_bam_me
+      - me_merge_bam
       - retroseq
   - CHAIN_MAIN:
     # PARALLEL chains, which inherit from MAIN in initiation, but are merged back to CHAIN_MAIN after execution

--- a/definitions/rd_dna_parameters.yaml
+++ b/definitions/rd_dna_parameters.yaml
@@ -226,7 +226,7 @@ recipe_core_number:
     gzip_fastq: 0
     manta: 36
     markduplicates: 13
-    merge_bam_me: 5
+    me_merge_bam: 5
     mitodel: 1
     mt_annotation: 1
     multiqc_ar: 1
@@ -358,7 +358,7 @@ recipe_time:
     gzip_fastq: 2
     manta: 30
     markduplicates: 20
-    merge_bam_me: 5
+    me_merge_bam: 5
     mitodel: 2
     mt_annotation: 1
     multiqc_ar: 5
@@ -1256,8 +1256,8 @@ sv_reformat_remove_genes_file:
   mandatory: no
   reference: reference_dir
   type: path
-## Mobile elenment chain
-merge_bam_me:
+## Mobile element chain
+me_merge_bam:
   analysis_mode: sample
   associated_recipe:
     - mip

--- a/definitions/rd_dna_parameters.yaml
+++ b/definitions/rd_dna_parameters.yaml
@@ -226,6 +226,7 @@ recipe_core_number:
     gzip_fastq: 0
     manta: 36
     markduplicates: 13
+    merge_bam_me: 5
     mitodel: 1
     mt_annotation: 1
     multiqc_ar: 1
@@ -357,6 +358,7 @@ recipe_time:
     gzip_fastq: 2
     manta: 30
     markduplicates: 20
+    merge_bam_me: 5
     mitodel: 2
     mt_annotation: 1
     multiqc_ar: 5
@@ -1255,6 +1257,17 @@ sv_reformat_remove_genes_file:
   reference: reference_dir
   type: path
 ## Mobile elenment chain
+merge_bam_me:
+  analysis_mode: sample
+  associated_recipe:
+    - mip
+  data_type: SCALAR
+  default: 1
+  file_tag: "_all"
+  program_executables:
+    - samtools
+  outfile_suffix: ".bam"
+  type: recipe
 retroseq:
   analysis_mode: sample
   associated_recipe:

--- a/lib/MIP/Cli/Mip/Analyse/Rd_dna.pm
+++ b/lib/MIP/Cli/Mip/Analyse/Rd_dna.pm
@@ -1157,7 +1157,7 @@ q{Default: hgvs, symbol, numbers, sift, polyphen, humdiv, domains, protein, ccds
     );
 
     option(
-        q{merge_bam_me} => (
+        q{me_merge_bam} => (
             cmd_tags      => [q{Analysis recipe switch}],
             documentation => q{Prepare bam files for RetroSeq},
             is            => q{rw},

--- a/lib/MIP/Cli/Mip/Analyse/Rd_dna.pm
+++ b/lib/MIP/Cli/Mip/Analyse/Rd_dna.pm
@@ -1157,7 +1157,16 @@ q{Default: hgvs, symbol, numbers, sift, polyphen, humdiv, domains, protein, ccds
     );
 
     option(
-        q{me_retroseq} => (
+        q{merge_bam_me} => (
+            cmd_tags      => [q{Analysis recipe switch}],
+            documentation => q{Prepare bam files for RetroSeq},
+            is            => q{rw},
+            isa           => enum( [ 0, 1, 2 ] ),
+        )
+    );
+
+    option(
+        q{retroseq} => (
             cmd_tags      => [q{Analysis recipe switch}],
             documentation => q{Discover mobile elements using RetroSeq},
             is            => q{rw},

--- a/lib/MIP/Recipes/Analysis/Samtools_merge.pm
+++ b/lib/MIP/Recipes/Analysis/Samtools_merge.pm
@@ -475,16 +475,26 @@ sub analysis_samtools_merge_panel {
 
     ## Unpack parameters
     ## Get the io infiles per chain and id
+
+    ## Special case for mobile elements
+    my $stream_for_input      = q{in};
+    my $recipe_name_for_input = $recipe_name;
+    if ( $recipe_name eq q{merge_bam_me} ) {
+
+        $recipe_name_for_input = $active_parameter_href->{bwa_mem2} ? q{bwa_mem2} : q{bwa_mem};
+        $stream_for_input      = q{out};
+    }
+
     my %io = get_io_files(
         {
             id             => $sample_id,
             file_info_href => $file_info_href,
             parameter_href => $parameter_href,
-            recipe_name    => $recipe_name,
-            stream         => q{in},
+            recipe_name    => $recipe_name_for_input,
+            stream         => $stream_for_input,
         }
     );
-    my @infile_paths = @{ $io{in}{file_paths} };
+    my @infile_paths = @{ $io{$stream_for_input}{file_paths} };
 
     my %recipe = parse_recipe_prerequisites(
         {

--- a/lib/MIP/Recipes/Analysis/Samtools_merge.pm
+++ b/lib/MIP/Recipes/Analysis/Samtools_merge.pm
@@ -480,7 +480,7 @@ sub analysis_samtools_merge_panel {
     ## Special case for mobile elements
     my $stream_for_input      = q{in};
     my $recipe_name_for_input = $recipe_name;
-    if ( $recipe_name eq q{merge_bam_me} ) {
+    if ( $recipe_name eq q{me_merge_bam} ) {
 
         $recipe_name_for_input = $active_parameter_href->{bwa_mem2} ? q{bwa_mem2} : q{bwa_mem};
         $stream_for_input      = q{out};

--- a/lib/MIP/Recipes/Pipeline/Analyse_rd_dna.pm
+++ b/lib/MIP/Recipes/Pipeline/Analyse_rd_dna.pm
@@ -130,7 +130,7 @@ sub parse_rd_dna {
     Readonly my @ONLY_WGS_VARIANT_CALLER_RECIPES => qw{ cnvnator_ar delly_reformat tiddit };
     Readonly my @ONLY_WGS_RECIPIES =>
       qw{ chromograph_rhoviz cnvnator_ar delly_call delly_reformat expansionhunter
-      gatk_collectreadcounts gatk_denoisereadcounts gens_generatedata merge_bam_me mitodel
+      gatk_collectreadcounts gatk_denoisereadcounts gens_generatedata me_merge_bam mitodel
       retroseq samtools_subsample_mt smncopynumbercaller star_caller telomerecat_ar tiddit };
     Readonly my @REMOVE_CONFIG_KEYS => qw{ associated_recipe };
 
@@ -588,7 +588,7 @@ sub pipeline_analyse_rd_dna {
         gzip_fastq                         => \&analysis_gzip_fastq,
         manta                              => \&analysis_manta,
         markduplicates                     => \&analysis_markduplicates,
-        merge_bam_me                       => \&analysis_samtools_merge_panel,
+        me_merge_bam                       => \&analysis_samtools_merge_panel,
         mitodel                            => \&analysis_mitodel,
         mt_annotation                      => \&analysis_mt_annotation,
         multiqc_ar                         => \&analysis_multiqc,

--- a/lib/MIP/Recipes/Pipeline/Analyse_rd_dna.pm
+++ b/lib/MIP/Recipes/Pipeline/Analyse_rd_dna.pm
@@ -130,8 +130,8 @@ sub parse_rd_dna {
     Readonly my @ONLY_WGS_VARIANT_CALLER_RECIPES => qw{ cnvnator_ar delly_reformat tiddit };
     Readonly my @ONLY_WGS_RECIPIES =>
       qw{ chromograph_rhoviz cnvnator_ar delly_call delly_reformat expansionhunter
-      gatk_collectreadcounts gatk_denoisereadcounts gens_generatedata mitodel retroseq
-      samtools_subsample_mt smncopynumbercaller star_caller telomerecat_ar tiddit };
+      gatk_collectreadcounts gatk_denoisereadcounts gens_generatedata merge_bam_me mitodel
+      retroseq samtools_subsample_mt smncopynumbercaller star_caller telomerecat_ar tiddit };
     Readonly my @REMOVE_CONFIG_KEYS => qw{ associated_recipe };
 
     ## Set analysis constants
@@ -496,7 +496,8 @@ sub pipeline_analyse_rd_dna {
     use MIP::Recipes::Analysis::Rtg_vcfeval qw{ analysis_rtg_vcfeval  };
     use MIP::Recipes::Analysis::Sacct qw{ analysis_sacct };
     use MIP::Recipes::Analysis::Sambamba_depth qw{ analysis_sambamba_depth };
-    use MIP::Recipes::Analysis::Samtools_merge qw{ analysis_samtools_merge };
+    use MIP::Recipes::Analysis::Samtools_merge
+      qw{ analysis_samtools_merge analysis_samtools_merge_panel };
     use MIP::Recipes::Analysis::Samtools_subsample_mt qw{ analysis_samtools_subsample_mt };
     use MIP::Recipes::Analysis::Smncopynumbercaller qw{ analysis_smncopynumbercaller };
     use MIP::Recipes::Analysis::Star_caller qw{ analysis_star_caller };
@@ -587,6 +588,7 @@ sub pipeline_analyse_rd_dna {
         gzip_fastq                         => \&analysis_gzip_fastq,
         manta                              => \&analysis_manta,
         markduplicates                     => \&analysis_markduplicates,
+        merge_bam_me                       => \&analysis_samtools_merge_panel,
         mitodel                            => \&analysis_mitodel,
         mt_annotation                      => \&analysis_mt_annotation,
         multiqc_ar                         => \&analysis_multiqc,


### PR DESCRIPTION
### This PR adds | fixes:

- In the WGS workflow we traditionally only operates on chromosome 1-22, X ,Y , MT but Retroseq wants to use the whole genome for calling transposable elements. This PR repurposes the panel version of `samtools_merge` to merge the files from bwa but not split them into chromosomes. 

Please ignore the wrong commit message referencing drop :p 

### How to test:

- Automatic and continuous test suite

### Expected outcome:
- [x] Installation, unit and integration test suite pass

### Review:
- [ ] Code review
- [ ] Tests pass

This [version](https://semver.org/) is a:
- [ ] **MAJOR** - when you make incompatible API changes. If applicable record manual test results in PR header
- [ ] **MINOR** - when you add functionality in a backwards compatible manner. If applicable record manual test results in PR header
- [ ] **PATCH** - when you make backwards compatible bug fixes or documentation/instructions
