### PR TITLE
patching gens_preproc

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,11 +3,20 @@
 All notable changes to this project will be documented in this file.
 This project adheres to [Semantic Versioning](http://semver.org/).
 
+## [11.2.2]
+
+- New patch of gens pre processing container.
+
+### Tools
+
+gens_preproc 1.0.8 -> 1.0.11
+
 ## [11.2.1]
 
 - Patching of gens pre processing container to solve an issue with incomplete bed files.
 
 ### Tools
+
 gens_preproc 1.0.2 -> 1.0.8
 
 ## [11.2.0]

--- a/lib/MIP/Constants.pm
+++ b/lib/MIP/Constants.pm
@@ -82,7 +82,7 @@ Readonly our %ANALYSIS => (
 );
 
 ## Set MIP version
-Readonly our $MIP_VERSION => q{11.2.1};
+Readonly our $MIP_VERSION => q{11.2.2};
 
 ## Cli
 Readonly our $MOOSEX_APP_SCEEN_WIDTH => 160;

--- a/templates/mip_install_config.yaml
+++ b/templates/mip_install_config.yaml
@@ -93,7 +93,7 @@ container:
   gens_preproc:
     executable:
       generate_gens_data.pl:
-    uri: docker.io/raysloks/gens_preproc:1.0.8
+    uri: docker.io/raysloks/gens_preproc:1.0.11
   gffcompare:
     executable:
       gffcompare:
@@ -125,7 +125,7 @@ container:
   mip:
     executable:
       mip:
-    uri: docker.io/clinicalgenomics/mip:v11.2.1
+    uri: docker.io/clinicalgenomics/mip:v11.2.2
   multiqc:
     executable:
       multiqc:


### PR DESCRIPTION
### This PR adds | fixes:

- Last gens patch introduced a new bug which this PR aims to fix this by updating the gens preprocessing container 

### How to test:

- Automatic and continuous test suite

### Expected outcome:
- [ ] Installation, unit and integration test suite pass

### Review:
- [ ] Code review
- [ ] Tests pass

This [version](https://semver.org/) is a:
- [ ] **MAJOR** - when you make incompatible API changes. If applicable record manual test results in PR header
- [ ] **MINOR** - when you add functionality in a backwards compatible manner. If applicable record manual test results in PR header
- [ ] **PATCH** - when you make backwards compatible bug fixes or documentation/instructions
