### PR TITLE
increasing max retroseq run time to 15 h

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 - Increased the default required length for a trimmed rna read to be retained from 20 bp to 40 bp. Configurable via CLI or config.
 - Fixed a bug where gnomad SV version 2.0 instead of version 2.1 was used to annotate SVs
 - One-pass instead of two-pass mapping with STAR-Fusion, as recommended for STAR-Fusion 1.12
+- Bump max run time for retroseq to 15 hours.
 
 ### Tools
 

--- a/definitions/rd_dna_parameters.yaml
+++ b/definitions/rd_dna_parameters.yaml
@@ -377,7 +377,7 @@ recipe_time:
     prepareforvariantannotationblock: 5
     qccollect_ar: 1
     rankvariant: 10
-    retroseq: 5
+    retroseq: 15
     rhocall_ar: 5
     rhocall_viz: 1
     rtg_vcfeval: 1


### PR DESCRIPTION
### This PR adds | fixes:

- some samples requires more than 5 hours to run through retroseq. This PR increases the max run time to 15 hours.

### How to test:

- Automatic and continuous test suite

### Expected outcome:
- [ ] Installation, unit and integration test suite pass

### Review:
- [ ] Code review
- [ ] Tests pass

This [version](https://semver.org/) is a:
- [ ] **MAJOR** - when you make incompatible API changes. If applicable record manual test results in PR header
- [ ] **MINOR** - when you add functionality in a backwards compatible manner. If applicable record manual test results in PR header
- [ ] **PATCH** - when you make backwards compatible bug fixes or documentation/instructions
