### PR TITLE
Fix missing error handling for IPC::Open3 in ipc_open3 subroutine

### DIFF
--- a/lib/MIP/System_call.pm
+++ b/lib/MIP/System_call.pm
@@ -108,6 +108,11 @@ sub ipc_open3 {
     # System call
     my $pid = open3( $writer, $reader, $error, qq{$command_string} );
 
+    # Check if open3 succeeded
+    unless (defined $pid) {
+        croak(qq{open3 failed for command "$command_string": $OS_ERROR});
+    }
+
     # Terminate process
     waitpid $pid, 0 or croak(qq{Child process died: $OS_ERROR});
 


### PR DESCRIPTION
## Description

The `ipc_open3` subroutine in `lib/MIP/System_call.pm` did not check if `open3()` succeeds before attempting to read from filehandles. If `open3()` fails, `$writer`, `$reader`, and `$error` will be undefined, causing silent failures or crashes when reading from undefined filehandles.

## Changes

- Added error handling after the `open3()` call to check if it succeeded
- If `open3()` fails (returns `undef`), the subroutine now croaks with an informative error message including the command string and the system error
- This prevents silent failures and makes debugging easier

## Testing

The fix ensures that:
1. If `open3()` fails, an error is raised immediately with context
2. The filehandles are only accessed after confirming `open3()` succeeded
3. The error message includes the command that failed for easier debugging

Closes #431

---

*This PR was generated by [PRJanitor](https://prjanitor.com) — an automated tool that finds and fixes small bugs in open-source projects.*

We respect your contribution guidelines — if your project doesn't accept bot PRs, we won't send more. You can also add a `.github/prjanitor.yml` file with `enabled: false` to opt out explicitly.